### PR TITLE
docs(core): document the public API surface with verified JSDoc

### DIFF
--- a/packages/core/src/errors/engine-not-ready-error.ts
+++ b/packages/core/src/errors/engine-not-ready-error.ts
@@ -1,3 +1,7 @@
+/**
+ * Thrown by any API call made before {@link ensureEngineReady} (or `ensureEngineReadySync`) has
+ * loaded the engine. Once it is loaded, the query and controller APIs throw nothing.
+ */
 export class EngineNotReadyError extends Error {
   readonly name = 'EngineNotReadyError';
 

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -7,6 +7,14 @@ export * from './index';
 // Browser async init: fetches the code-split engine modules and decodes them off-thread (DecompressionStream). When to load is the consumer's call, never an import side effect.
 const loader = new LazyResourceLoader(decodeLayerStream);
 
+/**
+ * Loads the engine. Call it once before the first API call: it is idempotent, and nothing loads at
+ * import time. API calls made before it resolves throw {@link EngineNotReadyError}.
+ *
+ * @example
+ * await ensureEngineReady();
+ * parsePhoneNumber('+1 (415) 555-0132').isValid(); // true
+ */
 export function ensureEngineReady(): Promise<void> {
   return getResourceProvider().ensureReady(loader);
 }

--- a/packages/core/src/index.edge.ts
+++ b/packages/core/src/index.edge.ts
@@ -7,6 +7,14 @@ export * from './index';
 // Edge async init (workerd, edge-light, worker): dynamic import + off-thread DecompressionStream, run inside a request. For global-scope, once-per-isolate init, use @telixon/core/sync-init.
 const loader = new LazyResourceLoader(decodeLayerStream);
 
+/**
+ * Loads the engine. Call it once before the first API call: it is idempotent, and nothing loads at
+ * import time. API calls made before it resolves throw {@link EngineNotReadyError}.
+ *
+ * @example
+ * await ensureEngineReady();
+ * parsePhoneNumber('+1 (415) 555-0132').isValid(); // true
+ */
 export function ensureEngineReady(): Promise<void> {
   return getResourceProvider().ensureReady(loader);
 }

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -7,6 +7,14 @@ export * from './index';
 // Node async init: dynamic-imports the engine modules and decodes them off the libuv threadpool (native zlib). For synchronous init, use @telixon/core/sync-init.
 const loader = new LazyResourceLoader(decodeLayerNativeAsync);
 
+/**
+ * Loads the engine. Call it once before the first API call: it is idempotent, and nothing loads at
+ * import time. API calls made before it resolves throw {@link EngineNotReadyError}.
+ *
+ * @example
+ * await ensureEngineReady();
+ * parsePhoneNumber('+1 (415) 555-0132').isValid(); // true
+ */
 export function ensureEngineReady(): Promise<void> {
   return getResourceProvider().ensureReady(loader);
 }

--- a/packages/core/src/index.sync-init.node.ts
+++ b/packages/core/src/index.sync-init.node.ts
@@ -5,6 +5,14 @@ import { getResourceProvider } from './resource-provider';
 // Sync init extension for Node: native zlib decode of the bundled engine modules. This entry exports only the synchronous initializer.
 const loader = new EmbeddedResourceLoader(decodeLayerNative);
 
+/**
+ * Loads the engine synchronously from tables embedded in the bundle, for code that cannot await.
+ * Prefer {@link ensureEngineReady} elsewhere; embedding costs bundle size.
+ *
+ * @example
+ * import { ensureEngineReadySync } from '@telixon/core/sync-init';
+ * ensureEngineReadySync();
+ */
 export function ensureEngineReadySync(): void {
   getResourceProvider().ensureReadySync(loader);
 }

--- a/packages/core/src/index.sync-init.ts
+++ b/packages/core/src/index.sync-init.ts
@@ -4,6 +4,14 @@ import { getResourceProvider } from './resource-provider';
 // Sync init extension: bundles the engine modules (static import) and decodes them synchronously (pure-JS), readying the shared engine without awaiting. This entry exports only the synchronous initializer.
 const loader = new EmbeddedResourceLoader();
 
+/**
+ * Loads the engine synchronously from tables embedded in the bundle, for code that cannot await.
+ * Prefer {@link ensureEngineReady} elsewhere; embedding costs bundle size.
+ *
+ * @example
+ * import { ensureEngineReadySync } from '@telixon/core/sync-init';
+ * ensureEngineReadySync();
+ */
 export function ensureEngineReadySync(): void {
   getResourceProvider().ensureReadySync(loader);
 }

--- a/packages/core/src/modules/calling-code-for-region/get-calling-code-for-region.ts
+++ b/packages/core/src/modules/calling-code-for-region/get-calling-code-for-region.ts
@@ -1,7 +1,12 @@
 import { getMetadataRegionCallingCode, RegionCode } from '@telixon/core/engine';
 import { getResourceProvider } from '@telixon/core/resource-provider';
 
-// The calling code for a region (Google libphonenumber getCountryCodeForRegion), e.g. 'US' -> '1'; '0' for an unknown region. Requires ready resources.
+/**
+ * The country calling code for `region`, without the `+`, or `'0'` for a region the engine does not
+ * know. Mirrors libphonenumber's getCountryCodeForRegion.
+ *
+ * @example getCallingCodeForRegion('US'); // '1'
+ */
 export function getCallingCodeForRegion(region: RegionCode): string {
   const resourceProvider = getResourceProvider();
   const regionIndex: number | undefined = resourceProvider.regionKeyToIndex[region];

--- a/packages/core/src/modules/input-controller/international-input-controller/international-input-controller.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/international-input-controller.ts
@@ -383,6 +383,16 @@ class InternationalInputController implements InputController {
   }
 }
 
+/**
+ * Creates a headless {@link InputController} that resolves the region from the value. The calling
+ * code lives in the field unless `display.callingCodeInInput` is `false`, which requires
+ * `defaultRegion`.
+ *
+ * @example
+ * const controller = createInternationalInputController({});
+ * controller.setValue('+14155550132');
+ * // { value: '1 415-555-0132', region: 'US', selectionStart: 14, selectionEnd: 14 }
+ */
 export function createInternationalInputController(config: InternationalInputControllerConfig = {}): InputController {
   requireEngineReady();
 

--- a/packages/core/src/modules/input-controller/international-input-controller/models/index.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/models/index.ts
@@ -1,12 +1,25 @@
 import { RegionCode } from '@telixon/core/engine';
 
-// 'none' renders no plus, 'fixed' renders a permanent plus, 'erasable' renders a plus the user can delete and retype.
+/**
+ * How the leading `+` renders: `none` never shows it, `fixed` always shows it, `erasable` shows it
+ * only while the value carries one.
+ */
 export type PlusPrefixMode = 'none' | 'fixed' | 'erasable';
 
+/**
+ * Where the calling code lives. `callingCodeInInput: true`: the field holds calling-code digits
+ * (`1 415…` resolves as US) and `plusPrefix` controls the `+`. `false`: the field holds national
+ * digits only.
+ */
 export type InternationalDisplayConfig =
   | { readonly callingCodeInInput: false }
   | { readonly callingCodeInInput: true; readonly plusPrefix: PlusPrefixMode };
 
+/**
+ * Config for {@link createInternationalInputController}. `defaultRegion` is required only when the
+ * calling code is not shown in the input. `strict`, `initialValue`, and `maxHistorySize` match
+ * {@link NationalInputControllerConfig}.
+ */
 export type InternationalInputControllerConfig =
   | {
       defaultRegion?: RegionCode;

--- a/packages/core/src/modules/input-controller/models/index.ts
+++ b/packages/core/src/modules/input-controller/models/index.ts
@@ -2,10 +2,15 @@ import { NumberType, RegionCode } from '@telixon/core/engine';
 import { NumberResolverSnapshot, NumberTypeProfileRef } from '../../number-resolver/models';
 import { PhoneNumber } from '../../phone-number/models';
 
+/** The next value and caret to apply to the field. Returned by every mutating {@link InputController} method. */
 export interface InputState {
+  /** The formatted string to place in the field. */
   readonly value: string;
+  /** The region the value resolves to (a national controller's own region counts), or `null` when none does. */
   readonly region: RegionCode | null;
+  /** Caret start, as an index into `value`. */
   readonly selectionStart: number;
+  /** Caret end. Equal to `selectionStart` unless a range is selected. */
   readonly selectionEnd: number;
 }
 
@@ -25,19 +30,39 @@ export interface InputChange {
 
 export type CaretIndex = number;
 
+/**
+ * A headless controller for a phone-number field. Every edit takes the current value and caret and
+ * returns the next {@link InputState} to write back, reformatted and recorded in history. Holds the
+ * region, filters, and history; never touches the DOM. Bind it to an `<input>` yourself, or let
+ * `@telixon/web-sdk` do it.
+ */
 export interface InputController {
+  /** Replaces the selection from `selectionStart` to `selectionEnd` in `value` with `text`, then reformats. */
   insert(value: string, text: string, selectionStart: number, selectionEnd: number): InputState;
+  /** Deletes the selection, or the character before the caret when it is empty, then reformats. */
   deleteBackward(value: string, selectionStart: number, selectionEnd: number): InputState;
+  /** Deletes the selection, or the character after the caret when it is empty, then reformats. */
   deleteForward(value: string, selectionStart: number, selectionEnd: number): InputState;
+  /** Replaces the whole value and reformats, as for a paste or a programmatic set. */
   setValue(value: string): InputState;
+  /** Switches to `region` and reformats the current digits the way that region writes them. */
   setRegion(region: RegionCode): InputState;
+  /** Steps back to the previous state in history. */
   undo(): InputState;
+  /** Steps forward again after an {@link InputController.undo}. */
   redo(): InputState;
+  /** Restricts which regions the value may resolve to, or `null` to allow all. */
   setRegionFilter(regions: readonly RegionCode[] | null): InputState;
+  /** Restricts which number types the value may resolve to, or `null` to allow all. */
   setNumberTypeFilter(numberTypes: readonly NumberType[] | null): InputState;
+  /** Drops the undo and redo history. */
   clearHistory(): void;
+  /** The current value as a {@link PhoneNumber} to query. */
   getPhoneNumber(): PhoneNumber;
+  /** Whether there is history to {@link InputController.undo}. */
   readonly canUndo: boolean;
+  /** Whether there is history to {@link InputController.redo}. */
   readonly canRedo: boolean;
+  /** The value and caret as they stand, without mutating. */
   readonly currentState: InputState;
 }

--- a/packages/core/src/modules/input-controller/national-input-controller/models/index.ts
+++ b/packages/core/src/modules/input-controller/national-input-controller/models/index.ts
@@ -1,8 +1,13 @@
 import { RegionCode } from '@telixon/core/engine';
 
+/** Config for {@link createNationalInputController}. `defaultRegion` is required: the field holds one region's national number. */
 export interface NationalInputControllerConfig {
+  /** The region the field formats for. */
   defaultRegion: RegionCode;
+  /** Restricts validity to `defaultRegion`, as in {@link ParsePhoneNumberOptions}. */
   strict?: boolean;
+  /** Seeds the field with a starting value. */
   initialValue?: string;
+  /** Bounds the undo and redo history. */
   maxHistorySize?: number;
 }

--- a/packages/core/src/modules/input-controller/national-input-controller/national-input-controller.ts
+++ b/packages/core/src/modules/input-controller/national-input-controller/national-input-controller.ts
@@ -331,6 +331,15 @@ class NationalInputController implements InputController {
   }
 }
 
+/**
+ * Creates a headless {@link InputController} for one region's national format. The calling code
+ * never appears in the field.
+ *
+ * @example
+ * const controller = createNationalInputController({ defaultRegion: 'US' });
+ * controller.insert('(415) 555-013', '2', 13, 13);
+ * // { value: '(415) 555-0132', region: 'US', selectionStart: 14, selectionEnd: 14 }
+ */
 export function createNationalInputController(config: NationalInputControllerConfig): InputController {
   requireEngineReady();
 

--- a/packages/core/src/modules/parse-phone-number/models/index.ts
+++ b/packages/core/src/modules/parse-phone-number/models/index.ts
@@ -1,9 +1,12 @@
 import { RegionCode } from '@telixon/core/engine';
 
+/** Options for {@link parsePhoneNumber}. */
 export interface ParsePhoneNumberOptions {
-  // Assumed region for input without a leading '+'.
+  /** The region to resolve input against when it has no leading `+`. */
   defaultRegion?: RegionCode;
-  // Restrict validity (`isValid`/`getNumberType`) to `defaultRegion` (libphonenumber isValidNumberForRegion);
-  // `getRegion`, `isPossible`, and `format*` ignore it. No effect without `defaultRegion`; off by default.
+  /**
+   * Restricts `isValid` and `getNumberType` to `defaultRegion`. Other methods ignore it. No effect
+   * without `defaultRegion`; off by default.
+   */
   strict?: boolean;
 }

--- a/packages/core/src/modules/parse-phone-number/parse-phone-number.ts
+++ b/packages/core/src/modules/parse-phone-number/parse-phone-number.ts
@@ -8,7 +8,17 @@ function isWhitespace(charCode: number): boolean {
   return charCode === 0x20 || charCode === 0x09 || charCode === 0x0a || charCode === 0x0d;
 }
 
-// Parses a number into a PhoneNumber (no controller): '+' is international, else national via defaultRegion.
+/**
+ * Parses a phone number to validate, format, and inspect it. A leading `+` reads as international;
+ * otherwise pass `defaultRegion`. Never throws on bad input: the returned {@link PhoneNumber} reports
+ * why it is not valid.
+ *
+ * @param input - The number in any common notation. Spacing and punctuation are ignored.
+ * @param options - `defaultRegion` for input without a `+`; `strict` to restrict validity to it.
+ * @example
+ * parsePhoneNumber('+1 (415) 555-0132').formatE164(); // '+14155550132'
+ * parsePhoneNumber('(415) 555-0132', { defaultRegion: 'US' }).isValid(); // true
+ */
 // Detects the leading-plus flag, then defers to the shared resolveNumber pipeline (which ignores non-digits).
 export function parsePhoneNumber(input: string, options: ParsePhoneNumberOptions = {}): PhoneNumber {
   requireEngineReady();

--- a/packages/core/src/modules/phone-number/models/index.ts
+++ b/packages/core/src/modules/phone-number/models/index.ts
@@ -1,6 +1,11 @@
 import { NumberType, RegionCode } from '@telixon/core/engine';
 import { BinaryFilter } from '@telixon/core/models';
 
+/**
+ * The possibility check as a reason code: a resolvable calling code and a length the region dials,
+ * nationally (`IS_POSSIBLE`) or locally only (`IS_POSSIBLE_LOCAL_ONLY`). Mirrors libphonenumber's
+ * ValidationResult.
+ */
 export type PossibilityResult =
   | 'IS_POSSIBLE'
   | 'IS_POSSIBLE_LOCAL_ONLY'
@@ -9,15 +14,26 @@ export type PossibilityResult =
   | 'TOO_LONG'
   | 'INVALID_LENGTH';
 
-/** Structured validation outcome beyond `valid: boolean`. Kind values mirror libphonenumber where applicable. */
+/**
+ * Why a number is not valid, discriminated on `kind`. Four variants carry data. Returned by
+ * {@link PhoneNumber.getValidationError}; kinds mirror libphonenumber where applicable.
+ */
 export type ValidationError =
+  /** No digits to resolve. */
   | { readonly kind: 'EMPTY' }
+  /** The digits begin with no known country calling code. */
   | { readonly kind: 'INVALID_CALLING_CODE' }
+  /** Fewer digits than the region's shortest number. `minLength` is that shortest length. */
   | { readonly kind: 'TOO_SHORT'; readonly minLength: number }
+  /** More digits than the region's longest number. `maxLength` is that longest length. */
   | { readonly kind: 'TOO_LONG'; readonly maxLength: number }
+  /** The length falls in a gap between valid lengths. `possibleLengths` lists the lengths that exist. */
   | { readonly kind: 'INVALID_LENGTH'; readonly possibleLengths: readonly number[] }
+  /** Valid only for dialling inside its own area, not as a full number. */
   | { readonly kind: 'POSSIBLE_LOCAL_ONLY' }
+  /** The length is valid but the digits match no number that exists in the region. */
   | { readonly kind: 'PATTERN_MISMATCH' }
+  /** A required national (trunk) prefix was not typed. `expectedPrefix` is the missing prefix. */
   | { readonly kind: 'NATIONAL_PREFIX_MISSING'; readonly expectedPrefix: string };
 
 export interface ResolvedPhoneNumber {
@@ -33,18 +49,38 @@ export interface ResolvedPhoneNumber {
   readonly strict: boolean;
 }
 
+/**
+ * A parsed number: query its validity, region, and type, and format it. Returned by
+ * {@link parsePhoneNumber} and by a controller's `getPhoneNumber`.
+ */
 export interface PhoneNumber {
+  /** Whether the number exists in its region's numbering plan. */
   isValid(): boolean;
+  /** Whether the number is valid for `region` specifically. Mirrors libphonenumber's isValidNumberForRegion. */
   isValidForRegion(region: RegionCode): boolean;
+  /**
+   * Whether the calling code resolves and the length is one the region dials. Unlike
+   * {@link PhoneNumber.isValid}, the number itself is not checked.
+   */
   isPossible(): boolean;
+  /** The possibility check as a reason code, so a failed {@link PhoneNumber.isPossible} says why. */
   isPossibleWithReason(): PossibilityResult;
+  /** Why the number is not valid, or `null` when it is. One of eight typed variants. */
   getValidationError(): ValidationError | null;
+  /** The line type, such as `MOBILE` or `FIXED_LINE`. `UNKNOWN` when the number is not valid or the type is ambiguous. */
   getNumberType(): NumberType;
+  /** The national significant number: digits only, with the national prefix stripped. */
   getNationalNumber(): string;
+  /** The country calling code read from the digits, without the `+`, or `null` when there are none. */
   getCallingCode(): string | null;
+  /** The region the number resolves to, or `null` when none does. */
   getRegion(): RegionCode | null;
+  /** E.164, or `null` when the number is not valid. */
   formatE164(): string | null;
+  /** National format, or `null` when the number is not valid. */
   formatNational(): string | null;
+  /** International format, or `null` when the number is not valid. */
   formatInternational(): string | null;
+  /** RFC 3966 `tel:` URI, or `null` when the number is not valid. */
   formatRfc3966(): string | null;
 }

--- a/packages/core/src/modules/placeholders/build-example-placeholders.ts
+++ b/packages/core/src/modules/placeholders/build-example-placeholders.ts
@@ -8,10 +8,13 @@ import { getResourceProvider } from '@telixon/core/resource-provider';
 import { MetadataPlaceholders } from '@telixon/core/resource-provider/models';
 import { pickFormatMask } from '../number-resolver/utils/format-masks';
 
-/** Example placeholder variants for one number type, all optional. */
+/** A region's example number for one type, in each format a field might use. Each is absent when the region has no such form. */
 export interface Placeholders {
+  /** National format, without the national (trunk) prefix. */
   readonly national?: string;
+  /** National format, with the national (trunk) prefix. */
   readonly nationalWithPrefix?: string;
+  /** International format, the digits after `+` and the calling code. */
   readonly international?: string;
 }
 

--- a/packages/core/src/modules/placeholders/get-placeholders.ts
+++ b/packages/core/src/modules/placeholders/get-placeholders.ts
@@ -27,7 +27,7 @@ function hasInternationalFormat(callingCodeIndex: number): boolean {
   return false;
 }
 
-/** Returns example placeholder variants for `(region, type)`, or `null` if none. Requires ready resources. */
+/** Example placeholder variants for `(region, type)`, or `null` when none exists. */
 export function getPlaceholders(region: RegionCode, type: NumberType): Placeholders | null {
   const resourceProvider = getResourceProvider();
   const tables = resourceProvider.engine;

--- a/packages/core/src/modules/placeholders/is-national-prefix-optional.ts
+++ b/packages/core/src/modules/placeholders/is-national-prefix-optional.ts
@@ -12,7 +12,7 @@ import { getCallingCodeIndexByRegionIndex } from '@telixon/core/utils/get-callin
 import { resolveMetadataTypes } from '../number-resolver/utils/resolve-metadata-types';
 import { selectNationalFormatIndex } from '../number-resolver/utils/select-national-format';
 
-/** True when the format matching the example number for `(region, type)` allows the national prefix to be omitted. */
+/** Whether a `(region, type)` number can be written without its national (trunk) prefix. */
 export function isNationalPrefixOptional(region: RegionCode, type: NumberType): boolean {
   const resourceProvider = getResourceProvider();
   const tables = resourceProvider.engine;

--- a/packages/core/src/modules/region-number-types/region-supports-number-types.ts
+++ b/packages/core/src/modules/region-number-types/region-supports-number-types.ts
@@ -2,7 +2,12 @@ import { getRegionTypeCount, getRegionTypeId, NumberType, RegionCode } from '@te
 import { getResourceProvider } from '@telixon/core/resource-provider';
 import { resolveMetadataTypes } from '../number-resolver/utils/resolve-metadata-types';
 
-// True if the region supports at least one of the given types (FIXED_LINE_OR_MOBILE matches FIXED_LINE or MOBILE; UNKNOWN/empty matches nothing). Requires ready resources.
+/**
+ * Whether `region` supports at least one of `types`. `FIXED_LINE_OR_MOBILE` matches either side;
+ * `UNKNOWN` and an empty list match nothing.
+ *
+ * @example regionSupportsNumberTypes('US', ['MOBILE']); // true
+ */
 export function regionSupportsNumberTypes(region: RegionCode, types: readonly NumberType[]): boolean {
   if (types.length === 0) return false;
 

--- a/packages/core/src/number-types.ts
+++ b/packages/core/src/number-types.ts
@@ -1,5 +1,6 @@
 import { NumberType } from '@telixon/core/engine';
 
+/** Every {@link NumberType} value, in a stable order. */
 export const NUMBER_TYPES = [
   'FIXED_LINE',
   'MOBILE',

--- a/packages/core/src/resource-provider/index.ts
+++ b/packages/core/src/resource-provider/index.ts
@@ -2,7 +2,7 @@ import { getResourceProvider } from './resource-provider';
 
 export { getResourceProvider } from './resource-provider';
 
-// Synchronous readiness predicate for guards in code that may run before the engine is initialized.
+/** Whether the engine is loaded. Branch on it to avoid an {@link EngineNotReadyError}. */
 export function isEngineReady(): boolean {
   return getResourceProvider().isReady;
 }


### PR DESCRIPTION
## Summary

Adds JSDoc across the public `@telixon/core` surface: `parsePhoneNumber` and `PhoneNumber`, the input
controllers, `ValidationError`, setup, and region data.

## Motivation

The public API shipped with almost no doc comments, so editor hovers showed bare types. Every symbol
now has a plain-language docstring, and every `@example` was run against the real build. The three
generated engine symbols (`RegionCode`, `NumberType`, `REGION_CODES`) are documented by the generator
and untouched.

## Conformance impact

None. Comments only; no engine or query-method behavior changes.

## Checklist

- [x] Tests added or updated (or a rationale for why none). None: docstrings only; every `@example` verified by execution.
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally. Typecheck and both `.d.ts` builds clean too.
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention