### PR TITLE
Docs/core docs

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -40,9 +40,14 @@ export default defineConfig({
         { tag: 'meta', attrs: { name: 'twitter:card', content: 'summary' } },
       ],
       // One group per available package, labeled by npm name; PackageSidebar matches on that label.
+      // The pages inside a group come from the registry's sidebar field.
       sidebar: AVAILABLE_PACKAGES.map((pkg) => ({
         label: pkg.name,
-        items: [{ slug: pkg.base }],
+        items: (pkg.sidebar ?? [pkg.base]).map((entry) =>
+          typeof entry === 'string'
+            ? { slug: entry }
+            : { label: entry.label, items: entry.items.map((slug) => ({ slug })) },
+        ),
       })),
       components: {
         Sidebar: './src/components/PackageSidebar.astro',

--- a/apps/docs/src/content/docs/core/guides/build-a-phone-input.mdx
+++ b/apps/docs/src/content/docs/core/guides/build-a-phone-input.mdx
@@ -1,0 +1,117 @@
+---
+title: Build a phone input
+description: Wire a text field to a controller that formats live, moves the caret, and keeps history.
+---
+
+A phone input pairs a plain text field with an
+[`InputController`](/core/reference/input-controller/). The field emits edits; the controller
+returns the next state to write back.
+
+## Create the controller
+
+A single-region form takes a national controller. For a field that accepts any region, jump to
+[the international field](#the-international-field).
+
+```ts
+import { createNationalInputController } from '@telixon/core';
+
+const controller = createNationalInputController({ defaultRegion: 'US' });
+```
+
+## Wire the field
+
+Translate the field's `beforeinput` events into controller calls. Write each returned state back:
+
+```ts
+import type { InputState } from '@telixon/core';
+
+const input = document.querySelector('input')!;
+
+function apply(state: InputState) {
+  input.value = state.value;
+  input.setSelectionRange(state.selectionStart, state.selectionEnd);
+}
+
+input.addEventListener('beforeinput', (event) => {
+  event.preventDefault();
+  const value = input.value;
+  const start = input.selectionStart ?? 0;
+  const end = input.selectionEnd ?? 0;
+
+  if (event.inputType === 'deleteContentBackward') {
+    apply(controller.deleteBackward(value, start, end));
+  } else if (event.inputType === 'deleteContentForward') {
+    apply(controller.deleteForward(value, start, end));
+  } else {
+    const text = event.data ?? event.dataTransfer?.getData('text') ?? '';
+    apply(controller.insert(value, text, start, end));
+  }
+});
+```
+
+Typing `4155550132` leaves the field showing `(415) 555-0132`, with the caret after the last
+digit. A paste flows through the same handler. For a production binding, use
+[`@telixon/web-sdk`](/web-sdk/), the DOM adapter for controllers.
+
+## Undo and redo
+
+The controller already holds the [history](/core/reference/input-controller/#history); wire the
+keys to it:
+
+```ts
+input.addEventListener('keydown', (event) => {
+  if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== 'z') return;
+  event.preventDefault();
+  apply(event.shiftKey ? controller.redo() : controller.undo());
+});
+```
+
+## Read the number
+
+`getPhoneNumber` answers for the current value at any moment, mid-typing included:
+
+```ts
+controller.insert('', '4155550132', 0, 0);
+
+controller.getPhoneNumber().isValid(); // true
+controller.getPhoneNumber().formatE164(); // '+14155550132'
+```
+
+While the value is unfinished, prefer the tolerant checks; see
+[Validate user input](/core/guides/validate-user-input/).
+
+## The international field
+
+A field that takes numbers from anywhere switches to the international controller. The region
+follows the digits from the first keystroke:
+
+```ts
+import { createInternationalInputController } from '@telixon/core';
+
+const controller = createInternationalInputController();
+
+let state = controller.insert('', '1', 0, 0);
+// { value: '1 ', region: 'US', selectionStart: 2, selectionEnd: 2 }
+
+state = controller.insert(state.value, '4155550132', 2, 2);
+// { value: '1 415-555-0132', region: 'US', selectionStart: 14, selectionEnd: 14 }
+```
+
+The display modes, including the leading `+`, are under
+[`InternationalInputControllerConfig`](/core/reference/input-controller/#internationalinputcontrollerconfig).
+
+## Restrict number types
+
+A field for one kind of number filters the rest out. A support-line field takes only toll-free
+numbers:
+
+```ts
+const supportLine = createNationalInputController({ defaultRegion: 'US' });
+supportLine.setNumberTypeFilter(['TOLL_FREE']);
+
+supportLine.setValue('8002345678');
+supportLine.getPhoneNumber().isValid(); // true
+
+supportLine.setValue('4155550132');
+supportLine.getPhoneNumber().isValid(); // false
+```

--- a/apps/docs/src/content/docs/core/guides/build-a-region-selector.mdx
+++ b/apps/docs/src/content/docs/core/guides/build-a-region-selector.mdx
@@ -1,0 +1,78 @@
+---
+title: Build a region selector
+description: Pair a region dropdown with the phone field and keep the two in sync.
+---
+
+A region selector pairs a dropdown with the phone field. The dropdown sets the region. The field
+holds the national number.
+
+## List the regions
+
+[`REGION_CODES`](/core/reference/region-data/#region_codes) and
+[`getCallingCodeForRegion`](/core/reference/region-data/#getcallingcodeforregion) supply the
+dropdown rows. Display names come from the platform:
+
+```ts
+import { REGION_CODES, getCallingCodeForRegion } from '@telixon/core';
+
+const displayNames = new Intl.DisplayNames(['en'], { type: 'region' });
+
+const options = REGION_CODES.map((region) => ({
+  region,
+  callingCode: getCallingCodeForRegion(region),
+  name: displayNames.of(region),
+}));
+// [{ region: 'AC', callingCode: '247', name: 'Ascension Island' }, ...]
+```
+
+When the product accepts only some number types, keep the list to regions that assign them:
+
+```ts
+import { regionSupportsNumberTypes } from '@telixon/core';
+
+const mobileRegions = REGION_CODES.filter((region) => regionSupportsNumberTypes(region, ['MOBILE']));
+```
+
+## Show a placeholder
+
+[`getPlaceholders`](/core/reference/region-data/#getplaceholders) turns the selected region into
+the field's placeholder:
+
+```ts
+import { getPlaceholders } from '@telixon/core';
+
+getPlaceholders('US', 'MOBILE')?.national; // '(201) 555-0123'
+```
+
+## Wire the dropdown to the field
+
+An international controller with the calling code kept out of the field takes its region from the
+dropdown. Call [`setRegion`](/core/reference/input-controller/#setregion) on the dropdown's
+`change` event and write the returned state back:
+
+```ts
+import { createInternationalInputController } from '@telixon/core';
+
+const field = createInternationalInputController({
+  defaultRegion: 'US',
+  display: { callingCodeInInput: false },
+});
+
+field.setRegion('CA');
+field.insert('', '6045550132', 0, 0);
+// { value: '604-555-0132', region: 'CA', selectionStart: 12, selectionEnd: 12 }
+
+field.getPhoneNumber().formatE164(); // '+16045550132'
+```
+
+The field shows national digits. The selected region supplies the calling code.
+
+## Pin the field to the selection
+
+[`setRegionFilter`](/core/reference/input-controller/#setregionfilter) pins resolution to the
+dropdown's choice. Digits from any other region stop validating:
+
+```ts
+field.setRegionFilter(['CA']);
+field.getPhoneNumber().isValid(); // true
+```

--- a/apps/docs/src/content/docs/core/guides/validate-user-input.mdx
+++ b/apps/docs/src/content/docs/core/guides/validate-user-input.mdx
@@ -1,0 +1,84 @@
+---
+title: Validate user input
+description: Tolerant feedback while the user types and an exact message on submit.
+---
+
+A phone field needs two kinds of feedback: tolerant while the user types, exact on submit. The
+possibility checks give the first. `getValidationError` gives the second.
+
+## While the user types
+
+Most values in a field are unfinished, so treat a short number as neutral. Two failures are worth
+flagging immediately, because more typing cannot fix them: a calling code that does not exist and a
+number that is already too long.
+
+```ts
+function feedbackWhileTyping(input: string): string | null {
+  const number = parsePhoneNumber(input, { defaultRegion: 'US' });
+  if (number.isValid()) return null;
+
+  switch (number.isPossibleWithReason()) {
+    case 'INVALID_CALLING_CODE':
+      return 'That country code does not exist.';
+    case 'TOO_LONG':
+      return 'This number has too many digits.';
+    default:
+      return null;
+  }
+}
+
+feedbackWhileTyping('+1 415'); // null, still typing
+feedbackWhileTyping('+999 123'); // 'That country code does not exist.'
+feedbackWhileTyping('+1 21255512345678'); // 'This number has too many digits.'
+```
+
+The six reason codes are under
+[`PossibilityResult`](/core/reference/phone-number/#possibilityresult).
+
+## On submit
+
+Require [`isValid`](/core/reference/phone-number/#isvalid) and turn the failure into a message the
+user can act on. The [carried payloads](/core/reference/validation-error/#carried-data) let each
+message name the fix:
+
+```ts
+import type { ValidationError } from '@telixon/core';
+
+function describe(error: ValidationError): string {
+  switch (error.kind) {
+    case 'EMPTY':
+      return 'Enter a phone number.';
+    case 'INVALID_CALLING_CODE':
+      return 'That country code does not exist.';
+    case 'TOO_SHORT':
+      return `Too short. This number needs ${error.minLength} digits.`;
+    case 'TOO_LONG':
+      return `Too long. This number takes at most ${error.maxLength} digits.`;
+    case 'INVALID_LENGTH':
+      return `Wrong length. Valid lengths are ${error.possibleLengths.join(', ')}.`;
+    case 'POSSIBLE_LOCAL_ONLY':
+      return 'That number only works when dialled locally.';
+    case 'PATTERN_MISMATCH':
+      return 'The length is right, but no number with these digits exists in this region.';
+    case 'NATIONAL_PREFIX_MISSING':
+      return `Start the number with ${error.expectedPrefix}.`;
+  }
+}
+
+const number = parsePhoneNumber('+1 415');
+if (!number.isValid()) {
+  describe(number.getValidationError()!); // 'Too short. This number needs 10 digits.'
+}
+```
+
+## Store the number
+
+Store the canonical E.164 string. It parses back with no options:
+
+```ts
+parsePhoneNumber('(415) 555-0132', { defaultRegion: 'US' }).formatE164(); // '+14155550132'
+parsePhoneNumber('+14155550132').isValid(); // true
+```
+
+To restrict validity to the form's own region at parse time, use
+[`strict`](/core/reference/parse-phone-number/#strict).

--- a/apps/docs/src/content/docs/core/how-it-works.mdx
+++ b/apps/docs/src/content/docs/core/how-it-works.mdx
@@ -1,0 +1,59 @@
+---
+title: How Telixon works
+description: Digits walk one automaton. Validity is an accepting state. The parser and the input controllers share the walk.
+---
+
+Google libphonenumber's metadata is compiled ahead of time into a single
+[deterministic finite automaton](https://en.wikipedia.org/wiki/Deterministic_finite_automaton)
+(DFA), stored as binary tables. Everything the API does is defined by that automaton.
+
+## Parsing
+
+Parsing is a walk over the automaton, one digit per step. The state the walk ends on determines
+the region, the number type, whether the number is valid, and how to format it.
+
+```ts
+const number = parsePhoneNumber('+1 (415) 555-0132');
+// the walk has already happened; every answer below derives from its end state
+
+number.getRegion(); // 'US'
+number.getNumberType(); // 'FIXED_LINE_OR_MOBILE'
+number.isValid(); // true
+```
+
+## Validity
+
+A number is valid when the walk ends on an accepting state. That is the whole definition.
+Everything else is a classified failure, returned as a typed value:
+
+```ts
+parsePhoneNumber('5550132', { defaultRegion: 'US' }).getValidationError();
+// { kind: 'POSSIBLE_LOCAL_ONLY' }
+```
+
+Seven digits form a US number that connects only inside its own area. The walk ends on a state that
+records exactly that. The eight variants are in
+[`ValidationError`](/core/reference/validation-error/).
+
+## Parser and controller consistency
+
+`parsePhoneNumber` walks the automaton once, over a whole string. An input controller walks it
+again on every keystroke, over the value as it stands. It is the same walk. A controller can hand
+you a `PhoneNumber` at any moment, mid-typing. Its answers agree with the parser's by construction.
+
+```ts
+const controller = createInternationalInputController();
+controller.setValue('+1 (415) 555-0132');
+
+controller.getPhoneNumber().formatE164(); // '+14155550132'
+parsePhoneNumber('+1 (415) 555-0132').formatE164(); // '+14155550132'
+```
+
+## Consequences
+
+- **[Parsing does not throw.](/core/reference/parse-phone-number/)** A walk always ends somewhere.
+  Where it ends is the result.
+- **[Formatting can return `null`.](/core/reference/phone-number/#formats)** A format is a property
+  of an accepting state. A number that never reached one has no format to give.
+- **[The engine loads first.](/core/load-the-engine/)** Without the tables there is nothing to
+  walk.

--- a/apps/docs/src/content/docs/core/index.mdx
+++ b/apps/docs/src/content/docs/core/index.mdx
@@ -1,7 +1,122 @@
 ---
 title: Getting started
-description: Parse, validate, and format phone numbers in Node.js, browsers, and edge runtimes with @telixon/core.
+description: Install @telixon/core, load the engine, and parse a first phone number.
 ---
 
-`@telixon/core` parses, validates, and formats phone numbers in Node.js, browsers, and edge
-runtimes.
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+`@telixon/core` parses, validates, and formats phone numbers. The same engine drives phone-number
+fields. It runs in Node.js, browsers, Deno, Bun, and edge runtimes, with no dependencies.
+
+## Install
+
+<Tabs syncKey="pkg">
+
+<TabItem label="npm">
+
+```sh
+npm install @telixon/core
+```
+
+</TabItem>
+
+<TabItem label="pnpm">
+
+```sh
+pnpm add @telixon/core
+```
+
+</TabItem>
+
+<TabItem label="Yarn">
+
+```sh
+yarn add @telixon/core
+```
+
+</TabItem>
+
+<TabItem label="Bun">
+
+```sh
+bun add @telixon/core
+```
+
+</TabItem>
+
+<TabItem label="Deno">
+
+```sh
+deno add npm:@telixon/core
+```
+
+</TabItem>
+
+</Tabs>
+
+## Parse a number
+
+One `await` at startup loads the engine. Everything after it is synchronous.
+[Load the engine](/core/load-the-engine/) covers the per-runtime builds and the synchronous entry.
+
+```ts
+import { ensureEngineReady, parsePhoneNumber } from '@telixon/core';
+
+await ensureEngineReady();
+
+const number = parsePhoneNumber('+1 (415) 555-0132');
+
+number.isValid(); // true
+number.getRegion(); // 'US'
+number.getNumberType(); // 'FIXED_LINE_OR_MOBILE'
+number.formatE164(); // '+14155550132'
+```
+
+A leading `+` reads as international. Anything else needs a
+[region to resolve against](/core/reference/parse-phone-number/#defaultregion):
+
+```ts
+parsePhoneNumber('(415) 555-0132', { defaultRegion: 'US' }).formatE164(); // '+14155550132'
+```
+
+## Inspect invalid input
+
+`parsePhoneNumber` [never throws](/core/reference/parse-phone-number/): bad input still comes back
+as a `PhoneNumber`, with a typed reason:
+
+```ts
+const wrongLength = parsePhoneNumber('+57 321 123 456');
+
+wrongLength.isValid(); // false
+wrongLength.getValidationError(); // { kind: 'INVALID_LENGTH', possibleLengths: [8, 10, 11] }
+```
+
+Colombia dials numbers of 8, 10, and 11 digits. Nine digits falls in a gap. The error carries the
+lengths that exist.
+
+[`ValidationError`](/core/reference/validation-error/) lists all eight variants.
+[Validate user input](/core/guides/validate-user-input/) turns them into messages.
+
+## Drive an input
+
+An input controller is the
+[same engine](/core/how-it-works/#parser-and-controller-consistency) called once per keystroke. It
+takes the field's value and caret, then returns the next ones. The field formats from the first digit:
+
+```ts
+import { createNationalInputController } from '@telixon/core';
+
+const controller = createNationalInputController({ defaultRegion: 'US' });
+
+controller.insert('', '4', 0, 0);
+// { value: '(4)', region: 'US', selectionStart: 2, selectionEnd: 2 }
+
+controller.insert('(4)', '155550132', 2, 2);
+// { value: '(415) 555-0132', region: 'US', selectionStart: 14, selectionEnd: 14 }
+
+controller.getPhoneNumber().formatE164(); // '+14155550132'
+```
+
+[Build a phone input](/core/guides/build-a-phone-input/) covers the field wiring.
+
+The model behind all of this is in [How Telixon works](/core/how-it-works/).

--- a/apps/docs/src/content/docs/core/load-the-engine.mdx
+++ b/apps/docs/src/content/docs/core/load-the-engine.mdx
@@ -1,0 +1,101 @@
+---
+title: Load the engine
+description: Load the engine with ensureEngineReady, or synchronously with ensureEngineReadySync.
+---
+
+The engine is the compiled automaton. Every query and controller call reads it, so it must be in
+memory first. Loading is explicit: nothing loads when you import the package.
+
+## ensureEngineReady
+
+```ts
+function ensureEngineReady(): Promise<void>;
+```
+
+Call it once, before the first API call. It is idempotent: later calls resolve immediately and load
+nothing. You choose the moment.
+
+```ts
+import { ensureEngineReady, parsePhoneNumber } from '@telixon/core';
+
+await ensureEngineReady();
+
+parsePhoneNumber('+1 (415) 555-0132').isValid(); // true
+```
+
+Concurrent calls share one in-flight load. A failed load rejects with the underlying error. The
+failure is not cached: the next call starts a fresh load.
+
+## EngineNotReadyError
+
+```ts
+class EngineNotReadyError extends Error {}
+```
+
+An API call before the engine is ready throws `EngineNotReadyError`. Once the engine is loaded, the
+query and controller APIs throw nothing.
+
+```ts
+import { EngineNotReadyError, parsePhoneNumber } from '@telixon/core';
+
+try {
+  parsePhoneNumber('+1 (415) 555-0132');
+} catch (error) {
+  error instanceof EngineNotReadyError; // true
+}
+```
+
+## isEngineReady
+
+```ts
+function isEngineReady(): boolean;
+```
+
+Whether the engine is loaded. Branch on it to avoid an `EngineNotReadyError`.
+
+```ts
+import { isEngineReady } from '@telixon/core';
+
+isEngineReady(); // false before ensureEngineReady() resolves
+```
+
+## Runtime builds
+
+The package name is the same everywhere. The runtime picks the build.
+
+| Runtime                  | Build resolved     |
+| ------------------------ | ------------------ |
+| Node.js                  | `index.node.js`    |
+| Deno, Bun                | `index.node.js`    |
+| Browsers and bundlers    | `index.browser.js` |
+| Workers, edge, `workerd` | `index.edge.js`    |
+
+The browser and edge builds import the tables as code-split modules, then inflate them with
+`DecompressionStream`. The Node build decodes with native zlib, off the event loop.
+`ensureEngineReady` is the same call everywhere.
+
+## ensureEngineReadySync
+
+```ts
+function ensureEngineReadySync(): void;
+```
+
+Initializes the engine synchronously, from tables embedded in the bundle. The cost is bundle size:
+the embedded tables are about [123 kB gzipped](/verified/#size). It lands only where this entry is imported.
+
+```ts
+import { ensureEngineReadySync } from '@telixon/core/sync-init';
+import { parsePhoneNumber } from '@telixon/core';
+
+ensureEngineReadySync();
+
+parsePhoneNumber('+1 (415) 555-0132').isValid(); // true
+```
+
+Reach for this only where you cannot await: a synchronous constructor, a module-level default, a
+migration script. Everywhere else, prefer `ensureEngineReady`.
+
+## One engine per process
+
+`ensureEngineReady` and `ensureEngineReadySync` fill the same process-wide engine. Loading it in
+two places loads it once. There is no instance to pass around.

--- a/apps/docs/src/content/docs/core/reference/input-controller.mdx
+++ b/apps/docs/src/content/docs/core/reference/input-controller.mdx
@@ -1,0 +1,226 @@
+---
+title: InputController
+description: The two controller factories, their configs, InputState, and all fourteen members.
+---
+
+A state controller for a phone-number field. Every state-changing call returns the next
+[`InputState`](#inputstate) to write back. The controller holds the region, the filters, and the
+history.
+
+## createNationalInputController
+
+```ts
+function createNationalInputController(config: NationalInputControllerConfig): InputController;
+```
+
+Creates a controller for one region's national format. The calling code never appears in the field.
+
+```ts
+const controller = createNationalInputController({ defaultRegion: 'US' });
+
+controller.insert('', '4155550132', 0, 0);
+// { value: '(415) 555-0132', region: 'US', selectionStart: 14, selectionEnd: 14 }
+```
+
+### NationalInputControllerConfig
+
+| Field            | Type         | Meaning                                                          |
+| ---------------- | ------------ | ---------------------------------------------------------------- |
+| `defaultRegion`  | `RegionCode` | Required. The region the field formats for.                      |
+| `strict`         | `boolean`    | Restricts validity to `defaultRegion`, as in `parsePhoneNumber`. |
+| `initialValue`   | `string`     | Seeds the field with a starting value, outside the history.      |
+| `maxHistorySize` | `number`     | Bounds the undo and redo history.                                |
+
+## createInternationalInputController
+
+```ts
+function createInternationalInputController(config?: InternationalInputControllerConfig): InputController;
+```
+
+Creates a controller that resolves the region from the value. The calling code lives in the field
+unless `display.callingCodeInInput` is `false`, which requires `defaultRegion`.
+
+```ts
+const controller = createInternationalInputController();
+
+controller.setValue('+14155550132');
+// { value: '1 415-555-0132', region: 'US', selectionStart: 14, selectionEnd: 14 }
+```
+
+### InternationalInputControllerConfig
+
+`defaultRegion`, `strict`, `initialValue`, and `maxHistorySize` match
+[`NationalInputControllerConfig`](#nationalinputcontrollerconfig), with two differences.
+`defaultRegion` is required only when the calling code is kept out of the field. When the calling
+code is in the field, `defaultRegion` pre-fills the field with that region's code.
+
+`display`, an `InternationalDisplayConfig`, places the calling code:
+
+| `display`                                  | The field holds                                                                      |
+| ------------------------------------------ | ------------------------------------------------------------------------------------ |
+| omitted                                    | Calling-code digits, with no `+` rendered                                            |
+| `{ callingCodeInInput: true, plusPrefix }` | Calling-code digits, with the `+` under `plusPrefix`                                 |
+| `{ callingCodeInInput: false }`            | National digits; the region comes from `defaultRegion` and [`setRegion`](#setregion) |
+
+`plusPrefix`, a `PlusPrefixMode`, renders the leading `+`: `'none'` never, `'fixed'` always,
+`'erasable'` while the value carries one. Under `'erasable'`, backspace at the start removes it.
+
+## InputState
+
+```ts
+interface InputState {
+  readonly value: string;
+  readonly region: RegionCode | null;
+  readonly selectionStart: number;
+  readonly selectionEnd: number;
+}
+```
+
+The next value and caret to apply to the field. `value` is the formatted string. `region` is the
+region the value resolves to, or `null` when none does. The selection indices point into `value`.
+Within a shared calling code, `region` reports the resolved owner of the digits: a `604` number
+reports `CA` even in a US-configured field.
+
+## Edits
+
+All four take the field's value as an argument, so the controller works from what the field
+actually shows.
+
+### insert
+
+```ts
+insert(value: string, text: string, selectionStart: number, selectionEnd: number): InputState;
+```
+
+Replaces the selection from `selectionStart` to `selectionEnd` in `value` with `text`, then
+reformats. `text` can be one keystroke or a whole paste.
+
+### deleteBackward
+
+```ts
+deleteBackward(value: string, selectionStart: number, selectionEnd: number): InputState;
+```
+
+Deletes the selection, or the character before the caret when the selection is empty, then
+reformats. When that character is a formatting character, the deletion steps across it to the
+nearest digit.
+
+### deleteForward
+
+```ts
+deleteForward(value: string, selectionStart: number, selectionEnd: number): InputState;
+```
+
+Mirrors [`deleteBackward`](#deletebackward) for the character after the caret.
+
+### setValue
+
+```ts
+setValue(value: string): InputState;
+```
+
+Replaces the whole value and reformats, as for a paste or a programmatic set.
+
+## Region and filters
+
+Every change here re-resolves the value already in the field.
+
+### setRegion
+
+```ts
+setRegion(region: RegionCode): InputState;
+```
+
+Switches to `region` and reformats the current digits the way that region writes them. Where the
+calling code lives in the field, the digits keep deciding the region. Where the field holds
+national digits only, the switch applies.
+
+### setRegionFilter
+
+```ts
+setRegionFilter(regions: readonly RegionCode[] | null): InputState;
+```
+
+Restricts which regions the value may resolve to, or `null` to allow all.
+
+### setNumberTypeFilter
+
+```ts
+setNumberTypeFilter(numberTypes: readonly NumberType[] | null): InputState;
+```
+
+Restricts which number types the value may resolve to, or `null` to allow all.
+
+## History
+
+The four edits and `setRegion` push a new entry onto the history. The two filters replace the
+current entry.
+
+### undo
+
+```ts
+undo(): InputState;
+```
+
+Steps back to the previous state in history. With nothing to undo, it returns the current state.
+
+### redo
+
+```ts
+redo(): InputState;
+```
+
+Steps forward again after an [`undo`](#undo).
+
+### canUndo
+
+```ts
+readonly canUndo: boolean;
+```
+
+Whether there is history to undo. `initialValue` seeds the field outside the history, so a freshly
+created controller reports `false`.
+
+### canRedo
+
+```ts
+readonly canRedo: boolean;
+```
+
+Whether there is history to redo.
+
+### clearHistory
+
+```ts
+clearHistory(): void;
+```
+
+Drops the undo and redo history.
+
+## Queries
+
+Reading changes nothing.
+
+### getPhoneNumber
+
+```ts
+getPhoneNumber(): PhoneNumber;
+```
+
+The current value as a [`PhoneNumber`](/core/reference/phone-number/) to query, equal to
+`parsePhoneNumber` of the displayed value.
+
+### currentState
+
+```ts
+readonly currentState: InputState;
+```
+
+The value and caret as they stand.
+
+## Conformance
+
+The conformance suite types enumerated inputs through a controller, character by character,
+requiring the [`getPhoneNumber`](#getphonenumber) equality on every input. `parsePhoneNumber` is
+the Google-compared path, so the controllers are held to the same parity; see
+[Verified](/verified/#conformance).

--- a/apps/docs/src/content/docs/core/reference/parse-phone-number.mdx
+++ b/apps/docs/src/content/docs/core/reference/parse-phone-number.mdx
@@ -1,0 +1,56 @@
+---
+title: parsePhoneNumber
+description: The parsing entry point and its two options.
+---
+
+```ts
+function parsePhoneNumber(input: string, options?: ParsePhoneNumberOptions): PhoneNumber;
+```
+
+Parses a phone number to validate, format, and inspect it. A leading `+` reads as international;
+otherwise the digits resolve against `defaultRegion`. Spacing and punctuation are ignored. It never
+throws on bad input: the returned [`PhoneNumber`](/core/reference/phone-number/) reports why it is
+not valid.
+
+```ts
+parsePhoneNumber('+1 (415) 555-0132').formatE164(); // '+14155550132'
+parsePhoneNumber('(415) 555-0132', { defaultRegion: 'US' }).isValid(); // true
+```
+
+## ParsePhoneNumberOptions
+
+### defaultRegion
+
+```ts
+defaultRegion?: RegionCode;
+```
+
+The region input without a `+` resolves against. Without it, plus-less digits read as
+international, calling code first:
+
+```ts
+parsePhoneNumber('415-555-0132').getRegion(); // 'CH', 41 read as the calling code
+parsePhoneNumber('415-555-0132', { defaultRegion: 'US' }).getRegion(); // 'US'
+```
+
+### strict
+
+```ts
+strict?: boolean;
+```
+
+Restricts `isValid` and `getNumberType` to `defaultRegion`. Other methods ignore it. Without
+`defaultRegion` it has no effect. It is off by default.
+
+```ts
+const number = parsePhoneNumber('(604) 555-0132', { defaultRegion: 'US', strict: true });
+
+number.getRegion(); // 'CA'
+number.isValid(); // false
+number.getNumberType(); // 'UNKNOWN'
+```
+
+## Conformance
+
+Conformance for the returned `PhoneNumber`'s methods is on
+[`PhoneNumber`](/core/reference/phone-number/#conformance).

--- a/apps/docs/src/content/docs/core/reference/phone-number.mdx
+++ b/apps/docs/src/content/docs/core/reference/phone-number.mdx
@@ -1,0 +1,152 @@
+---
+title: PhoneNumber
+description: The thirteen query and format methods on a parsed number.
+---
+
+A parsed number, returned by [`parsePhoneNumber`](/core/reference/parse-phone-number/) and by a
+controller's [`getPhoneNumber`](/core/reference/input-controller/#getphonenumber). Thirteen methods
+query and format it. Every answer derives from the state resolved at parse time.
+
+The examples share one number:
+
+```ts
+const number = parsePhoneNumber('+1 (415) 555-0132');
+```
+
+## Validity
+
+### isValid
+
+Whether the number exists in its region's numbering plan.
+
+```ts
+number.isValid(); // true
+```
+
+### isValidForRegion
+
+Whether the number is valid for one region specifically. Mirrors libphonenumber's
+`isValidNumberForRegion`.
+
+```ts
+number.isValidForRegion('US'); // true
+number.isValidForRegion('CA'); // false
+```
+
+### isPossible
+
+Whether the calling code resolves and the length is one the region dials. The digits themselves go
+unchecked, so a possible number can still be invalid.
+
+```ts
+number.isPossible(); // true
+parsePhoneNumber('+1 123-456-7890').isPossible(); // true, ten digits is a US length
+```
+
+### isPossibleWithReason
+
+The possibility check as a [`PossibilityResult`](#possibilityresult) reason code, so a failed
+`isPossible` says why.
+
+```ts
+number.isPossibleWithReason(); // 'IS_POSSIBLE'
+parsePhoneNumber('+1 415').isPossibleWithReason(); // 'TOO_SHORT'
+```
+
+### getValidationError
+
+Why the number is not valid, or `null` when it is. One of the eight typed
+[`ValidationError`](/core/reference/validation-error/) variants.
+
+```ts
+number.getValidationError(); // null
+parsePhoneNumber('+1 415').getValidationError(); // { kind: 'TOO_SHORT', minLength: 10 }
+```
+
+### PossibilityResult
+
+The six reason codes `isPossibleWithReason` returns. Mirrors libphonenumber's `ValidationResult`.
+
+| Value                    | Meaning                                                        |
+| ------------------------ | -------------------------------------------------------------- |
+| `IS_POSSIBLE`            | The calling code resolves and the length is dialled nationally |
+| `IS_POSSIBLE_LOCAL_ONLY` | The length is dialled only inside its own area                 |
+| `INVALID_CALLING_CODE`   | The digits begin with no known calling code                    |
+| `TOO_SHORT`              | Fewer digits than the region's shortest number                 |
+| `TOO_LONG`               | More digits than the region's longest number                   |
+| `INVALID_LENGTH`         | The length falls in a gap between valid lengths                |
+
+## Identity
+
+### getRegion
+
+The region the number resolves to, or `null` when none does.
+
+```ts
+number.getRegion(); // 'US'
+```
+
+### getCallingCode
+
+The country calling code read from the digits, without the `+`, or `null` when there are none.
+
+```ts
+number.getCallingCode(); // '1'
+```
+
+### getNationalNumber
+
+The national significant number: digits only, with the national prefix stripped.
+
+```ts
+number.getNationalNumber(); // '4155550132'
+```
+
+### getNumberType
+
+The line type, such as `MOBILE` or `FIXED_LINE`. `UNKNOWN` when the number is not valid or the type
+is ambiguous. The full value list is [`NUMBER_TYPES`](/core/reference/region-data/#number_types).
+
+```ts
+number.getNumberType(); // 'FIXED_LINE_OR_MOBILE'
+parsePhoneNumber('+1 800 234 5678').getNumberType(); // 'TOLL_FREE'
+```
+
+## Formats
+
+Each format method returns `null` when the number is not valid:
+
+```ts
+parsePhoneNumber('+1 415').formatE164(); // null
+```
+
+### formatE164
+
+```ts
+number.formatE164(); // '+14155550132'
+```
+
+### formatNational
+
+```ts
+number.formatNational(); // '(415) 555-0132'
+```
+
+### formatInternational
+
+```ts
+number.formatInternational(); // '+1 415-555-0132'
+```
+
+### formatRfc3966
+
+```ts
+number.formatRfc3966(); // 'tel:+1-415-555-0132'
+```
+
+## Conformance
+
+Twelve of the thirteen methods have a libphonenumber counterpart, each compared with Google's
+implementation on every corpus input. `getValidationError` is Telixon's own surface, with no
+counterpart to compare. The numbers, the method, and the cadence are on
+[Verified](/verified/#conformance).

--- a/apps/docs/src/content/docs/core/reference/region-data.mdx
+++ b/apps/docs/src/content/docs/core/reference/region-data.mdx
@@ -1,0 +1,107 @@
+---
+title: Region data
+description: REGION_CODES, NUMBER_TYPES, and the four region query functions.
+---
+
+Static data and lookups about regions and number types: the building blocks for region dropdowns,
+placeholders, and input constraints.
+
+## REGION_CODES
+
+```ts
+const REGION_CODES: readonly RegionCode[];
+```
+
+Every region the engine knows, in alphabetical order. The current engine ships 245 regions.
+
+```ts
+REGION_CODES.slice(0, 3); // ['AC', 'AD', 'AE']
+REGION_CODES.includes('US'); // true
+```
+
+`RegionCode` is the union of exactly these codes, so a plain string needs narrowing before it is
+one:
+
+```ts
+function isRegionCode(value: string): value is RegionCode {
+  return (REGION_CODES as readonly string[]).includes(value);
+}
+```
+
+## NUMBER_TYPES
+
+```ts
+const NUMBER_TYPES: readonly NumberType[];
+```
+
+Every `NumberType` value, in a stable order:
+
+```ts
+NUMBER_TYPES;
+// ['FIXED_LINE', 'MOBILE', 'FIXED_LINE_OR_MOBILE', 'TOLL_FREE', 'PREMIUM_RATE', 'SHARED_COST',
+//  'VOIP', 'PERSONAL_NUMBER', 'PAGER', 'UAN', 'VOICEMAIL', 'UNKNOWN']
+```
+
+## getCallingCodeForRegion
+
+```ts
+function getCallingCodeForRegion(region: RegionCode): string;
+```
+
+The country calling code `region` dials under, without the `+`, or `'0'` for a region the engine
+does not know. Mirrors libphonenumber's `getCountryCodeForRegion`.
+
+```ts
+getCallingCodeForRegion('US'); // '1'
+getCallingCodeForRegion('AC'); // '247'
+```
+
+## getPlaceholders
+
+```ts
+function getPlaceholders(region: RegionCode, type: NumberType): Placeholders | null;
+```
+
+A region's example number for one type, in each format a field might use. It returns `null` when
+the region has no example for that type.
+
+```ts
+getPlaceholders('US', 'FIXED_LINE');
+// { national: '(201) 555-0123', nationalWithPrefix: '1 (201) 555-0123', international: '201-555-0123' }
+```
+
+### Placeholders
+
+| Field                | Meaning                                                         |
+| -------------------- | --------------------------------------------------------------- |
+| `national`           | National format, without the national (trunk) prefix            |
+| `nationalWithPrefix` | National format, with the national (trunk) prefix               |
+| `international`      | International format: the digits after `+` and the calling code |
+
+Each field is absent when the region has no such form.
+
+## isNationalPrefixOptional
+
+```ts
+function isNationalPrefixOptional(region: RegionCode, type: NumberType): boolean;
+```
+
+Whether a `(region, type)` number can be written without its national (trunk) prefix.
+
+```ts
+isNationalPrefixOptional('US', 'FIXED_LINE'); // true
+```
+
+## regionSupportsNumberTypes
+
+```ts
+function regionSupportsNumberTypes(region: RegionCode, types: readonly NumberType[]): boolean;
+```
+
+Whether `region` supports at least one of `types`. `FIXED_LINE_OR_MOBILE` matches either side;
+`UNKNOWN` and an empty list match nothing.
+
+```ts
+regionSupportsNumberTypes('US', ['MOBILE']); // true
+regionSupportsNumberTypes('US', ['PAGER']); // false
+```

--- a/apps/docs/src/content/docs/core/reference/validation-error.mdx
+++ b/apps/docs/src/content/docs/core/reference/validation-error.mdx
@@ -1,0 +1,55 @@
+---
+title: ValidationError
+description: The eight-variant discriminated union returned by getValidationError.
+---
+
+```ts
+type ValidationError =
+  | { kind: 'EMPTY' }
+  | { kind: 'INVALID_CALLING_CODE' }
+  | { kind: 'TOO_SHORT'; minLength: number }
+  | { kind: 'TOO_LONG'; maxLength: number }
+  | { kind: 'INVALID_LENGTH'; possibleLengths: readonly number[] }
+  | { kind: 'POSSIBLE_LOCAL_ONLY' }
+  | { kind: 'PATTERN_MISMATCH' }
+  | { kind: 'NATIONAL_PREFIX_MISSING'; expectedPrefix: string };
+```
+
+Why a number is not valid. Returned by
+[`getValidationError`](/core/reference/phone-number/#getvalidationerror), which is `null` when the
+number is valid. The union is discriminated on `kind`, so a `switch` over it is exhaustive. When a
+variant is added, every `switch` that misses it stops compiling. The kinds mirror libphonenumber
+where applicable.
+
+## Variants
+
+Every row is a real input and its real result.
+
+| Input                                    | `getValidationError()`                                     | Meaning                                             |
+| ---------------------------------------- | ---------------------------------------------------------- | --------------------------------------------------- |
+| `''`                                     | `{ kind: 'EMPTY' }`                                        | No digits to resolve                                |
+| `'+999 123'`                             | `{ kind: 'INVALID_CALLING_CODE' }`                         | The digits begin with no known country calling code |
+| `'+1 21'`                                | `{ kind: 'TOO_SHORT', minLength: 10 }`                     | Fewer digits than the region's shortest number      |
+| `'+1 21255512345678'`                    | `{ kind: 'TOO_LONG', maxLength: 10 }`                      | More digits than the region's longest number        |
+| `'+57 321 123 456'`                      | `{ kind: 'INVALID_LENGTH', possibleLengths: [8, 10, 11] }` | The length falls in a gap between valid lengths     |
+| `'5550132'` with `defaultRegion: 'US'`   | `{ kind: 'POSSIBLE_LOCAL_ONLY' }`                          | Valid only when dialled inside its own area         |
+| `'+1 1234567890'`                        | `{ kind: 'PATTERN_MISMATCH' }`                             | The length is valid and the digits match no number  |
+| `'501234567'` with `defaultRegion: 'AE'` | `{ kind: 'NATIONAL_PREFIX_MISSING', expectedPrefix: '0' }` | A required national (trunk) prefix was missing      |
+
+## Carried data
+
+The four data-carrying variants name what would fix the input:
+
+```ts
+parsePhoneNumber('+1 21').getValidationError();
+// { kind: 'TOO_SHORT', minLength: 10 }
+
+parsePhoneNumber('+1 21255512345678').getValidationError();
+// { kind: 'TOO_LONG', maxLength: 10 }
+
+parsePhoneNumber('+57 321 123 456').getValidationError();
+// { kind: 'INVALID_LENGTH', possibleLengths: [8, 10, 11] }
+
+parsePhoneNumber('501234567', { defaultRegion: 'AE' }).getValidationError();
+// { kind: 'NATIONAL_PREFIX_MISSING', expectedPrefix: '0' }
+```

--- a/apps/docs/src/content/docs/verified.mdx
+++ b/apps/docs/src/content/docs/verified.mdx
@@ -1,0 +1,56 @@
+---
+title: Verified
+description: Conformance, performance, and size, each measured on every push and reproducible.
+---
+
+Telixon measures three properties on every push: conformance with Google libphonenumber,
+performance, and payload size. Each section names the method and the command that reproduces it.
+
+## Conformance
+
+Every query method is compared with Google libphonenumber. The oracle is version-matched: it runs
+Google's own JavaScript source at the exact commit the engine's metadata was built from, so a
+mismatch is a real difference and never version drift.
+
+Three gates cover it: the full corpus, one number from every distinct case the library can
+produce, and a one-million-input sample. The current run stands at 315,988 comparisons with
+zero divergences: twelve methods, each matching on 11,232 of 11,232 corpus inputs, across all 245
+regions. `isValidForRegion` is set-compared per case, 692,672 region checks. The allowlist of
+accepted divergences is empty.
+
+Weekly, the airtight proof enumerates the complete geographic input domain: 1,838,775,900 inputs,
+split across ten shards.
+
+```sh
+pnpm conformance
+```
+
+The [parity dashboard](https://proof.telixon.dev/parity.html) publishes every run.
+
+## Performance
+
+The benchmark measures parsing and query throughput, cold and warm, plus per-keystroke controller
+latency. The comparison baseline is the google-libphonenumber npm package, a third-party wrapper
+of Google's port. Wall-time numbers depend on hardware, so this page quotes none.
+CodSpeed tracks instrumented regressions.
+
+```sh
+pnpm bench
+```
+
+The [benchmark dashboard](https://proof.telixon.dev/benchmark.html) publishes each run.
+
+## Size
+
+`size-limit` gates the entry sizes. The engine tables ship outside the entries. The
+async builds load them on demand; the sync entry embeds them.
+
+| Artifact                        | Measured        | Budget |
+| ------------------------------- | --------------- | ------ |
+| `@telixon/core` Node entry      | 18.79 kB brotli | 22 kB  |
+| `@telixon/core` browser entry   | 21.34 kB brotli | 22 kB  |
+| Engine tables, loaded on demand | 123 kB gzip     | none   |
+
+```sh
+pnpm size
+```

--- a/apps/docs/src/package-registry.ts
+++ b/apps/docs/src/package-registry.ts
@@ -6,6 +6,9 @@
 // in a version subfolder, registered via a future `archivedMajors` field. Sidebar groups must not
 // autogenerate from a package root, or they would swallow version subfolders.
 
+/** One sidebar entry: a page slug, or a labeled group of page slugs. */
+export type SidebarEntry = string | { readonly label: string; readonly items: readonly string[] };
+
 export interface DocsPackage {
   /** npm package name; doubles as the sidebar group label, matched exactly by the switcher. */
   readonly name: string;
@@ -13,12 +16,42 @@ export interface DocsPackage {
   readonly label: string;
   /** URL base of the package's docs tree; absent while the package is planned and has no docs. */
   readonly base?: string;
+  /** The package's sidebar: page slugs or labeled groups of slugs; a single root page when absent. */
+  readonly sidebar?: readonly SidebarEntry[];
   /** Official framework mark for planned rows; available rows use the gem. */
   readonly logo?: 'angular' | 'react' | 'vue' | 'stencil';
 }
 
 export const PACKAGES: readonly DocsPackage[] = [
-  { base: 'core', name: '@telixon/core', label: 'Core' },
+  {
+    base: 'core',
+    name: '@telixon/core',
+    label: 'Core',
+    sidebar: [
+      'core',
+      'core/how-it-works',
+      'core/load-the-engine',
+      {
+        label: 'Guides',
+        items: [
+          'core/guides/validate-user-input',
+          'core/guides/build-a-phone-input',
+          'core/guides/build-a-region-selector',
+        ],
+      },
+      {
+        label: 'Reference',
+        items: [
+          'core/reference/parse-phone-number',
+          'core/reference/phone-number',
+          'core/reference/validation-error',
+          'core/reference/input-controller',
+          'core/reference/region-data',
+        ],
+      },
+      'verified',
+    ],
+  },
   { base: 'web-sdk', name: '@telixon/web-sdk', label: 'Web SDK' },
   { name: '@telixon/web-anatomy', label: 'Web Anatomy' },
   { name: '@telixon/web-theme', label: 'Web Theme' },

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -8,7 +8,7 @@ export * from './index';
 const loader = new LazyResourceLoader(decodeLayerStream);
 
 /**
- * Loads the engine. Call it once before the first API call: it is idempotent, and nothing loads at
+ * Loads the engine. Call it once before the first API call: it is idempotent. Nothing loads at
  * import time. API calls made before it resolves throw {@link EngineNotReadyError}.
  *
  * @example

--- a/packages/core/src/index.edge.ts
+++ b/packages/core/src/index.edge.ts
@@ -8,7 +8,7 @@ export * from './index';
 const loader = new LazyResourceLoader(decodeLayerStream);
 
 /**
- * Loads the engine. Call it once before the first API call: it is idempotent, and nothing loads at
+ * Loads the engine. Call it once before the first API call: it is idempotent. Nothing loads at
  * import time. API calls made before it resolves throw {@link EngineNotReadyError}.
  *
  * @example

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -8,7 +8,7 @@ export * from './index';
 const loader = new LazyResourceLoader(decodeLayerNativeAsync);
 
 /**
- * Loads the engine. Call it once before the first API call: it is idempotent, and nothing loads at
+ * Loads the engine. Call it once before the first API call: it is idempotent. Nothing loads at
  * import time. API calls made before it resolves throw {@link EngineNotReadyError}.
  *
  * @example

--- a/packages/core/src/modules/calling-code-for-region/__tests__/get-calling-code-for-region.test.ts
+++ b/packages/core/src/modules/calling-code-for-region/__tests__/get-calling-code-for-region.test.ts
@@ -24,7 +24,7 @@ describe('getCallingCodeForRegion', () => {
   });
 
   it("returns '0' for an unknown region (Google getCountryCodeForRegion parity)", () => {
-    // 'ZZ' is Google's unknown-region code, not a supported RegionCode; cast to exercise the guard.
+    // 'ZZ' is Google's unknown-region code, outside the RegionCode union; cast to exercise the guard.
     expect(getCallingCodeForRegion('ZZ' as unknown as RegionCode)).toBe('0');
   });
 });

--- a/packages/core/src/modules/input-controller/international-input-controller/__tests__/delete-operations.test.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/__tests__/delete-operations.test.ts
@@ -47,7 +47,7 @@ describe('InternationalInputController.deleteBackward', () => {
     const state = controller.deleteBackward('+1 ', 1, 1);
 
     expect(state.value).toBe('+1 ');
-    // Caret stays anchored on the "+" side instead of snapping to position 0.
+    // Caret stays anchored on the "+" side, never snapping to position 0.
     expect(state.selectionStart).toBe(1);
     expect(state.selectionEnd).toBe(1);
   });

--- a/packages/core/src/modules/input-controller/international-input-controller/__tests__/international-input-controller.test.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/__tests__/international-input-controller.test.ts
@@ -133,7 +133,7 @@ describe('InternationalInputController region resolution', () => {
     expect(state.region).toBe('AG');
   });
 
-  // setRegion only updates the default-region anchor, not the input; region still derives from the current digits.
+  // setRegion only updates the default-region anchor; the region still derives from the current digits.
   it('setRegion keeps current value and region when digits still resolve elsewhere', () => {
     const controller = createInternationalInputController({ defaultRegion: 'US' });
     const state = controller.setRegion('GB');

--- a/packages/core/src/modules/input-controller/international-input-controller/international-input-controller.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/international-input-controller.ts
@@ -384,7 +384,7 @@ class InternationalInputController implements InputController {
 }
 
 /**
- * Creates a headless {@link InputController} that resolves the region from the value. The calling
+ * Creates an {@link InputController} that resolves the region from the value. The calling
  * code lives in the field unless `display.callingCodeInInput` is `false`, which requires
  * `defaultRegion`.
  *

--- a/packages/core/src/modules/input-controller/international-input-controller/utils/resolve-international-controller-state.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/utils/resolve-international-controller-state.ts
@@ -73,7 +73,7 @@ export function resolveInternationalControllerState(
     }
 
     if (snapshot.strict) {
-      // Strict never leaves the preferred region: report it, not the digit-resolved region (NANP shares a calling code).
+      // Strict never leaves the preferred region: report it even when the digits resolve elsewhere (NANP shares a calling code).
       region = resourceProvider.regionIds[regionIndex] ?? null;
     } else {
       region = resolveRegionCodeOrFallback(

--- a/packages/core/src/modules/input-controller/models/index.ts
+++ b/packages/core/src/modules/input-controller/models/index.ts
@@ -6,7 +6,7 @@ import { PhoneNumber } from '../../phone-number/models';
 export interface InputState {
   /** The formatted string to place in the field. */
   readonly value: string;
-  /** The region the value resolves to (a national controller's own region counts), or `null` when none does. */
+  /** The region the value resolves to, or `null` when none does. */
   readonly region: RegionCode | null;
   /** Caret start, as an index into `value`. */
   readonly selectionStart: number;
@@ -31,10 +31,8 @@ export interface InputChange {
 export type CaretIndex = number;
 
 /**
- * A headless controller for a phone-number field. Every edit takes the current value and caret and
- * returns the next {@link InputState} to write back, reformatted and recorded in history. Holds the
- * region, filters, and history; never touches the DOM. Bind it to an `<input>` yourself, or let
- * `@telixon/web-sdk` do it.
+ * A state controller for a phone-number field. Every state-changing call returns the next
+ * {@link InputState} to write back. Holds the region, the filters, and the history.
  */
 export interface InputController {
   /** Replaces the selection from `selectionStart` to `selectionEnd` in `value` with `text`, then reformats. */

--- a/packages/core/src/modules/input-controller/national-input-controller/national-input-controller.ts
+++ b/packages/core/src/modules/input-controller/national-input-controller/national-input-controller.ts
@@ -332,7 +332,7 @@ class NationalInputController implements InputController {
 }
 
 /**
- * Creates a headless {@link InputController} for one region's national format. The calling code
+ * Creates an {@link InputController} for one region's national format. The calling code
  * never appears in the field.
  *
  * @example

--- a/packages/core/src/modules/input-controller/national-input-controller/utils/resolve-national-controller-state.ts
+++ b/packages/core/src/modules/input-controller/national-input-controller/utils/resolve-national-controller-state.ts
@@ -43,7 +43,7 @@ export function resolveNationalControllerState(
     const formatRef = resolveFormatFromProfile(profile, displayDigits);
 
     if (snapshot.strict) {
-      // Strict never leaves the preferred region: report it, not the digit-resolved region (NANP shares a calling code).
+      // Strict never leaves the preferred region: report it even when the digits resolve elsewhere (NANP shares a calling code).
       region = resourceProvider.regionIds[regionIndex] ?? null;
     } else {
       // No specific region (possible but not valid): fall back to the calling code's primary region.

--- a/packages/core/src/modules/number-resolver/__tests__/resolve-profile.test.ts
+++ b/packages/core/src/modules/number-resolver/__tests__/resolve-profile.test.ts
@@ -167,7 +167,7 @@ describe('priority chain: non-strict', () => {
 
       const profile = resolveProfileRef(resolver.snapshot, getResourceProvider().regionKeyToIndex['US']!);
 
-      // Recovery reads the terminal-prefix history, not a live DFA state; with US preferred the NANP anchor resolves to US.
+      // Recovery reads the terminal-prefix history; no live DFA state is consulted. With US preferred the NANP anchor resolves to US.
       expect(profile).not.toBeNull();
       expect(getProfileRegion(profile!)).toBe('US');
     });

--- a/packages/core/src/modules/number-resolver/resolve-number.ts
+++ b/packages/core/src/modules/number-resolver/resolve-number.ts
@@ -46,7 +46,7 @@ function collectDigits(input: string): string {
 }
 
 // libphonenumber maybeStripInternationalPrefixAndNormalize: strip a leading IDD prefix and re-parse the
-// remainder. Not an IDD when the next digit is '0' (a national trunk digit, not a code).
+// remainder. Not an IDD when the next digit is '0', the national trunk digit.
 function stripIddPrefix(digits: string, matcher: RegExp): string | null {
   const match: RegExpExecArray | null = matcher.exec(digits);
   if (match === null || match[0].length === 0) return null;
@@ -100,7 +100,7 @@ export function resolveNumber(params: ResolveNumberInput): ResolvedNumberState {
   resolver.setStrict(strict);
 
   // True once a redundant leading calling code is dropped: from then on the number behaves as if dialled
-  // through that calling code, so the strip below uses its main region instead of the default region.
+  // through that calling code, so the strip below prefers its main region over the default region.
   let leadingCallingCodeStripped = false;
   if (readAsNational) {
     const callingCode: string = String(getMetadataRegionCallingCode(resourceProvider.engine, defaultRegionIndex));

--- a/packages/core/src/modules/parse-phone-number/__tests__/selection.test.ts
+++ b/packages/core/src/modules/parse-phone-number/__tests__/selection.test.ts
@@ -2,7 +2,7 @@ import { getExampleNumber } from '@telixon/core/testing';
 import { describe, expect, it } from 'vitest';
 import { parsePhoneNumber } from '../parse-phone-number';
 
-// NANP (+1) shares one calling code across the US, Canada, and the Caribbean, so the region is decided by the number, not defaultRegion.
+// NANP (+1) shares one calling code across the US, Canada, and the Caribbean, so the number itself decides the region.
 const US_MOBILE = getExampleNumber('US', 'MOBILE');
 const CA_FIXED = getExampleNumber('CA', 'FIXED_LINE');
 const BS_FIXED = getExampleNumber('BS', 'FIXED_LINE');

--- a/packages/core/src/modules/phone-number/models/index.ts
+++ b/packages/core/src/modules/phone-number/models/index.ts
@@ -29,7 +29,7 @@ export type ValidationError =
   | { readonly kind: 'TOO_LONG'; readonly maxLength: number }
   /** The length falls in a gap between valid lengths. `possibleLengths` lists the lengths that exist. */
   | { readonly kind: 'INVALID_LENGTH'; readonly possibleLengths: readonly number[] }
-  /** Valid only for dialling inside its own area, not as a full number. */
+  /** Valid only when dialled inside its own area. */
   | { readonly kind: 'POSSIBLE_LOCAL_ONLY' }
   /** The length is valid but the digits match no number that exists in the region. */
   | { readonly kind: 'PATTERN_MISMATCH' }
@@ -50,7 +50,7 @@ export interface ResolvedPhoneNumber {
 }
 
 /**
- * A parsed number: query its validity, region, and type, and format it. Returned by
+ * A parsed number: query its validity, region, and type; format it four ways. Returned by
  * {@link parsePhoneNumber} and by a controller's `getPhoneNumber`.
  */
 export interface PhoneNumber {
@@ -59,8 +59,8 @@ export interface PhoneNumber {
   /** Whether the number is valid for `region` specifically. Mirrors libphonenumber's isValidNumberForRegion. */
   isValidForRegion(region: RegionCode): boolean;
   /**
-   * Whether the calling code resolves and the length is one the region dials. Unlike
-   * {@link PhoneNumber.isValid}, the number itself is not checked.
+   * Whether the calling code resolves and the length is one the region dials. The digits
+   * themselves go unchecked, so a possible number can still be invalid.
    */
   isPossible(): boolean;
   /** The possibility check as a reason code, so a failed {@link PhoneNumber.isPossible} says why. */

--- a/packages/core/src/modules/phone-number/query/__tests__/get-validation-error.test.ts
+++ b/packages/core/src/modules/phone-number/query/__tests__/get-validation-error.test.ts
@@ -34,7 +34,7 @@ describe('PhoneNumber.getValidationError', () => {
   });
 
   it('returns INVALID_LENGTH when the length falls in a gap between valid lengths', () => {
-    // Colombia has 8-, 10-, and 11-digit national numbers; 9 digits is a gap.
+    // Colombia has national numbers of 8, 10, and 11 digits; 9 digits is a gap.
     const error = parsePhoneNumber('321123456', { defaultRegion: 'CO' }).getValidationError();
     expect(error).toEqual({ kind: 'INVALID_LENGTH', possibleLengths: [8, 10, 11] });
   });

--- a/packages/core/src/modules/phone-number/query/get-validation-error.ts
+++ b/packages/core/src/modules/phone-number/query/get-validation-error.ts
@@ -40,7 +40,7 @@ export function getValidationError(
   if (reason === 'TOO_LONG') return { kind: 'TOO_LONG', maxLength: getMaxLength(nationalMask) };
   if (reason === 'INVALID_LENGTH') return { kind: 'INVALID_LENGTH', possibleLengths: getPossibleLengths(nationalMask) };
 
-  // Possible only for local dialing (e.g. a subscriber number without its area code): incomplete, not a pattern fault.
+  // Possible only for local dialing (e.g. a subscriber number without its area code): an incompleteness case, distinct from a pattern fault.
   if (reason === 'IS_POSSIBLE_LOCAL_ONLY') return { kind: 'POSSIBLE_LOCAL_ONLY' };
 
   if (!valid) return { kind: 'PATTERN_MISMATCH' };

--- a/packages/core/src/resource-loader/decode-layer-pure.ts
+++ b/packages/core/src/resource-loader/decode-layer-pure.ts
@@ -1,7 +1,7 @@
 import { decodeBase64 } from '../utils/decode-base64';
 import { gunzipSync } from '../utils/gunzip';
 
-// Universal sync decode: pure-JS base64 + gunzip, runs in any runtime. The floor where neither node:zlib nor a sync DecompressionStream exists (such as edge global scope), and the default for EmbeddedResourceLoader.
+// Universal sync decode: pure-JS base64 + gunzip, runs in any runtime. The floor where neither node:zlib nor a sync DecompressionStream exists (such as edge global scope). Also the default for EmbeddedResourceLoader.
 export function decodeLayerPure(base64: string): ArrayBuffer {
   return gunzipSync(decodeBase64(base64)).buffer;
 }

--- a/packages/core/src/resource-provider/models/index.ts
+++ b/packages/core/src/resource-provider/models/index.ts
@@ -19,7 +19,7 @@ export abstract class ResourceProvider {
   // Region index to calling-code index (per-keystroke formatting path).
   abstract callingCodeIndexByRegion: Int16Array;
   abstract numberTypeNames: readonly MetadataNumberType[];
-  // 1 = the region declares leadingDigits (region disambiguation by prefix instead of by type).
+  // 1 = the region declares leadingDigits (region disambiguation by prefix).
   abstract regionHasLeadingDigits: Uint8Array;
   abstract placeholders: MetadataPlaceholders;
 


### PR DESCRIPTION
## Summary

Adds the full `/core` documentation: Getting started, How Telixon works, Load the engine, three
scenario guides, five reference pages, and the top-level Verified page. Every example was executed
against the real build; the field-wiring snippets were exercised in a real Chromium. Core JSDoc is
aligned with the same framing and style; that diff is comment-only.

## Motivation

The site had a single stub page for core. Every public symbol now has one documented home, with
each fact stated once and linked everywhere else.

## Conformance impact

None. Engine and query methods are untouched; the core diff is docstrings and comments.

## Checklist

- [x] Tests added or updated (or a rationale for why none). Docs and comments only; every example verified by execution.
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention