### PR TITLE
feat(docs): rebuild dark elevation and give the proof dashboards the …

### DIFF
--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -117,7 +117,7 @@ const closedTypesCode = `controller.setRegion('USA')
         /* The wordmark runs harder than body text on purpose; it is not --text. */
         --brand-ink: #ffffff;
         --muted: #9ba1a6;
-        --faint: #8a9198;
+        --faint: #93999f;
         --green: var(--brand-solid);
         --green-text: #1fd8a4;
         --green-glow: rgb(var(--brand) / 0.35);
@@ -127,19 +127,24 @@ const closedTypesCode = `controller.setRegion('USA')
         --font-sans: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
         --font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
 
-        --card-shadow: 0 30px 80px -35px rgba(0, 0, 0, 0.8);
         --field-bg: rgba(0, 0, 0, 0.45);
         --field-border: rgba(255, 255, 255, 0.4);
         --nav-bg: rgba(22, 22, 24, 0.86);
         --grid-dot: rgba(255, 255, 255, 0.05);
         --link-underline: rgba(31, 216, 164, 0.35);
-        --error: #eb6668;
+        --error: #ef7275;
         --cta-bg: var(--green);
         --cta-bg-hover: color-mix(in srgb, var(--green) 86%, #ffffff);
         --cta-fg: #161618;
-        --surface: #212225;
-        --surface-border: rgba(255, 255, 255, 0.08);
-        --surface-shadow: 0 8px 20px -14px rgba(0, 0, 0, 0.5), 0 1px 4px -2px rgba(0, 0, 0, 0.3);
+        --surface: #272a2d;
+        --surface-border: rgba(255, 255, 255, 0.12);
+        /* A black shadow cannot darken a near-black canvas, so the top edge carries the elevation. */
+        --surface-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.09), 0 1px 2px rgba(0, 0, 0, 0.6),
+          0 20px 40px -24px rgba(0, 0, 0, 0.95);
+        --card-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.12), 0 1px 3px rgba(0, 0, 0, 0.7),
+          0 36px 68px -32px rgba(0, 0, 0, 1);
       }
 
       [data-theme='light'] {
@@ -600,10 +605,11 @@ const closedTypesCode = `controller.setRegion('USA')
       .sec-head {
         margin-bottom: 14px;
       }
+      /* Must rank below the h1 at every width, so its minimum and slope both stay under the h1's. */
       h2 {
-        font-size: clamp(30px, 4vw, 44px);
-        line-height: 1.08;
-        letter-spacing: -0.03em;
+        font-size: clamp(26px, 3vw, 36px);
+        line-height: 1.12;
+        letter-spacing: -0.025em;
         font-weight: 750;
         margin: 0;
       }
@@ -747,9 +753,13 @@ const closedTypesCode = `controller.setRegion('USA')
           color 0.15s ease,
           border-color 0.15s ease;
       }
-      .dfa-replay:hover {
+      .dfa-replay:hover:not(:disabled) {
         color: var(--green-text);
         border-color: var(--green);
+      }
+      .dfa-replay:disabled {
+        opacity: 0.4;
+        cursor: default;
       }
       .walk-digits {
         font-family: var(--font-mono);
@@ -2004,9 +2014,16 @@ const closedTypesCode = `controller.setRegion('USA')
           for (var j = 0; j < cells.length; j++) cells[j].className = 'dcell';
         }
 
-        function walk(step) {
+        var replay = document.getElementById('walk-replay');
+        var pending = null;
+        // Bumped per play: a step from a superseded run sees a stale token and stops typing.
+        var run = 0;
+
+        function walk(step, token) {
+          if (token !== run) return;
           if (step >= PATH.length) {
             result.classList.add('show');
+            if (replay) replay.disabled = false;
             return;
           }
           if (step > 0) {
@@ -2019,22 +2036,23 @@ const closedTypesCode = `controller.setRegion('USA')
           }
           fillStep(step, true);
           digitsEl.textContent += LINE[step];
-          setTimeout(function () {
-            walk(step + 1);
+          pending = setTimeout(function () {
+            walk(step + 1, token);
           }, 200);
         }
 
-        var pending = null;
         function play() {
+          run += 1;
           clearTimeout(pending);
           reset();
+          if (replay) replay.disabled = true;
+          var token = run;
           pending = setTimeout(function () {
-            walk(0);
+            walk(0, token);
           }, 800);
         }
 
         // One run per visit; the replay control owns every repeat.
-        var replay = document.getElementById('walk-replay');
         if (replay) replay.addEventListener('click', play);
 
         var seen = false;

--- a/packages/core/bench/artifacts.ts
+++ b/packages/core/bench/artifacts.ts
@@ -104,6 +104,8 @@ interface ShieldsBadge {
 const BENCH_DIR = dirname(fileURLToPath(import.meta.url));
 const ARTIFACT_DIR = join(BENCH_DIR, 'dist');
 const TEMPLATE_PATH = join(BENCH_DIR, 'benchmark.template.html');
+// One stylesheet behind every proof page, so they and telixon.dev stay one visual system.
+const THEME_PATH = join(BENCH_DIR, '..', 'proof-theme.css');
 const KEYSTROKE_LATENCY_PATH = join(ARTIFACT_DIR, 'keystroke-latency.json');
 const HOTPATH_FILE_SUFFIX = '/bench/hotpath.bench.ts';
 const INPUT_CONTROLLER_FILE_SUFFIX = '/bench/input-controller.bench.ts';
@@ -236,6 +238,7 @@ function buildBadge(): ShieldsBadge {
 function renderHtml(data: BenchData): string {
   const template: string = readFileSync(TEMPLATE_PATH, 'utf8');
   const tokens: Record<string, string> = {
+    '{{theme}}': readFileSync(THEME_PATH, 'utf8'),
     '{{commit}}': data.commit,
     '{{shortCommit}}': data.commit.slice(0, 7),
     '{{corpusSize}}': data.corpusSize.toLocaleString('en-US'),

--- a/packages/core/bench/benchmark.template.html
+++ b/packages/core/bench/benchmark.template.html
@@ -15,284 +15,191 @@
     <meta name="twitter:title" content="{{ogTitle}}" />
     <meta name="twitter:description" content="{{ogDescription}}" />
     <link rel="canonical" href="https://proof.telixon.dev/benchmark.html" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400..800&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
     <style>
-      body {
-        font:
-          16px/1.5 system-ui,
-          sans-serif;
-        max-width: 960px;
-        margin: 2rem auto;
-        padding: 0 1rem;
-        color: #17191b;
-      }
-      h1 {
-        font-size: 1.4rem;
-        margin-bottom: 0.5rem;
-      }
-      h2 {
-        font-size: 1.1rem;
-        margin-top: 2rem;
-        margin-bottom: 0.25rem;
-      }
-      .meta,
-      .section-note {
-        color: #4c5257;
-        font-size: 0.9rem;
-        margin-bottom: 1rem;
-      }
-      table {
-        border-collapse: collapse;
-        width: 100%;
-        font-size: 0.92rem;
-        margin-bottom: 1rem;
-      }
-      .section-note p {
-        margin: 0;
-      }
-      .section-note p + p {
-        margin-top: 0.75rem;
-      }
-      .section-note strong {
-        color: #17191b;
-      }
-      th,
-      td {
-        padding: 0.4rem 0.6rem;
-        border-bottom: 1px solid #eee;
-        text-align: right;
-        font-variant-numeric: tabular-nums;
-      }
-      th:first-child,
-      td:first-child {
-        text-align: left;
-      }
-      thead th {
-        font-weight: 600;
-        border-bottom: 2px solid #ddd;
-      }
-      .win {
-        color: #058e69;
-        font-weight: 600;
-      }
-      .hero-stats {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 0.75rem;
-        margin: 1rem 0;
-      }
-      .stat-card {
-        border: 1px solid #e5e5e5;
-        border-radius: 8px;
-        padding: 0.9rem 1rem;
-      }
-      .stat-value {
-        font-size: 1.6rem;
-        font-weight: 700;
-        color: #058e69;
-        font-variant-numeric: tabular-nums;
-      }
-      .stat-label {
-        font-weight: 600;
-        margin-top: 0.1rem;
-      }
-      .stat-sub {
-        color: #4c5257;
-        font-size: 0.85rem;
-        margin-top: 0.15rem;
-      }
-      .frame-bar {
-        position: relative;
-        height: 28px;
-        border: 1px solid #ddd;
-        border-radius: 6px;
-        background: #fafafa;
-        margin: 0.75rem 0 0.25rem;
-        overflow: hidden;
-      }
-      .frame-bar-fill {
-        position: absolute;
-        left: 0;
-        top: 0;
-        bottom: 0;
-        min-width: 2px;
-        background: #058e69;
-      }
-      .frame-bar-caption {
-        color: #4c5257;
-        font-size: 0.85rem;
-        margin-bottom: 1rem;
-      }
-      .loss {
-        color: #ce2c31;
-        font-weight: 600;
-      }
-      code {
-        background: #f4f4f4;
-        padding: 0.1rem 0.3rem;
-        border-radius: 3px;
-        font-size: 0.9em;
-      }
-      footer {
-        margin-top: 2rem;
-        color: #7d838a;
-        font-size: 0.85rem;
-      }
-      a {
-        color: #208368;
-      }
+      {{theme}}
     </style>
   </head>
-  <body>
-    <h1>Telixon benchmark vs libphonenumber-js, google-libphonenumber</h1>
-    <div class="meta">
-      Engine compiled from Google's libphonenumber source at
-      <a href="https://github.com/google/libphonenumber/commit/{{commit}}"
-        >github.com/google/libphonenumber@{{shortCommit}}</a
-      >.<br />
-      Corpus: {{corpusSize}} phone numbers, one Google example per region per type (the example set the conformance
-      corpus is derived from).<br />
-      Compared against the npm packages
-      <a href="https://www.npmjs.com/package/libphonenumber-js/v/{{libphonenumberJsVersion}}"
-        >libphonenumber-js@{{libphonenumberJsVersion}}</a
-      >
-      and
-      <a href="https://www.npmjs.com/package/google-libphonenumber/v/{{googleLibphonenumberVersion}}"
-        >google-libphonenumber@{{googleLibphonenumberVersion}}</a
-      >
-      (a community wrapper around Google's libphonenumber JS source).<br />
-      Generated {{runAt}}.
+  <body class="wide">
+    <header class="masthead">
+      <div class="masthead-inner">
+        <a class="home" href="https://telixon.dev/">
+          <svg viewBox="0 0 121 104" fill="none" aria-hidden="true">
+            <path
+              d="M103.054 5.99002C100.224 2.22002 95.7739 0 91.0539 0H28.514C23.794 0 19.354 2.22002 16.514 5.99002L3.00394 23.99C-1.15606 29.53 -0.976059 37.19 3.42394 42.54L19.0039 61.44L48.2739 96.78C54.2739 104.03 65.3939 104.02 71.3939 96.77L100.584 61.44L116.164 42.54C120.564 37.2 120.744 29.53 116.584 23.99L103.074 5.99002H103.054ZM94.8339 52.65L75.074 78.2C73.904 79.71 71.4939 78.88 71.4939 76.98V41.25H87.6139L87.6639 53.34L100.804 35.47C101.854 34.04 101.844 32.09 100.764 30.68L91.8339 18.93C91.0739 17.93 89.9039 17.35 88.6539 17.35H30.9139C29.6639 17.35 28.484 17.93 27.734 18.93L18.8039 30.68C17.7339 32.09 17.714 34.04 18.764 35.47L31.9039 53.34L31.9539 41.25H48.074V76.98C48.074 78.89 45.6539 79.71 44.4939 78.2L24.734 52.65L13.1139 37.8C10.9239 35 10.8439 31.09 12.9139 28.2L23.4139 13.58C24.9139 11.49 27.3339 10.25 29.9139 10.25H89.6439C92.2239 10.25 94.6339 11.49 96.1439 13.58L106.644 28.2C108.724 31.09 108.644 35 106.444 37.8L94.824 52.65H94.8339Z"
+              fill="url(#gem)"
+            />
+            <defs>
+              <linearGradient id="gem" x1="59.79" y1="-4.01" x2="59.79" y2="103.25" gradientUnits="userSpaceOnUse">
+                <stop offset="0.02" stop-color="#27B78D" />
+                <stop offset="0.44" stop-color="#25A581" />
+                <stop offset="1" stop-color="#22896D" />
+              </linearGradient>
+            </defs>
+          </svg>
+          Telixon
+        </a>
+        <span class="kind">Benchmark</span>
+      </div>
+    </header>
+
+    <div class="wrap">
+      <h1>Benchmark vs libphonenumber-js and google-libphonenumber</h1>
+      <p class="note">
+        Engine compiled from Google's libphonenumber source at
+        <a href="https://github.com/google/libphonenumber/commit/{{commit}}"
+          >github.com/google/libphonenumber@{{shortCommit}}</a
+        >.<br />
+        Corpus: {{corpusSize}} phone numbers, one Google example per region per type (the example set the conformance
+        corpus is derived from).<br />
+        Compared against the npm packages
+        <a href="https://www.npmjs.com/package/libphonenumber-js/v/{{libphonenumberJsVersion}}"
+          >libphonenumber-js@{{libphonenumberJsVersion}}</a
+        >
+        and
+        <a href="https://www.npmjs.com/package/google-libphonenumber/v/{{googleLibphonenumberVersion}}"
+          >google-libphonenumber@{{googleLibphonenumberVersion}}</a
+        >
+        (a community wrapper around Google's libphonenumber JS source).<br />
+        Generated {{runAt}}.
+      </p>
+
+      <h2 id="parse">Parse</h2>
+      <p class="note">Parse cost only.</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Operation</th>
+            <th>Telixon (ops/s)</th>
+            <th>libphonenumber-js (ops/s)</th>
+            <th>google-libphonenumber (ops/s)</th>
+            <th>vs libphonenumber-js</th>
+            <th>vs google-libphonenumber</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{parseRows}}
+        </tbody>
+      </table>
+
+      <h2 id="strict-cold">Strict cold</h2>
+      <p class="note">Parse + one method call. Telixon module caches cleared per iteration.</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Method</th>
+            <th>Telixon (ops/s)</th>
+            <th>libphonenumber-js (ops/s)</th>
+            <th>google-libphonenumber (ops/s)</th>
+            <th>vs libphonenumber-js</th>
+            <th>vs google-libphonenumber</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{strictColdRows}}
+        </tbody>
+      </table>
+
+      <h2 id="cold">Cold</h2>
+      <p class="note">Parse + one method call. Caches retained across iterations.</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Method</th>
+            <th>Telixon (ops/s)</th>
+            <th>libphonenumber-js (ops/s)</th>
+            <th>google-libphonenumber (ops/s)</th>
+            <th>vs libphonenumber-js</th>
+            <th>vs google-libphonenumber</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{coldRows}}
+        </tbody>
+      </table>
+
+      <h2 id="warm">Warm</h2>
+      <p class="note">
+        Pre-parsed value, method called repeatedly. Where libphonenumber-js stores the value as a direct property after
+        parse (<code>nationalNumber</code>, <code>countryCallingCode</code>, <code>number</code>, <code>country</code>),
+        a property read is 1-4% faster than Telixon's cached method call.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Method</th>
+            <th>Telixon (ops/s)</th>
+            <th>libphonenumber-js (ops/s)</th>
+            <th>google-libphonenumber (ops/s)</th>
+            <th>vs libphonenumber-js</th>
+            <th>vs google-libphonenumber</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{warmRows}}
+        </tbody>
+      </table>
+
+      <h2 id="input-controller">Input controller</h2>
+      <p class="note">
+        Telixon only: competitor formatters have no comparable API (no caret, no deletion, no undo, no per-keystroke
+        queries). One iteration is a <strong>full corpus pass</strong>: every digit of all {{corpusSize}} corpus
+        numbers, typed end to end through the controller. Read the mean column as "what typing the entire corpus costs";
+        single keystrokes are profiled in <a href="#keystroke-latency">the next section</a>.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Scenario</th>
+            <th>ops/s</th>
+            <th>mean (ms)</th>
+            <th>p99 (ms)</th>
+            <th>±rme</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{inputControllerRows}}
+        </tbody>
+      </table>
+
+      <h2 id="keystroke-latency">Per-keystroke latency</h2>
+      <p class="note">
+        The number that decides whether an input feels instant: the cost of one keystroke, sampled individually (<code
+          >process.hrtime.bigint()</code
+        >
+        after warmup). For scale, the panel below measures that latency against one display frame across common refresh
+        rates (60-360 Hz); the benchmark itself runs headless, so it assumes no single display.
+      </p>
+      {{keystrokeHero}}
+      <table>
+        <thead>
+          <tr>
+            <th>Scenario</th>
+            <th>samples</th>
+            <th>mean</th>
+            <th>p50</th>
+            <th>p95</th>
+            <th>p99</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{keystrokeLatencyRows}}
+        </tbody>
+      </table>
+      <p class="note">Worst-case (p99) keystroke against one frame, at common display refresh rates:</p>
+      {{refreshLadder}}
+      <p class="note">{{keystrokeLatencyVerdict}}</p>
+
+      <footer>
+        Reproduce locally: <code>pnpm bench</code>.<br />
+        Source:
+        <a href="https://github.com/martsinlabs/telixon/tree/main/packages/core/bench">benchmark harness</a>.
+      </footer>
     </div>
-
-    <h2 id="parse">Parse</h2>
-    <div class="section-note">Parse cost only.</div>
-    <table>
-      <thead>
-        <tr>
-          <th>Operation</th>
-          <th>Telixon (ops/s)</th>
-          <th>libphonenumber-js (ops/s)</th>
-          <th>google-libphonenumber (ops/s)</th>
-          <th>vs libphonenumber-js</th>
-          <th>vs google-libphonenumber</th>
-        </tr>
-      </thead>
-      <tbody>
-        {{parseRows}}
-      </tbody>
-    </table>
-
-    <h2 id="strict-cold">Strict cold</h2>
-    <div class="section-note">Parse + one method call. Telixon module caches cleared per iteration.</div>
-    <table>
-      <thead>
-        <tr>
-          <th>Method</th>
-          <th>Telixon (ops/s)</th>
-          <th>libphonenumber-js (ops/s)</th>
-          <th>google-libphonenumber (ops/s)</th>
-          <th>vs libphonenumber-js</th>
-          <th>vs google-libphonenumber</th>
-        </tr>
-      </thead>
-      <tbody>
-        {{strictColdRows}}
-      </tbody>
-    </table>
-
-    <h2 id="cold">Cold</h2>
-    <div class="section-note">Parse + one method call. Caches retained across iterations.</div>
-    <table>
-      <thead>
-        <tr>
-          <th>Method</th>
-          <th>Telixon (ops/s)</th>
-          <th>libphonenumber-js (ops/s)</th>
-          <th>google-libphonenumber (ops/s)</th>
-          <th>vs libphonenumber-js</th>
-          <th>vs google-libphonenumber</th>
-        </tr>
-      </thead>
-      <tbody>
-        {{coldRows}}
-      </tbody>
-    </table>
-
-    <h2 id="warm">Warm</h2>
-    <div class="section-note">
-      Pre-parsed value, method called repeatedly. Where libphonenumber-js stores the value as a direct property after
-      parse (<code>nationalNumber</code>, <code>countryCallingCode</code>, <code>number</code>, <code>country</code>), a
-      property read is 1-4% faster than Telixon's cached method call.
-    </div>
-    <table>
-      <thead>
-        <tr>
-          <th>Method</th>
-          <th>Telixon (ops/s)</th>
-          <th>libphonenumber-js (ops/s)</th>
-          <th>google-libphonenumber (ops/s)</th>
-          <th>vs libphonenumber-js</th>
-          <th>vs google-libphonenumber</th>
-        </tr>
-      </thead>
-      <tbody>
-        {{warmRows}}
-      </tbody>
-    </table>
-
-    <h2 id="input-controller">Input controller</h2>
-    <div class="section-note">
-      Telixon only: competitor formatters have no comparable API (no caret, no deletion, no undo, no per-keystroke
-      queries). One iteration is a <strong>full corpus pass</strong>: every digit of all {{corpusSize}} corpus numbers,
-      typed end to end through the controller. Read the mean column as "what typing the entire corpus costs"; single
-      keystrokes are profiled in <a href="#keystroke-latency">the next section</a>.
-    </div>
-    <table>
-      <thead>
-        <tr>
-          <th>Scenario</th>
-          <th>ops/s</th>
-          <th>mean (ms)</th>
-          <th>p99 (ms)</th>
-          <th>±rme</th>
-        </tr>
-      </thead>
-      <tbody>
-        {{inputControllerRows}}
-      </tbody>
-    </table>
-
-    <h2 id="keystroke-latency">Per-keystroke latency</h2>
-    <div class="section-note">
-      The number that decides whether an input feels instant: the cost of one keystroke, sampled individually (<code
-        >process.hrtime.bigint()</code
-      >
-      after warmup). For scale, the panel below measures that latency against one display frame across common refresh
-      rates (60-360 Hz); the benchmark itself runs headless, so it assumes no single display.
-    </div>
-    {{keystrokeHero}}
-    <table>
-      <thead>
-        <tr>
-          <th>Scenario</th>
-          <th>samples</th>
-          <th>mean</th>
-          <th>p50</th>
-          <th>p95</th>
-          <th>p99</th>
-        </tr>
-      </thead>
-      <tbody>
-        {{keystrokeLatencyRows}}
-      </tbody>
-    </table>
-    <div class="section-note">Worst-case (p99) keystroke against one frame, at common display refresh rates:</div>
-    {{refreshLadder}}
-    <div class="section-note">{{keystrokeLatencyVerdict}}</div>
-
-    <footer>
-      Reproduce locally: <code>pnpm bench</code>.<br />
-      Source:
-      <a href="https://github.com/martsinlabs/telixon/tree/main/packages/core/bench">benchmark harness</a>.
-    </footer>
   </body>
 </html>

--- a/packages/core/conformance/artifacts.ts
+++ b/packages/core/conformance/artifacts.ts
@@ -91,6 +91,8 @@ interface ShieldsBadge {
 const CONFORMANCE_DIR = resolve('packages/core/conformance');
 const ARTIFACT_DIR = join(CONFORMANCE_DIR, 'dist');
 const TEMPLATE = readFileSync(join(CONFORMANCE_DIR, 'parity.template.html'), 'utf8');
+// One stylesheet behind every proof page, so they and telixon.dev stay one visual system.
+const THEME = readFileSync(resolve('packages/core/proof-theme.css'), 'utf8');
 
 const METHOD_ROW_INDENT = '\n        ';
 
@@ -222,11 +224,20 @@ function buildBadge(data: ParityData): ShieldsBadge {
 // ── HTML rendering ───────────────────────────────────────
 
 function renderHtml(data: ParityData): string {
+  // data.overall already aggregates the method comparisons together with both sweeps.
+  const divergences = data.overall.total - data.overall.matched;
+  const methodsPerfect = data.methods.filter((method) => method.matchRate === 1).length;
+
   const tokens: Record<string, string> = {
+    '{{theme}}': THEME,
+    '{{divergences}}': formatCount(divergences),
+    '{{methodsPerfect}}': String(methodsPerfect),
+    '{{methodsTotal}}': String(data.methods.length),
+    '{{comparisons}}': formatCount(data.overall.total),
     '{{commit}}': data.commit,
     '{{shortCommit}}': data.commit.slice(0, 7),
-    '{{corpusSize}}': String(data.corpus.size),
-    '{{compared}}': String(data.corpus.compared),
+    '{{corpusSize}}': formatCount(data.corpus.size),
+    '{{compared}}': formatCount(data.corpus.compared),
     '{{regionsCovered}}': String(data.corpus.regionsCovered),
     '{{regionsTotal}}': String(data.corpus.regionsTotal),
     '{{skipped}}': String(data.corpus.skipped),
@@ -241,8 +252,12 @@ function renderHtml(data: ParityData): string {
   return Object.entries(tokens).reduce((html, [token, value]) => html.split(token).join(value), TEMPLATE);
 }
 
+function formatCount(value: number): string {
+  return value.toLocaleString('en-US');
+}
+
 function renderCorpusByKind(byKind: readonly ParityKind[]): string {
-  return byKind.map(({ kind, cases }) => `${kind}&nbsp;${cases}`).join(' · ');
+  return byKind.map(({ kind, cases }) => `${kind}&nbsp;${formatCount(cases)}`).join(' · ');
 }
 
 function renderPrefixSweep(sweep: ParityPrefixSweep): string {
@@ -256,8 +271,8 @@ function renderValidForRegionSweep(sweep: ParityValidForRegionSweep): string {
 }
 
 function renderAllowlist(allowlist: ParityAllowlist): string {
-  if (allowlist.unexpected === 0 && allowlist.stale === 0) return '<span class="ok">empty</span>';
-  return `${allowlist.unexpected} unexpected, ${allowlist.stale} stale`;
+  if (allowlist.unexpected === 0 && allowlist.stale === 0) return '<span class="ok">0</span>';
+  return `<span class="bad">${allowlist.unexpected} unexpected, ${allowlist.stale} stale</span>`;
 }
 
 function renderMethodRow(method: ParityMethod): string {

--- a/packages/core/conformance/parity.template.html
+++ b/packages/core/conformance/parity.template.html
@@ -4,91 +4,117 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Telixon conformance · {{shortCommit}}</title>
+    <meta
+      name="description"
+      content="Telixon matches Google libphonenumber on {{methodsPerfect}} of {{methodsTotal}} methods across {{comparisons}} comparisons, with {{divergences}} divergences."
+    />
+    <link rel="canonical" href="https://proof.telixon.dev/parity.html" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400..800&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
     <style>
-      body {
-        font:
-          16px/1.5 system-ui,
-          sans-serif;
-        max-width: 720px;
-        margin: 2rem auto;
-        padding: 0 1rem;
-        color: #17191b;
-      }
-      h1 {
-        font-size: 1.4rem;
-        margin-bottom: 0.5rem;
-      }
-      .meta {
-        color: #4c5257;
-        font-size: 0.9rem;
-        margin-bottom: 1.5rem;
-      }
-      table {
-        border-collapse: collapse;
-        width: 100%;
-      }
-      th,
-      td {
-        padding: 0.4rem 0.6rem;
-        border-bottom: 1px solid #eee;
-        text-align: left;
-      }
-      th:last-child,
-      td:last-child {
-        text-align: right;
-      }
-      .ok {
-        color: #058e69;
-        font-weight: 600;
-      }
-      code {
-        background: #f4f4f4;
-        padding: 0.1rem 0.3rem;
-        border-radius: 3px;
-        font-size: 0.9em;
-      }
-      footer {
-        margin-top: 2rem;
-        color: #7d838a;
-        font-size: 0.85rem;
-      }
-      a {
-        color: #208368;
-      }
+      {{theme}}
     </style>
   </head>
   <body>
-    <h1>Telixon conformance vs Google libphonenumber</h1>
-    <div class="meta">
-      Engine and oracle pinned to
-      <a href="https://github.com/google/libphonenumber/commit/{{commit}}">google/libphonenumber@{{shortCommit}}</a
-      >.<br />
-      {{corpusSize}} cases · {{compared}} compared · {{regionsCovered}}/{{regionsTotal}} regions · {{skipped}}
-      skipped.<br />
-      Corpus: {{corpusByKind}}.<br />
-      Google-rejected mutations judged not possible: {{rejection}}.<br />
-      Possibility prefix sweep: {{prefixSweep}}.<br />
-      Valid-for-region case sweep (one number per engine case): {{validForRegionCases}}.<br />
-      Allowlist: {{allowlist}}.<br />
-      Generated {{runAt}}.
+    <header class="masthead">
+      <div class="masthead-inner">
+        <a class="home" href="https://telixon.dev/">
+          <svg viewBox="0 0 121 104" fill="none" aria-hidden="true">
+            <path
+              d="M103.054 5.99002C100.224 2.22002 95.7739 0 91.0539 0H28.514C23.794 0 19.354 2.22002 16.514 5.99002L3.00394 23.99C-1.15606 29.53 -0.976059 37.19 3.42394 42.54L19.0039 61.44L48.2739 96.78C54.2739 104.03 65.3939 104.02 71.3939 96.77L100.584 61.44L116.164 42.54C120.564 37.2 120.744 29.53 116.584 23.99L103.074 5.99002H103.054ZM94.8339 52.65L75.074 78.2C73.904 79.71 71.4939 78.88 71.4939 76.98V41.25H87.6139L87.6639 53.34L100.804 35.47C101.854 34.04 101.844 32.09 100.764 30.68L91.8339 18.93C91.0739 17.93 89.9039 17.35 88.6539 17.35H30.9139C29.6639 17.35 28.484 17.93 27.734 18.93L18.8039 30.68C17.7339 32.09 17.714 34.04 18.764 35.47L31.9039 53.34L31.9539 41.25H48.074V76.98C48.074 78.89 45.6539 79.71 44.4939 78.2L24.734 52.65L13.1139 37.8C10.9239 35 10.8439 31.09 12.9139 28.2L23.4139 13.58C24.9139 11.49 27.3339 10.25 29.9139 10.25H89.6439C92.2239 10.25 94.6339 11.49 96.1439 13.58L106.644 28.2C108.724 31.09 108.644 35 106.444 37.8L94.824 52.65H94.8339Z"
+              fill="url(#gem)"
+            />
+            <defs>
+              <linearGradient id="gem" x1="59.79" y1="-4.01" x2="59.79" y2="103.25" gradientUnits="userSpaceOnUse">
+                <stop offset="0.02" stop-color="#27B78D" />
+                <stop offset="0.44" stop-color="#25A581" />
+                <stop offset="1" stop-color="#22896D" />
+              </linearGradient>
+            </defs>
+          </svg>
+          Telixon
+        </a>
+        <span class="kind">Conformance</span>
+      </div>
+    </header>
+
+    <div class="wrap">
+      <h1>Conformance against Google libphonenumber</h1>
+      <p class="note">
+        The engine and the oracle are pinned to the same commit, so the library is compared against the exact source it
+        was compiled from.
+      </p>
+
+      <section class="verdict">
+        <div class="verdict-value">{{divergences}}</div>
+        <div class="verdict-claim">divergences from Google libphonenumber</div>
+        <div class="verdict-rows">
+          <div><span>Methods at full parity</span><b>{{methodsPerfect}}/{{methodsTotal}}</b></div>
+          <div><span>Comparisons</span><b>{{comparisons}}</b></div>
+          <div><span>Regions covered</span><b>{{regionsCovered}}/{{regionsTotal}}</b></div>
+          <div><span>Cases skipped</span><b>{{skipped}}</b></div>
+          <div><span>Allowlisted divergences</span><b>{{allowlist}}</b></div>
+        </div>
+      </section>
+
+      <h2>Every method, every case</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Method</th>
+            <th>Match</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{methodRows}}
+        </tbody>
+      </table>
+
+      <h2>Sweeps</h2>
+      <p class="note">
+        Two additional passes widen the corpus beyond the case list: every possibility prefix, and one number per engine
+        case checked for its region.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Sweep</th>
+            <th>Agreement</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Possibility prefix</td>
+            <td>{{prefixSweep}}</td>
+          </tr>
+          <tr>
+            <td>Valid for region, one number per engine case</td>
+            <td>{{validForRegionCases}}</td>
+          </tr>
+          <tr>
+            <td>Google-rejected mutations judged not possible</td>
+            <td>{{rejection}}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Corpus</h2>
+      <p class="fine">
+        Pinned to
+        <a href="https://github.com/google/libphonenumber/commit/{{commit}}">google/libphonenumber@{{shortCommit}}</a>.
+        {{corpusSize}} cases, of which {{compared}} were compared.<br />
+        By kind: {{corpusByKind}}.<br />
+        Generated {{runAt}}.
+      </p>
+
+      <footer>
+        Reproduce locally with <code>pnpm conformance</code>. Source:
+        <a href="https://github.com/martsinlabs/telixon/tree/main/packages/core/conformance">conformance harness</a>.
+      </footer>
     </div>
-
-    <table>
-      <thead>
-        <tr>
-          <th>Method</th>
-          <th>Match</th>
-        </tr>
-      </thead>
-      <tbody>
-        {{methodRows}}
-      </tbody>
-    </table>
-
-    <footer>
-      Reproduce locally: <code>pnpm conformance</code>.<br />
-      Source:
-      <a href="https://github.com/martsinlabs/telixon/tree/main/packages/core/conformance">conformance harness</a>.
-    </footer>
   </body>
 </html>

--- a/packages/core/proof-theme.css
+++ b/packages/core/proof-theme.css
@@ -1,0 +1,325 @@
+/* Shared by every generated proof page, so the dashboards and telixon.dev stay one visual system. */
+
+:root {
+  --brand: 38 153 123;
+  --brand-solid: rgb(var(--brand));
+
+  /* The reading rail. Pages whose tables carry many columns opt into the wider one. */
+  --rail: 880px;
+
+  --bg: #f7f8f8;
+  --surface: #ffffff;
+  --surface-border: rgba(0, 0, 0, 0.1);
+  --surface-shadow: 0 10px 22px -14px rgba(20, 45, 32, 0.2), 0 2px 5px -3px rgba(20, 45, 32, 0.1);
+  --hairline: rgba(0, 0, 0, 0.09);
+  --text: #17191b;
+  --muted: #4c5257;
+  --faint: #676d73;
+  --accent: var(--brand-solid);
+  --accent-text: #1b7359;
+  --error: #ce2c31;
+  --well: #f2f3f4;
+
+  --font-sans: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #161618;
+    --surface: #272a2d;
+    --surface-border: rgba(255, 255, 255, 0.12);
+    /* A black shadow cannot darken a near-black canvas, so the top edge carries the elevation. */
+    --surface-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.09), 0 1px 2px rgba(0, 0, 0, 0.6), 0 20px 40px -24px rgba(0, 0, 0, 0.95);
+    --hairline: rgba(255, 255, 255, 0.08);
+    --text: #f2f3f4;
+    --muted: #9ba1a6;
+    --faint: #93999f;
+    --accent-text: #1fd8a4;
+    --error: #ef7275;
+    --well: #0b0d0e;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  font-size: 15px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+}
+
+body.wide {
+  --rail: 1120px;
+}
+
+.wrap {
+  max-width: var(--rail);
+  margin: 0 auto;
+  padding: 40px 24px 96px;
+}
+
+/* Full-bleed, so the rule reads as the edge of the bar rather than a line ruled under the logo. */
+.masthead {
+  border-bottom: 1px solid var(--hairline);
+}
+.masthead-inner {
+  max-width: var(--rail);
+  margin: 0 auto;
+  padding: 0 24px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+.masthead a.home {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--text);
+  font-weight: 700;
+  font-size: 16px;
+  letter-spacing: -0.02em;
+  text-decoration: none;
+}
+.masthead a.home svg {
+  width: 22px;
+  height: 22px;
+  display: block;
+}
+.masthead .kind {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--faint);
+}
+
+.verdict {
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: 18px;
+  box-shadow: var(--surface-shadow);
+  padding: 34px 32px;
+  margin-bottom: 40px;
+}
+.verdict-value {
+  font-size: 72px;
+  line-height: 1;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: var(--accent-text);
+  font-variant-numeric: tabular-nums;
+}
+.verdict-claim {
+  margin-top: 12px;
+  font-size: 17px;
+  color: var(--text);
+}
+.verdict-rows {
+  margin-top: 22px;
+  padding-top: 20px;
+  border-top: 1px solid var(--hairline);
+  display: grid;
+  gap: 9px;
+}
+.verdict-rows div {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  font-size: 14px;
+  color: var(--muted);
+}
+.verdict-rows b {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+h1 {
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 8px;
+}
+h2 {
+  font-size: 18px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  margin: 44px 0 6px;
+}
+p {
+  margin: 0 0 12px;
+}
+.note {
+  color: var(--muted);
+  font-size: 14px;
+}
+.fine {
+  color: var(--faint);
+  font-size: 13px;
+}
+
+a {
+  color: var(--accent-text);
+  text-decoration: underline;
+  text-decoration-color: rgb(var(--brand) / 0.35);
+  text-underline-offset: 0.2em;
+}
+a:hover {
+  text-decoration-color: currentColor;
+}
+:focus-visible {
+  outline: 2px solid var(--accent-text);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+}
+th {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--faint);
+  text-align: right;
+  padding: 0 12px 8px 0;
+  border-bottom: 1px solid var(--surface-border);
+}
+td {
+  text-align: right;
+  padding: 9px 12px 9px 0;
+  border-bottom: 1px solid var(--hairline);
+  color: var(--muted);
+}
+th:first-child,
+td:first-child {
+  text-align: left;
+}
+th:last-child,
+td:last-child {
+  padding-right: 0;
+}
+td code {
+  color: var(--text);
+}
+.ok,
+.win {
+  color: var(--accent-text);
+  font-weight: 600;
+}
+.bad {
+  color: var(--error);
+  font-weight: 600;
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.86em;
+  background: var(--well);
+  border: 1px solid var(--hairline);
+  border-radius: 6px;
+  padding: 0.1rem 0.35rem;
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 14px;
+  margin: 22px 0 8px;
+}
+.stat-card {
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: 14px;
+  box-shadow: var(--surface-shadow);
+  padding: 18px 20px;
+}
+.stat-value {
+  font-size: 30px;
+  line-height: 1.1;
+  font-weight: 750;
+  letter-spacing: -0.02em;
+  color: var(--accent-text);
+  font-variant-numeric: tabular-nums;
+}
+.stat-label {
+  margin-top: 4px;
+  font-weight: 600;
+  font-size: 14px;
+}
+.stat-sub {
+  margin-top: 2px;
+  color: var(--faint);
+  font-size: 13px;
+}
+
+/* One frame, drawn to scale. The keystroke is too small to fill anything, so it is a tick, not a fill. */
+.frame-bar {
+  position: relative;
+  height: 34px;
+  border: 1px solid var(--surface-border);
+  border-radius: 8px;
+  background: var(--well);
+  margin: 22px 0 8px;
+  overflow: hidden;
+}
+.frame-bar-fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  min-width: 3px;
+  background: var(--accent);
+  box-shadow: 0 0 12px 1px rgb(var(--brand) / 0.55);
+}
+.frame-bar-caption {
+  color: var(--muted);
+  font-size: 13px;
+  margin-bottom: 8px;
+}
+.loss {
+  color: var(--error);
+  font-weight: 600;
+}
+strong {
+  color: var(--text);
+  font-weight: 650;
+}
+
+footer {
+  margin-top: 56px;
+  padding-top: 20px;
+  border-top: 1px solid var(--hairline);
+  color: var(--faint);
+  font-size: 13px;
+}
+
+@media (max-width: 640px) {
+  .wrap {
+    padding: 32px 18px 64px;
+  }
+  .verdict {
+    padding: 26px 22px;
+  }
+  .verdict-value {
+    font-size: 56px;
+  }
+  table {
+    font-size: 13px;
+  }
+}


### PR DESCRIPTION
## Summary

Rebuilds elevation in the dark theme, gives the generated proof pages the Telixon design system, ranks
the h1 above the h2, and fixes the replay control. No engine or query-method code is touched.

## Motivation

Dark cards sat behind a black shadow, which cannot darken a near-black page, so they read as flat.
Elevation is now carried by light. The proof dashboards, which the landing points at as evidence,
rendered in system-ui with no theme and no dark mode. Parity now leads with its result: `0`
divergences. The h2 outranked the h1 at every width. Replay left the previous walk typing into the
same line.

## Conformance impact

None. Comparisons, assertions, and the parity gate are unchanged; only artifact rendering moved.

## Checklist

- [x] Tests added or updated (or a rationale for why none). None: CSS, markup, and artifact rendering.
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally. Typecheck and build clean too.
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention