### PR TITLE
fix(core): keep PhoneNumber queries coherent under selector mode and …

### DIFF
--- a/apps/docs/src/content/docs/core/guides/build-a-region-selector.mdx
+++ b/apps/docs/src/content/docs/core/guides/build-a-region-selector.mdx
@@ -65,7 +65,7 @@ field.insert('', '6045550132', 0, 0);
 field.getPhoneNumber().formatE164(); // '+16045550132'
 ```
 
-The field shows national digits. The selected region supplies the calling code.
+The field shows the digits after the calling code. The selected region supplies that code.
 
 ## Pin the field to the selection
 
@@ -76,3 +76,5 @@ dropdown's choice. Digits from any other region stop validating:
 field.setRegionFilter(['CA']);
 field.getPhoneNumber().isValid(); // true
 ```
+
+The full member list is in the [`InputController` reference](/core/reference/input-controller/).

--- a/apps/docs/src/content/docs/core/guides/validate-user-input.mdx
+++ b/apps/docs/src/content/docs/core/guides/validate-user-input.mdx
@@ -62,6 +62,8 @@ function describe(error: ValidationError): string {
       return 'The length is right, but no number with these digits exists in this region.';
     case 'NATIONAL_PREFIX_MISSING':
       return `Start the number with ${error.expectedPrefix}.`;
+    case 'NATIONAL_PREFIX_PRESENT':
+      return `Drop the leading ${error.prefix}.`;
   }
 }
 

--- a/apps/docs/src/content/docs/core/how-it-works.mdx
+++ b/apps/docs/src/content/docs/core/how-it-works.mdx
@@ -32,7 +32,7 @@ parsePhoneNumber('5550132', { defaultRegion: 'US' }).getValidationError();
 ```
 
 Seven digits form a US number that connects only inside its own area. The walk ends on a state that
-records exactly that. The eight variants are in
+records exactly that. The nine variants are in
 [`ValidationError`](/core/reference/validation-error/).
 
 ## Parser and controller consistency

--- a/apps/docs/src/content/docs/core/index.mdx
+++ b/apps/docs/src/content/docs/core/index.mdx
@@ -94,7 +94,7 @@ wrongLength.getValidationError(); // { kind: 'INVALID_LENGTH', possibleLengths: 
 Colombia dials numbers of 8, 10, and 11 digits. Nine digits falls in a gap. The error carries the
 lengths that exist.
 
-[`ValidationError`](/core/reference/validation-error/) lists all eight variants.
+[`ValidationError`](/core/reference/validation-error/) lists all nine variants.
 [Validate user input](/core/guides/validate-user-input/) turns them into messages.
 
 ## Drive an input

--- a/apps/docs/src/content/docs/core/reference/input-controller.mdx
+++ b/apps/docs/src/content/docs/core/reference/input-controller.mdx
@@ -56,11 +56,11 @@ code is in the field, `defaultRegion` pre-fills the field with that region's cod
 
 `display`, an `InternationalDisplayConfig`, places the calling code:
 
-| `display`                                  | The field holds                                                                      |
-| ------------------------------------------ | ------------------------------------------------------------------------------------ |
-| omitted                                    | Calling-code digits, with no `+` rendered                                            |
-| `{ callingCodeInInput: true, plusPrefix }` | Calling-code digits, with the `+` under `plusPrefix`                                 |
-| `{ callingCodeInInput: false }`            | National digits; the region comes from `defaultRegion` and [`setRegion`](#setregion) |
+| `display`                                  | The field holds                                                                                           |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| omitted                                    | Calling-code digits, with no `+` rendered                                                                 |
+| `{ callingCodeInInput: true, plusPrefix }` | Calling-code digits, with the `+` under `plusPrefix`                                                      |
+| `{ callingCodeInInput: false }`            | The international significant number; the region comes from `defaultRegion` and [`setRegion`](#setregion) |
 
 `plusPrefix`, a `PlusPrefixMode`, renders the leading `+`: `'none'` never, `'fixed'` always,
 `'erasable'` while the value carries one. Under `'erasable'`, backspace at the start removes it.
@@ -132,8 +132,8 @@ setRegion(region: RegionCode): InputState;
 ```
 
 Switches to `region` and reformats the current digits the way that region writes them. Where the
-calling code lives in the field, the digits keep deciding the region. Where the field holds
-national digits only, the switch applies.
+calling code lives in the field, the digits keep deciding the region. Where the field holds the
+international significant number, the switch applies.
 
 ### setRegionFilter
 
@@ -141,7 +141,10 @@ national digits only, the switch applies.
 setRegionFilter(regions: readonly RegionCode[] | null): InputState;
 ```
 
-Restricts which regions the value may resolve to, or `null` to allow all.
+Restricts which regions the value may resolve to, or `null` to allow all. Every
+[`PhoneNumber`](/core/reference/phone-number/) query answers within the allowed set. A filter that
+excludes every region of the value's calling code reports
+[`INVALID_CALLING_CODE`](/core/reference/validation-error/).
 
 ### setNumberTypeFilter
 
@@ -149,7 +152,9 @@ Restricts which regions the value may resolve to, or `null` to allow all.
 setNumberTypeFilter(numberTypes: readonly NumberType[] | null): InputState;
 ```
 
-Restricts which number types the value may resolve to, or `null` to allow all.
+Restricts which number types the value may resolve to, or `null` to allow all. A filter that
+leaves no possible length for the value's calling code reports
+[`INVALID_CALLING_CODE`](/core/reference/validation-error/).
 
 ## History
 
@@ -208,7 +213,10 @@ getPhoneNumber(): PhoneNumber;
 ```
 
 The current value as a [`PhoneNumber`](/core/reference/phone-number/) to query, equal to
-`parsePhoneNumber` of the displayed value.
+`parsePhoneNumber` of the displayed value. With the calling code kept out of the field
+(`callingCodeInInput: false`), the digits resolve literally as the international significant
+number behind the selected region's calling code. A typed national (trunk) prefix there reports
+[`NATIONAL_PREFIX_PRESENT`](/core/reference/validation-error/).
 
 ### currentState
 

--- a/apps/docs/src/content/docs/core/reference/phone-number.mdx
+++ b/apps/docs/src/content/docs/core/reference/phone-number.mdx
@@ -55,7 +55,7 @@ parsePhoneNumber('+1 415').isPossibleWithReason(); // 'TOO_SHORT'
 
 ### getValidationError
 
-Why the number is not valid, or `null` when it is. One of the eight typed
+The fault to correct, or `null` when none applies. One of the nine typed
 [`ValidationError`](/core/reference/validation-error/) variants.
 
 ```ts
@@ -114,7 +114,7 @@ parsePhoneNumber('+1 800 234 5678').getNumberType(); // 'TOLL_FREE'
 
 ## Formats
 
-Each format method returns `null` when the number is not valid:
+Each format method returns `null` when the number is not possible:
 
 ```ts
 parsePhoneNumber('+1 415').formatE164(); // null

--- a/apps/docs/src/content/docs/core/reference/validation-error.mdx
+++ b/apps/docs/src/content/docs/core/reference/validation-error.mdx
@@ -1,6 +1,6 @@
 ---
 title: ValidationError
-description: The eight-variant discriminated union returned by getValidationError.
+description: The nine-variant discriminated union returned by getValidationError.
 ---
 
 ```ts
@@ -12,12 +12,13 @@ type ValidationError =
   | { kind: 'INVALID_LENGTH'; possibleLengths: readonly number[] }
   | { kind: 'POSSIBLE_LOCAL_ONLY' }
   | { kind: 'PATTERN_MISMATCH' }
-  | { kind: 'NATIONAL_PREFIX_MISSING'; expectedPrefix: string };
+  | { kind: 'NATIONAL_PREFIX_MISSING'; expectedPrefix: string }
+  | { kind: 'NATIONAL_PREFIX_PRESENT'; prefix: string };
 ```
 
-Why a number is not valid. Returned by
-[`getValidationError`](/core/reference/phone-number/#getvalidationerror), which is `null` when the
-number is valid. The union is discriminated on `kind`, so a `switch` over it is exhaustive. When a
+The fault to correct in the input. Returned by
+[`getValidationError`](/core/reference/phone-number/#getvalidationerror), which is `null` when
+none applies. The union is discriminated on `kind`, so a `switch` over it is exhaustive. When a
 variant is added, every `switch` that misses it stops compiling. The kinds mirror libphonenumber
 where applicable.
 
@@ -25,20 +26,27 @@ where applicable.
 
 Every row is a real input and its real result.
 
-| Input                                    | `getValidationError()`                                     | Meaning                                             |
-| ---------------------------------------- | ---------------------------------------------------------- | --------------------------------------------------- |
-| `''`                                     | `{ kind: 'EMPTY' }`                                        | No digits to resolve                                |
-| `'+999 123'`                             | `{ kind: 'INVALID_CALLING_CODE' }`                         | The digits begin with no known country calling code |
-| `'+1 21'`                                | `{ kind: 'TOO_SHORT', minLength: 10 }`                     | Fewer digits than the region's shortest number      |
-| `'+1 21255512345678'`                    | `{ kind: 'TOO_LONG', maxLength: 10 }`                      | More digits than the region's longest number        |
-| `'+57 321 123 456'`                      | `{ kind: 'INVALID_LENGTH', possibleLengths: [8, 10, 11] }` | The length falls in a gap between valid lengths     |
-| `'5550132'` with `defaultRegion: 'US'`   | `{ kind: 'POSSIBLE_LOCAL_ONLY' }`                          | Valid only when dialled inside its own area         |
-| `'+1 1234567890'`                        | `{ kind: 'PATTERN_MISMATCH' }`                             | The length is valid and the digits match no number  |
-| `'501234567'` with `defaultRegion: 'AE'` | `{ kind: 'NATIONAL_PREFIX_MISSING', expectedPrefix: '0' }` | A required national (trunk) prefix was missing      |
+| Input                                                         | `getValidationError()`                                     | Meaning                                                       |
+| ------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------- |
+| `''`                                                          | `{ kind: 'EMPTY' }`                                        | No digits to resolve                                          |
+| `'+999 123'`                                                  | `{ kind: 'INVALID_CALLING_CODE' }`                         | The digits begin with no known country calling code           |
+| `'+1 21'`                                                     | `{ kind: 'TOO_SHORT', minLength: 10 }`                     | Fewer digits than the region's shortest number                |
+| `'+1 21255512345678'`                                         | `{ kind: 'TOO_LONG', maxLength: 10 }`                      | More digits than the region's longest number                  |
+| `'+57 321 123 456'`                                           | `{ kind: 'INVALID_LENGTH', possibleLengths: [8, 10, 11] }` | The length falls in a gap between valid lengths               |
+| `'5550132'` with `defaultRegion: 'US'`                        | `{ kind: 'POSSIBLE_LOCAL_ONLY' }`                          | Valid only when dialled inside its own area                   |
+| `'+1 1234567890'`                                             | `{ kind: 'PATTERN_MISMATCH' }`                             | The length is valid and the digits match no number            |
+| `'501234567'` with `defaultRegion: 'AE'`                      | `{ kind: 'NATIONAL_PREFIX_MISSING', expectedPrefix: '0' }` | A required national (trunk) prefix was missing                |
+| `'0501234567'` in an `AE` field with the calling code outside | `{ kind: 'NATIONAL_PREFIX_PRESENT', prefix: '0' }`         | The trunk prefix was typed where international input omits it |
+
+`NATIONAL_PREFIX_PRESENT` comes only from a controller holding the calling code outside the field
+(`callingCodeInInput: false`), where the digits are the international significant number. It
+reports when the typed digits begin with national-dialing digits, the trunk prefix or a carrier
+code, that dropping would leave a valid number. `prefix` is the exact leading chunk to drop; a
+Belarusian number typed as `80 29…` reports `prefix: '80'`.
 
 ## Carried data
 
-The four data-carrying variants name what would fix the input:
+The five data-carrying variants name what would fix the input:
 
 ```ts
 parsePhoneNumber('+1 21').getValidationError();
@@ -52,4 +60,12 @@ parsePhoneNumber('+57 321 123 456').getValidationError();
 
 parsePhoneNumber('501234567', { defaultRegion: 'AE' }).getValidationError();
 // { kind: 'NATIONAL_PREFIX_MISSING', expectedPrefix: '0' }
+
+const field = createInternationalInputController({
+  defaultRegion: 'AE',
+  display: { callingCodeInInput: false },
+});
+field.setValue('0501234567');
+field.getPhoneNumber().getValidationError();
+// { kind: 'NATIONAL_PREFIX_PRESENT', prefix: '0' }
 ```

--- a/packages/core/conformance/controller-consistency.test.ts
+++ b/packages/core/conformance/controller-consistency.test.ts
@@ -1,6 +1,7 @@
 import {
   createInternationalInputController,
   createNationalInputController,
+  getCallingCodeForRegion,
   InputController,
   InputState,
   parsePhoneNumber,
@@ -27,6 +28,10 @@ function typeInto(controller: InputController, input: string): InputState {
   return state;
 }
 
+function collectDigits(value: string): string {
+  return value.replace(/\D/g, '');
+}
+
 function methods(phoneNumber: PhoneNumber): Record<string, string> {
   const values: Record<string, string> = {};
   for (const method of COMPARED_METHODS as readonly MethodName[]) {
@@ -50,6 +55,47 @@ describe('Input controllers resolve identically to parsePhoneNumber', () => {
       const options = number.region === undefined ? undefined : { defaultRegion: number.region };
 
       expect(methods(controller.getPhoneNumber())).toEqual(methods(parsePhoneNumber(state.value, options)));
+    }
+  }, 120_000);
+
+  // The literal selector read equals parsePhoneNumber of the calling code plus the displayed value;
+  // when parse leniency drops leading digits and rescues the number, it answers NATIONAL_PREFIX_PRESENT instead.
+  it('selector-mode getPhoneNumber holds the literal-read contract against parsePhoneNumber', () => {
+    const enumerator = createNumberEnumerator({ callingCodes, regions, minLength: 5, maxLength: 14 });
+    const count = 100_000;
+    for (let index = 0; index < count; index++) {
+      const number = enumerator.at(index);
+      if (number.region === undefined) continue;
+
+      const controller: InputController = createInternationalInputController({
+        defaultRegion: number.region,
+        display: { callingCodeInInput: false },
+      });
+
+      const state: InputState = typeInto(controller, number.input);
+      const literalDigits: string = collectDigits(state.value);
+      const callingCode: string = getCallingCodeForRegion(number.region);
+      const parsed: PhoneNumber = parsePhoneNumber(`+${callingCode}${state.value}`);
+      const literal: PhoneNumber = controller.getPhoneNumber();
+      const literalError = literal.getValidationError();
+
+      // The literal read never rewrites the typed digits.
+      expect(literal.getNationalNumber()).toBe(literalDigits);
+
+      // Soundness: the reported prefix plus the parse-side number reconstructs the typed digits exactly.
+      if (literalError?.kind === 'NATIONAL_PREFIX_PRESENT') {
+        expect(literal.isValid()).toBe(false);
+        expect(parsed.isValid()).toBe(true);
+        expect(literalError.prefix + parsed.getNationalNumber()).toBe(literalDigits);
+      }
+
+      if (parsed.getNationalNumber() === literalDigits) {
+        expect(methods(literal)).toEqual(methods(parsed));
+      } else if (!literal.isValid() && parsed.isValid() && literalDigits.endsWith(parsed.getNationalNumber())) {
+        expect(literalError?.kind).toBe('NATIONAL_PREFIX_PRESENT');
+      } else {
+        expect(literalError === null).toBe(literal.isValid());
+      }
     }
   }, 120_000);
 });

--- a/packages/core/src/modules/input-controller/__tests__/phone-number-coherence.test.ts
+++ b/packages/core/src/modules/input-controller/__tests__/phone-number-coherence.test.ts
@@ -1,0 +1,314 @@
+import { RegionCode } from '@telixon/core/engine';
+import { getExampleNumber } from '@telixon/core/testing';
+import { describe, expect, it } from 'vitest';
+import { getCallingCodeForRegion } from '../../calling-code-for-region';
+import { parsePhoneNumber } from '../../parse-phone-number';
+import { PhoneNumber } from '../../phone-number';
+import { createInternationalInputController } from '../international-input-controller';
+import { InputController } from '../models';
+import { createNationalInputController } from '../national-input-controller';
+
+// PhoneNumber self-coherence across controller modes and filters; only national mode may pair a valid number with the NATIONAL_PREFIX_MISSING advisory.
+
+type ControllerMode = 'national' | 'international' | 'selector';
+
+const QUERY_METHODS = [
+  'isValid',
+  'isPossible',
+  'isPossibleWithReason',
+  'getValidationError',
+  'getRegion',
+  'getNumberType',
+  'getCallingCode',
+  'getNationalNumber',
+  'formatE164',
+  'formatNational',
+  'formatInternational',
+  'formatRfc3966',
+] as const;
+
+const UA_MOBILE = getExampleNumber('UA', 'MOBILE');
+const CA_NUMBER = getExampleNumber('CA', 'FIXED_LINE');
+const US_TOLL_FREE = getExampleNumber('US', 'TOLL_FREE');
+const BY_MOBILE = getExampleNumber('BY', 'MOBILE');
+const AU_MOBILE = getExampleNumber('AU', 'MOBILE');
+const GG_MOBILE = getExampleNumber('GG', 'MOBILE');
+
+function queryAnswers(phoneNumber: PhoneNumber): Record<string, unknown> {
+  const answers: Record<string, unknown> = {};
+  for (const method of QUERY_METHODS) {
+    answers[method] = (phoneNumber as unknown as Record<string, () => unknown>)[method]!();
+  }
+  return answers;
+}
+
+function expectCoherent(
+  phoneNumber: PhoneNumber,
+  mode: ControllerMode,
+  allowedRegions: readonly RegionCode[] | null = null,
+): void {
+  const validationError = phoneNumber.getValidationError();
+
+  if (phoneNumber.isValid()) {
+    expect(phoneNumber.isPossible()).toBe(true);
+    expect(phoneNumber.getRegion()).not.toBeNull();
+    if (mode === 'national' && validationError !== null) {
+      expect(validationError.kind).toBe('NATIONAL_PREFIX_MISSING');
+    }
+    if (mode !== 'national') {
+      expect(validationError).toBeNull();
+    }
+  } else {
+    expect(validationError).not.toBeNull();
+  }
+
+  if (validationError?.kind === 'INVALID_LENGTH') {
+    expect(validationError.possibleLengths.length).toBeGreaterThan(0);
+  }
+  if (validationError?.kind === 'NATIONAL_PREFIX_PRESENT') {
+    expect(phoneNumber.isValid()).toBe(false);
+    expect(mode).toBe('selector');
+  }
+  if (validationError?.kind === 'TOO_SHORT') {
+    expect(validationError.minLength).toBeGreaterThan(phoneNumber.getNationalNumber().length);
+  }
+  if (validationError?.kind === 'TOO_LONG') {
+    expect(validationError.maxLength).toBeLessThan(phoneNumber.getNationalNumber().length);
+  }
+
+  expect(phoneNumber.formatE164() !== null).toBe(phoneNumber.isPossible());
+
+  const region = phoneNumber.getRegion();
+  if (allowedRegions !== null && region !== null) {
+    expect(allowedRegions).toContain(region);
+  }
+}
+
+function createSelectorController(region: RegionCode): InputController {
+  return createInternationalInputController({ defaultRegion: region, display: { callingCodeInInput: false } });
+}
+
+describe('Selector mode resolves the field as an international significant number', () => {
+  it('accepts the national significant number without a trunk prefix', () => {
+    const controller = createSelectorController('UA');
+    controller.setValue(UA_MOBILE);
+    const phoneNumber = controller.getPhoneNumber();
+
+    expectCoherent(phoneNumber, 'selector');
+    expect(phoneNumber.isValid()).toBe(true);
+    expect(phoneNumber.getValidationError()).toBeNull();
+    expect(phoneNumber.formatE164()).toBe(`+380${UA_MOBILE}`);
+  });
+
+  it('rejects the same number typed with the trunk prefix', () => {
+    const controller = createSelectorController('UA');
+    controller.setValue(`0${UA_MOBILE}`);
+    const phoneNumber = controller.getPhoneNumber();
+
+    expectCoherent(phoneNumber, 'selector');
+    expect(phoneNumber.isValid()).toBe(false);
+    expect(phoneNumber.getValidationError()).toEqual({ kind: 'NATIONAL_PREFIX_PRESENT', prefix: '0' });
+  });
+
+  it('rejects a NANP number typed with the redundant leading 1', () => {
+    const controller = createSelectorController('CA');
+    controller.setValue(`1${CA_NUMBER}`);
+    const phoneNumber = controller.getPhoneNumber();
+
+    expectCoherent(phoneNumber, 'selector');
+    expect(phoneNumber.isValid()).toBe(false);
+    expect(phoneNumber.getValidationError()).toEqual({ kind: 'NATIONAL_PREFIX_PRESENT', prefix: '1' });
+  });
+
+  it('reports the exact dropped chunk for a compound national prefix', () => {
+    const controller = createSelectorController('BY');
+    controller.setValue(`80${BY_MOBILE}`);
+    const phoneNumber = controller.getPhoneNumber();
+
+    expectCoherent(phoneNumber, 'selector');
+    expect(phoneNumber.getValidationError()).toEqual({ kind: 'NATIONAL_PREFIX_PRESENT', prefix: '80' });
+  });
+
+  it('reports the exact dropped chunk for a typed carrier code', () => {
+    const controller = createSelectorController('AU');
+    controller.setValue(`1831${AU_MOBILE}`);
+    const phoneNumber = controller.getPhoneNumber();
+
+    expectCoherent(phoneNumber, 'selector');
+    expect(phoneNumber.getValidationError()).toEqual({ kind: 'NATIONAL_PREFIX_PRESENT', prefix: '1831' });
+  });
+
+  it('keeps digit-rewriting local dialing forms out of the prefix error', () => {
+    const controller = createSelectorController('AR');
+    controller.setValue('0111523456789');
+    const phoneNumber = controller.getPhoneNumber();
+
+    expectCoherent(phoneNumber, 'selector');
+    expect(phoneNumber.getValidationError()?.kind).toBe('TOO_LONG');
+  });
+
+  it('keeps TOO_SHORT while a trunk-prefixed number is still incomplete', () => {
+    const controller = createSelectorController('UA');
+    controller.setValue('0');
+    const phoneNumber = controller.getPhoneNumber();
+
+    expectCoherent(phoneNumber, 'selector');
+    expect(phoneNumber.getValidationError()?.kind).toBe('TOO_SHORT');
+  });
+
+  it('reports TOO_SHORT for the empty field', () => {
+    const controller = createSelectorController('UA');
+    const phoneNumber = controller.getPhoneNumber();
+
+    expectCoherent(phoneNumber, 'selector');
+    expect(phoneNumber.getValidationError()?.kind).toBe('TOO_SHORT');
+  });
+
+  it('answers every query exactly like parsePhoneNumber of the calling code plus the displayed value', () => {
+    const inputs: ReadonlyArray<readonly [RegionCode, string]> = [
+      ['UA', UA_MOBILE],
+      ['CA', CA_NUMBER],
+    ];
+
+    for (const [region, input] of inputs) {
+      const controller = createSelectorController(region);
+      const { value } = controller.setValue(input);
+      const callingCode: string = getCallingCodeForRegion(region);
+
+      expect(queryAnswers(controller.getPhoneNumber())).toEqual(
+        queryAnswers(parsePhoneNumber(`+${callingCode}${value}`)),
+      );
+    }
+  });
+});
+
+describe('Region filters keep every query coherent', () => {
+  it('keeps a number valid when the filter allows its region', () => {
+    const selector = createSelectorController('CA');
+    selector.setValue(CA_NUMBER);
+
+    const international = createInternationalInputController({});
+    international.setValue(`+1${CA_NUMBER}`);
+
+    const national = createNationalInputController({ defaultRegion: 'US' });
+    national.setValue(CA_NUMBER);
+
+    const controllers: ReadonlyArray<readonly [InputController, ControllerMode]> = [
+      [selector, 'selector'],
+      [international, 'international'],
+      [national, 'national'],
+    ];
+
+    for (const [controller, mode] of controllers) {
+      controller.setRegionFilter(['CA']);
+      const phoneNumber = controller.getPhoneNumber();
+
+      expectCoherent(phoneNumber, mode, ['CA']);
+      expect(phoneNumber.isValid()).toBe(true);
+      expect(phoneNumber.getValidationError()).toBeNull();
+      expect(phoneNumber.getRegion()).toBe('CA');
+      expect(phoneNumber.formatE164()).toBe(`+1${CA_NUMBER}`);
+    }
+  });
+
+  it('rejects a number whose region the filter excludes with PATTERN_MISMATCH', () => {
+    const controller = createInternationalInputController({});
+    controller.setValue(`+1${CA_NUMBER}`);
+    controller.setRegionFilter(['US']);
+    const phoneNumber = controller.getPhoneNumber();
+
+    expectCoherent(phoneNumber, 'international', ['US']);
+    expect(phoneNumber.isValid()).toBe(false);
+    expect(phoneNumber.getValidationError()?.kind).toBe('PATTERN_MISMATCH');
+    expect(phoneNumber.getRegion()).toBeNull();
+  });
+
+  it('resolves a shared-pattern number to the allowed region', () => {
+    const controller = createInternationalInputController({});
+    controller.setValue(`+1${US_TOLL_FREE}`);
+    controller.setRegionFilter(['CA']);
+    const phoneNumber = controller.getPhoneNumber();
+
+    expectCoherent(phoneNumber, 'international', ['CA']);
+    expect(phoneNumber.isValid()).toBe(true);
+    expect(phoneNumber.getRegion()).toBe('CA');
+    expect(phoneNumber.getNumberType()).toBe('TOLL_FREE');
+  });
+
+  it('reports TOO_SHORT while the number is incomplete under a filter', () => {
+    const controller = createSelectorController('CA');
+    controller.setValue(CA_NUMBER.slice(0, 6));
+    controller.setRegionFilter(['CA']);
+    const phoneNumber = controller.getPhoneNumber();
+
+    expectCoherent(phoneNumber, 'selector', ['CA']);
+    expect(phoneNumber.getValidationError()?.kind).toBe('TOO_SHORT');
+  });
+
+  it('bounds the length verdicts by the allowed regions of the calling code', () => {
+    // Christmas Island has no 5-digit numbers; Australia does.
+    const australia = createSelectorController('AU');
+    australia.setValue(AU_MOBILE.slice(0, 5));
+    australia.setRegionFilter(['CX']);
+    const shortNumber = australia.getPhoneNumber();
+
+    expectCoherent(shortNumber, 'selector', ['CX']);
+    expect(shortNumber.getValidationError()).toEqual({ kind: 'TOO_SHORT', minLength: 6 });
+
+    // Guernsey has a length gap at 8 digits; Great Britain does not.
+    const britain = createSelectorController('GB');
+    britain.setValue(GG_MOBILE.slice(0, 8));
+    britain.setRegionFilter(['GG']);
+    const gapNumber = britain.getPhoneNumber();
+
+    expectCoherent(gapNumber, 'selector', ['GG']);
+    expect(gapNumber.getValidationError()).toEqual({ kind: 'INVALID_LENGTH', possibleLengths: [7, 9, 10] });
+  });
+
+  it('reports INVALID_CALLING_CODE when the filter excludes every region of the calling code', () => {
+    const selector = createSelectorController('UA');
+    selector.setValue(UA_MOBILE);
+
+    const international = createInternationalInputController({});
+    international.setValue(`+380${UA_MOBILE}`);
+
+    const controllers: ReadonlyArray<readonly [InputController, ControllerMode]> = [
+      [selector, 'selector'],
+      [international, 'international'],
+    ];
+
+    for (const [controller, mode] of controllers) {
+      controller.setRegionFilter(['US']);
+      const phoneNumber = controller.getPhoneNumber();
+
+      expectCoherent(phoneNumber, mode, ['US']);
+      expect(phoneNumber.isValid()).toBe(false);
+      expect(phoneNumber.getValidationError()?.kind).toBe('INVALID_CALLING_CODE');
+      expect(phoneNumber.formatE164()).toBeNull();
+    }
+  });
+});
+
+describe('Number type filters keep every query coherent', () => {
+  it('rejects an excluded type with PATTERN_MISMATCH', () => {
+    const controller = createNationalInputController({ defaultRegion: 'UA' });
+    controller.setValue(`0${UA_MOBILE}`);
+    controller.setNumberTypeFilter(['FIXED_LINE']);
+    const phoneNumber = controller.getPhoneNumber();
+
+    expectCoherent(phoneNumber, 'national');
+    expect(phoneNumber.isValid()).toBe(false);
+    expect(phoneNumber.getValidationError()?.kind).toBe('PATTERN_MISMATCH');
+  });
+
+  it('reports INVALID_CALLING_CODE when the region has none of the allowed types', () => {
+    const controller = createNationalInputController({ defaultRegion: 'US' });
+    controller.setValue(CA_NUMBER);
+    controller.setNumberTypeFilter(['SHARED_COST']);
+    const phoneNumber = controller.getPhoneNumber();
+
+    expectCoherent(phoneNumber, 'national');
+    expect(phoneNumber.isValid()).toBe(false);
+    expect(phoneNumber.getValidationError()?.kind).toBe('INVALID_CALLING_CODE');
+  });
+});

--- a/packages/core/src/modules/input-controller/international-input-controller/international-input-controller.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/international-input-controller.ts
@@ -339,23 +339,18 @@ class InternationalInputController implements InputController {
   }
 
   getPhoneNumber(): PhoneNumber {
+    // Selector mode resolves the displayed digits literally behind the seeded calling code, exactly as the state pipeline walks them.
     const resolved: ResolvedNumberState = resolveNumber({
       input: this.#history.current.value,
-      hasLeadingPlus: this.config.display?.callingCodeInInput !== false,
+      hasLeadingPlus: true,
+      seedCallingCode: this.config.display?.callingCodeInInput === false ? this.#defaultCallingCode : null,
       defaultRegionIndex: this.#defaultRegionIndex,
       regionFilter: this.#numberResolver.regionFilter,
       numberTypeFilter: this.#numberResolver.numberTypeFilter,
       strict: this.config.strict === true,
     });
 
-    return createPhoneNumber(
-      toResolvedPhoneNumber(
-        resolved.snapshot,
-        this.#defaultRegionIndex,
-        resolved.nationalPrefixPresent,
-        resolved.readAsNational,
-      ),
-    );
+    return createPhoneNumber(toResolvedPhoneNumber(resolved, this.#defaultRegionIndex));
   }
 
   clearHistory(): void {

--- a/packages/core/src/modules/input-controller/international-input-controller/models/index.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/models/index.ts
@@ -8,8 +8,8 @@ export type PlusPrefixMode = 'none' | 'fixed' | 'erasable';
 
 /**
  * Where the calling code lives. `callingCodeInInput: true`: the field holds calling-code digits
- * (`1 415…` resolves as US) and `plusPrefix` controls the `+`. `false`: the field holds national
- * digits only.
+ * (`1 415…` resolves as US) and `plusPrefix` controls the `+`. `false`: the field holds the
+ * international significant number and the selected region supplies the calling code.
  */
 export type InternationalDisplayConfig =
   | { readonly callingCodeInInput: false }

--- a/packages/core/src/modules/input-controller/international-input-controller/utils/resolve-international-controller-state.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/utils/resolve-international-controller-state.ts
@@ -80,6 +80,7 @@ export function resolveInternationalControllerState(
         snapshot.callingCodeState,
         snapshot.endState,
         snapshot.nationalDigits,
+        snapshot.regionFilter,
         regionIndex,
       );
     }

--- a/packages/core/src/modules/input-controller/national-input-controller/national-input-controller.ts
+++ b/packages/core/src/modules/input-controller/national-input-controller/national-input-controller.ts
@@ -294,20 +294,14 @@ class NationalInputController implements InputController {
     const resolved: ResolvedNumberState = resolveNumber({
       input: this.#history.current.value,
       hasLeadingPlus: false,
+      seedCallingCode: null,
       defaultRegionIndex: this.#defaultRegionIndex,
       regionFilter: this.#numberResolver.regionFilter,
       numberTypeFilter: this.#numberResolver.numberTypeFilter,
       strict: this.config.strict === true,
     });
 
-    return createPhoneNumber(
-      toResolvedPhoneNumber(
-        resolved.snapshot,
-        this.#defaultRegionIndex,
-        resolved.nationalPrefixPresent,
-        resolved.readAsNational,
-      ),
-    );
+    return createPhoneNumber(toResolvedPhoneNumber(resolved, this.#defaultRegionIndex));
   }
 
   undo(): InputState {

--- a/packages/core/src/modules/input-controller/national-input-controller/utils/resolve-national-controller-state.ts
+++ b/packages/core/src/modules/input-controller/national-input-controller/utils/resolve-national-controller-state.ts
@@ -54,6 +54,7 @@ export function resolveNationalControllerState(
         snapshot.callingCodeState,
         snapshot.endState,
         snapshot.nationalDigits,
+        snapshot.regionFilter,
         fallbackRegionIndex,
       );
     }

--- a/packages/core/src/modules/number-resolver/resolve-number.ts
+++ b/packages/core/src/modules/number-resolver/resolve-number.ts
@@ -13,7 +13,7 @@ import { resolvePrimaryRegionIndex } from './utils/resolve-primary-region-index'
 
 // The single parse pipeline shared by parsePhoneNumber and the input controllers. Walks the raw input
 // (non-digits ignored) and strips IDD prefix, redundant leading calling code, and national prefix, so
-// every caller resolves a number identically.
+// every caller resolves a number identically. A seeded calling code walks the input literally instead.
 
 let cachedResolver: NumberResolver | null = null;
 
@@ -67,6 +67,8 @@ export interface ResolveNumberInput {
   readonly input: string;
   // International input (had a leading '+', or an international controller); national otherwise.
   readonly hasLeadingPlus: boolean;
+  // Calling code held outside the field: the input is the international significant number, walked literally with no parse leniency.
+  readonly seedCallingCode: string | null;
   readonly defaultRegionIndex: number;
   readonly regionFilter: BinaryFilter | null;
   readonly numberTypeFilter: BinaryFilter | null;
@@ -78,11 +80,29 @@ export interface ResolvedNumberState {
   readonly nationalPrefixPresent: boolean;
   // National-mode input (no leading '+', resolved against the default region); national-prefix checks apply only then.
   readonly readAsNational: boolean;
+  // The seeded literal read above; the national-prefix-present check applies only then.
+  readonly callingCodeSeeded: boolean;
 }
 
 export function resolveNumber(params: ResolveNumberInput): ResolvedNumberState {
-  const { input, hasLeadingPlus, defaultRegionIndex, regionFilter, numberTypeFilter, strict } = params;
+  const { input, hasLeadingPlus, seedCallingCode, defaultRegionIndex, regionFilter, numberTypeFilter, strict } = params;
   const resourceProvider = getResourceProvider();
+
+  const resolver: NumberResolver = cachedResolver ?? (cachedResolver = new NumberResolver());
+  resolver.setRegionFilter(regionFilter);
+  resolver.setNumberTypeFilter(numberTypeFilter);
+  resolver.setStrict(strict);
+
+  if (seedCallingCode !== null) {
+    resolver.setCallingCode(seedCallingCode);
+    walkInput(resolver, input);
+    return {
+      snapshot: resolver.snapshot,
+      nationalPrefixPresent: false,
+      readAsNational: false,
+      callingCodeSeeded: true,
+    };
+  }
 
   // National-mode digits beginning with the region's IDD prefix are internationally dialled: strip the
   // prefix and parse the remainder as international (libphonenumber FROM_NUMBER_WITH_IDD).
@@ -93,11 +113,6 @@ export function resolveNumber(params: ResolveNumberInput): ResolvedNumberState {
   }
 
   const readAsNational: boolean = !hasLeadingPlus && defaultRegionIndex !== -1 && iddRemainder === null;
-
-  const resolver: NumberResolver = cachedResolver ?? (cachedResolver = new NumberResolver());
-  resolver.setRegionFilter(regionFilter);
-  resolver.setNumberTypeFilter(numberTypeFilter);
-  resolver.setStrict(strict);
 
   // True once a redundant leading calling code is dropped: from then on the number behaves as if dialled
   // through that calling code, so the strip below prefers its main region over the default region.
@@ -149,5 +164,5 @@ export function resolveNumber(params: ResolveNumberInput): ResolvedNumberState {
     walkInput(resolver, stripped);
   }
 
-  return { snapshot: resolver.snapshot, nationalPrefixPresent, readAsNational };
+  return { snapshot: resolver.snapshot, nationalPrefixPresent, readAsNational, callingCodeSeeded: false };
 }

--- a/packages/core/src/modules/number-resolver/utils/resolve-possibility-length-masks.ts
+++ b/packages/core/src/modules/number-resolver/utils/resolve-possibility-length-masks.ts
@@ -1,0 +1,40 @@
+import { getCallingCodeStateRegions } from '@telixon/core/engine';
+import { BinaryFilter } from '@telixon/core/models';
+import { getResourceProvider } from '@telixon/core/resource-provider';
+import { getAllowedLengthMask } from './get-allowed-length-mask';
+import { getAllowedLocalOnlyLengthMask } from './get-allowed-local-only-length-mask';
+import { resolvePrimaryRegionIndex } from './resolve-primary-region-index';
+
+/** Length masks backing the possibility checks; `national` and `localOnly` mirror libphonenumber's split. */
+export interface PossibilityLengthMasks {
+  readonly national: number;
+  readonly localOnly: number;
+}
+
+// Unfiltered, the masks read the calling code's main region (libphonenumber testNumberLength); a
+// region filter unions the allowed regions instead, so a number valid for an allowed region is always possible.
+export function resolvePossibilityLengthMasks(
+  callingCodeState: number,
+  defaultRegionIndex: number,
+  regionFilter: BinaryFilter | null,
+  numberTypeFilter: BinaryFilter | null,
+): PossibilityLengthMasks {
+  if (regionFilter === null || callingCodeState === -1) {
+    const regionIndex: number = resolvePrimaryRegionIndex(callingCodeState, defaultRegionIndex);
+    return {
+      national: getAllowedLengthMask(regionIndex, regionFilter, numberTypeFilter),
+      localOnly: getAllowedLocalOnlyLengthMask(regionIndex, regionFilter, numberTypeFilter),
+    };
+  }
+
+  const regions: Uint8Array = getCallingCodeStateRegions(getResourceProvider().engine, callingCodeState);
+  let national = 0;
+  let localOnly = 0;
+  for (const regionIndex of regions) {
+    if (regionFilter[regionIndex] === 0) continue;
+    national |= getAllowedLengthMask(regionIndex, null, numberTypeFilter);
+    localOnly |= getAllowedLocalOnlyLengthMask(regionIndex, null, numberTypeFilter);
+  }
+
+  return { national, localOnly };
+}

--- a/packages/core/src/modules/number-resolver/utils/resolve-region-code-or-fallback.ts
+++ b/packages/core/src/modules/number-resolver/utils/resolve-region-code-or-fallback.ts
@@ -1,4 +1,5 @@
 import { RegionCode } from '@telixon/core/engine';
+import { BinaryFilter } from '@telixon/core/models';
 import { getResourceProvider } from '@telixon/core/resource-provider';
 import { resolveRegionCodeFast } from './resolve-region-code';
 
@@ -7,10 +8,11 @@ export function resolveRegionCodeOrFallback(
   callingCodeState: number,
   endState: number,
   nationalDigits: string,
+  regionFilter: BinaryFilter | null,
   fallbackRegionIndex: number,
 ): RegionCode | null {
   return (
-    resolveRegionCodeFast(callingCodeState, endState, nationalDigits) ??
+    resolveRegionCodeFast(callingCodeState, endState, nationalDigits, regionFilter) ??
     getResourceProvider().regionIds[fallbackRegionIndex] ??
     null
   );

--- a/packages/core/src/modules/number-resolver/utils/resolve-region-code.ts
+++ b/packages/core/src/modules/number-resolver/utils/resolve-region-code.ts
@@ -9,6 +9,7 @@ import {
   verdictIsDecided,
   verdictRegion,
 } from '@telixon/core/engine';
+import { BinaryFilter } from '@telixon/core/models';
 import { getResourceProvider } from '@telixon/core/resource-provider';
 import { resolveExactMatchedTypeIdMask } from './resolve-exact-matched-types';
 
@@ -42,11 +43,12 @@ function matchesRegion(
   return resolveExactMatchedTypeIdMask(endState, nationalDigits.length, regionIndex, null) !== 0;
 }
 
-// libphonenumber getRegionCodeForNumber: first region (main-first) the number matches, or null; fallback behind baked verdicts.
+// libphonenumber getRegionCodeForNumber: first region (main-first) the number matches, or null; a region filter narrows the scan.
 export function resolveRegionCode(
   callingCodeState: number,
   endState: number,
   nationalDigits: string,
+  regionFilter: BinaryFilter | null,
 ): RegionCode | null {
   if (callingCodeState === -1) return null;
 
@@ -54,11 +56,14 @@ export function resolveRegionCode(
   const regions: Uint8Array = getCallingCodeStateRegions(resourceProvider.engine, callingCodeState);
 
   if (regions.length === 1) {
-    return resourceProvider.regionIds[regions[0]!] ?? null;
+    const regionIndex: number = regions[0]!;
+    if (regionFilter !== null && regionFilter[regionIndex] === 0) return null;
+    return resourceProvider.regionIds[regionIndex] ?? null;
   }
 
   const exactRegions: number[] = collectExactRegions(endState, nationalDigits.length);
   for (const regionIndex of regions) {
+    if (regionFilter !== null && regionFilter[regionIndex] === 0) continue;
     if (matchesRegion(regionIndex, nationalDigits, endState, exactRegions)) {
       return resourceProvider.regionIds[regionIndex] ?? null;
     }
@@ -67,15 +72,16 @@ export function resolveRegionCode(
   return null;
 }
 
-// Verdict-first region resolution: one baked lookup at (endState, length), else the explicit resolution above.
+// Verdict-first region resolution: one baked lookup at (endState, length). Verdicts are unfiltered, so a region filter takes the explicit path.
 export function resolveRegionCodeFast(
   callingCodeState: number,
   endState: number,
   nationalDigits: string,
+  regionFilter: BinaryFilter | null,
 ): RegionCode | null {
   const length: number = nationalDigits.length;
 
-  if (length < VERDICT_LENGTH_COUNT) {
+  if (regionFilter === null && length < VERDICT_LENGTH_COUNT) {
     const verdict: number = getVerdict(getResourceProvider().engine, endState, length);
     if (verdictIsDecided(verdict)) {
       const regionIndex: number = verdictRegion(verdict);
@@ -84,5 +90,5 @@ export function resolveRegionCodeFast(
     }
   }
 
-  return resolveRegionCode(callingCodeState, endState, nationalDigits);
+  return resolveRegionCode(callingCodeState, endState, nationalDigits, regionFilter);
 }

--- a/packages/core/src/modules/parse-phone-number/parse-phone-number.ts
+++ b/packages/core/src/modules/parse-phone-number/parse-phone-number.ts
@@ -34,18 +34,12 @@ export function parsePhoneNumber(input: string, options: ParsePhoneNumberOptions
   const resolved: ResolvedNumberState = resolveNumber({
     input,
     hasLeadingPlus,
+    seedCallingCode: null,
     defaultRegionIndex,
     regionFilter: null,
     numberTypeFilter: null,
     strict: options.strict ?? false,
   });
 
-  return createPhoneNumber(
-    toResolvedPhoneNumber(
-      resolved.snapshot,
-      defaultRegionIndex,
-      resolved.nationalPrefixPresent,
-      resolved.readAsNational,
-    ),
-  );
+  return createPhoneNumber(toResolvedPhoneNumber(resolved, defaultRegionIndex));
 }

--- a/packages/core/src/modules/phone-number/models/index.ts
+++ b/packages/core/src/modules/phone-number/models/index.ts
@@ -15,7 +15,7 @@ export type PossibilityResult =
   | 'INVALID_LENGTH';
 
 /**
- * Why a number is not valid, discriminated on `kind`. Four variants carry data. Returned by
+ * Why a number is not valid, discriminated on `kind`. Five variants carry data. Returned by
  * {@link PhoneNumber.getValidationError}; kinds mirror libphonenumber where applicable.
  */
 export type ValidationError =
@@ -34,7 +34,9 @@ export type ValidationError =
   /** The length is valid but the digits match no number that exists in the region. */
   | { readonly kind: 'PATTERN_MISMATCH' }
   /** A required national (trunk) prefix was not typed. `expectedPrefix` is the missing prefix. */
-  | { readonly kind: 'NATIONAL_PREFIX_MISSING'; readonly expectedPrefix: string };
+  | { readonly kind: 'NATIONAL_PREFIX_MISSING'; readonly expectedPrefix: string }
+  /** International-significant input begins with national-dialing digits (trunk prefix or carrier code). `prefix` is the exact leading digits to drop. */
+  | { readonly kind: 'NATIONAL_PREFIX_PRESENT'; readonly prefix: string };
 
 export interface ResolvedPhoneNumber {
   readonly nationalDigits: string;
@@ -46,6 +48,7 @@ export interface ResolvedPhoneNumber {
   readonly numberTypeFilter: BinaryFilter | null;
   readonly nationalPrefixPresent: boolean;
   readonly readAsNational: boolean;
+  readonly callingCodeSeeded: boolean;
   readonly strict: boolean;
 }
 
@@ -65,7 +68,7 @@ export interface PhoneNumber {
   isPossible(): boolean;
   /** The possibility check as a reason code, so a failed {@link PhoneNumber.isPossible} says why. */
   isPossibleWithReason(): PossibilityResult;
-  /** Why the number is not valid, or `null` when it is. One of eight typed variants. */
+  /** The fault to correct, or `null` when none applies. One of nine typed variants. */
   getValidationError(): ValidationError | null;
   /** The line type, such as `MOBILE` or `FIXED_LINE`. `UNKNOWN` when the number is not valid or the type is ambiguous. */
   getNumberType(): NumberType;
@@ -75,12 +78,12 @@ export interface PhoneNumber {
   getCallingCode(): string | null;
   /** The region the number resolves to, or `null` when none does. */
   getRegion(): RegionCode | null;
-  /** E.164, or `null` when the number is not valid. */
+  /** E.164, or `null` when the number is not possible. */
   formatE164(): string | null;
-  /** National format, or `null` when the number is not valid. */
+  /** National format, or `null` when the number is not possible. */
   formatNational(): string | null;
-  /** International format, or `null` when the number is not valid. */
+  /** International format, or `null` when the number is not possible. */
   formatInternational(): string | null;
-  /** RFC 3966 `tel:` URI, or `null` when the number is not valid. */
+  /** RFC 3966 `tel:` URI, or `null` when the number is not possible. */
   formatRfc3966(): string | null;
 }

--- a/packages/core/src/modules/phone-number/query/get-number-type.ts
+++ b/packages/core/src/modules/phone-number/query/get-number-type.ts
@@ -17,9 +17,9 @@ import { numberTypeForRegion } from './number-type-for-region';
 
 // Explicit resolution behind the baked verdicts: undecided inputs and filtered queries.
 function getNumberTypeResolved(resolved: ResolvedPhoneNumber): NumberType {
-  const { callingCodeState, nationalDigits, endState } = resolved;
+  const { callingCodeState, nationalDigits, endState, regionFilter } = resolved;
 
-  const region: RegionCode | null = resolveRegionCode(callingCodeState, endState, nationalDigits);
+  const region: RegionCode | null = resolveRegionCode(callingCodeState, endState, nationalDigits, regionFilter);
   if (!region) return 'UNKNOWN';
 
   const regionIndex: number | undefined = getResourceProvider().regionKeyToIndex[region];

--- a/packages/core/src/modules/phone-number/query/get-region.ts
+++ b/packages/core/src/modules/phone-number/query/get-region.ts
@@ -4,5 +4,10 @@ import { ResolvedPhoneNumber } from '../models';
 
 // Region the number belongs to (libphonenumber getRegionCodeForNumber): one baked verdict lookup, with the explicit resolution behind it.
 export function getRegion(resolved: ResolvedPhoneNumber): RegionCode | null {
-  return resolveRegionCodeFast(resolved.callingCodeState, resolved.endState, resolved.nationalDigits);
+  return resolveRegionCodeFast(
+    resolved.callingCodeState,
+    resolved.endState,
+    resolved.nationalDigits,
+    resolved.regionFilter,
+  );
 }

--- a/packages/core/src/modules/phone-number/query/get-validation-error.ts
+++ b/packages/core/src/modules/phone-number/query/get-validation-error.ts
@@ -6,10 +6,16 @@ import {
 } from '@telixon/core/engine';
 import { getResourceProvider } from '@telixon/core/resource-provider';
 import { getCallingCodeIndexByRegionIndex } from '@telixon/core/utils/get-calling-code-index-by-region-index';
-import { getAllowedLengthMask } from '../../number-resolver/utils/get-allowed-length-mask';
+import { ResolvedNumberState, resolveNumber } from '../../number-resolver/resolve-number';
+import {
+  PossibilityLengthMasks,
+  resolvePossibilityLengthMasks,
+} from '../../number-resolver/utils/resolve-possibility-length-masks';
 import { resolvePrimaryRegionIndex } from '../../number-resolver/utils/resolve-primary-region-index';
 import { selectNationalFormatIndex } from '../../number-resolver/utils/select-national-format';
 import { PossibilityResult, ResolvedPhoneNumber, ValidationError } from '../models';
+import { toResolvedPhoneNumber } from '../to-resolved-phone-number';
+import { getNumberType } from './get-number-type';
 import { getMinLength, getPossibleLengths } from './length-utils';
 
 /** Returns the highest-precedence validation error for the resolved number, or `null` when none apply. */
@@ -27,14 +33,28 @@ export function getValidationError(
     numberTypeFilter,
     nationalPrefixPresent,
     readAsNational,
+    callingCodeSeeded,
   } = resolved;
 
   if (nationalDigits.length === 0 && callingCode.length === 0) return { kind: 'EMPTY' };
 
   if (reason === 'INVALID_CALLING_CODE') return { kind: 'INVALID_CALLING_CODE' };
 
+  // Detect a typed national prefix before the length verdicts, which would misread the extra digits.
+  if (callingCodeSeeded && !valid) {
+    const nationalPrefixPresentError: ValidationError | null = detectNationalPrefixPresent(resolved);
+    if (nationalPrefixPresentError !== null) return nationalPrefixPresentError;
+  }
+
   const regionIndex: number = resolvePrimaryRegionIndex(callingCodeState, defaultRegionIndex);
-  const nationalMask: number = getAllowedLengthMask(regionIndex, regionFilter, numberTypeFilter);
+  // The same masks the possibility check read, so the reported lengths always agree with the reason.
+  const masks: PossibilityLengthMasks = resolvePossibilityLengthMasks(
+    callingCodeState,
+    defaultRegionIndex,
+    regionFilter,
+    numberTypeFilter,
+  );
+  const nationalMask: number = masks.national;
 
   if (reason === 'TOO_SHORT') return { kind: 'TOO_SHORT', minLength: getMinLength(nationalMask) };
   if (reason === 'TOO_LONG') return { kind: 'TOO_LONG', maxLength: getMaxLength(nationalMask) };
@@ -71,4 +91,31 @@ function detectNationalPrefixMissing(regionIndex: number, nationalDigits: string
   if (isFormatPrefixOptional(resourceProvider.engine, formatIndex)) return null;
 
   return { kind: 'NATIONAL_PREFIX_MISSING', expectedPrefix: nationalPrefix };
+}
+
+/** Returns `NATIONAL_PREFIX_PRESENT` when the parse-side read drops leading national-dialing digits and the remainder is a valid number; otherwise `null`. */
+function detectNationalPrefixPresent(resolved: ResolvedPhoneNumber): ValidationError | null {
+  const { nationalDigits, callingCode, defaultRegionIndex, regionFilter, numberTypeFilter, strict } = resolved;
+  if (nationalDigits.length === 0 || callingCode === '') return null;
+
+  // Parse-side read of the same digits; only a strict-suffix result names a droppable leading chunk.
+  const reparsed: ResolvedNumberState = resolveNumber({
+    input: `+${callingCode}${nationalDigits}`,
+    hasLeadingPlus: true,
+    seedCallingCode: null,
+    defaultRegionIndex,
+    regionFilter,
+    numberTypeFilter,
+    strict,
+  });
+  const reparsedDigits: string = reparsed.snapshot.nationalDigits;
+  if (reparsedDigits === nationalDigits || !nationalDigits.endsWith(reparsedDigits)) return null;
+
+  // The rescued number must be valid for the typed prefix to be the explanation.
+  if (getNumberType(toResolvedPhoneNumber(reparsed, defaultRegionIndex)) === 'UNKNOWN') return null;
+
+  return {
+    kind: 'NATIONAL_PREFIX_PRESENT',
+    prefix: nationalDigits.slice(0, nationalDigits.length - reparsedDigits.length),
+  };
 }

--- a/packages/core/src/modules/phone-number/query/is-possible-with-reason.ts
+++ b/packages/core/src/modules/phone-number/query/is-possible-with-reason.ts
@@ -1,7 +1,9 @@
 import { containsLength, isCallingCodeComplete } from '@telixon/core/engine';
 import { getResourceProvider } from '@telixon/core/resource-provider';
-import { getAllowedLengthMask } from '../../number-resolver/utils/get-allowed-length-mask';
-import { getAllowedLocalOnlyLengthMask } from '../../number-resolver/utils/get-allowed-local-only-length-mask';
+import {
+  PossibilityLengthMasks,
+  resolvePossibilityLengthMasks,
+} from '../../number-resolver/utils/resolve-possibility-length-masks';
 import { resolvePrimaryRegionIndex } from '../../number-resolver/utils/resolve-primary-region-index';
 import { PossibilityResult, ResolvedPhoneNumber } from '../models';
 import { validationResultFromLength } from './validation-result-from-length';
@@ -21,13 +23,23 @@ export function isPossibleWithReason(resolved: ResolvedPhoneNumber): Possibility
   const length: number = nationalDigits.length;
   // Beyond every valid national length; guard before containsLength, whose `1 << length` wraps past 31.
   if (length >= 32) return 'TOO_LONG';
-  const nationalMask: number = getAllowedLengthMask(regionIndex, regionFilter, numberTypeFilter);
+
+  const masks: PossibilityLengthMasks = resolvePossibilityLengthMasks(
+    callingCodeState,
+    defaultRegionIndex,
+    regionFilter,
+    numberTypeFilter,
+  );
+
+  // Active filters that leave no possible length at all exclude the whole calling code (Telixon extension).
+  if ((regionFilter !== null || numberTypeFilter !== null) && masks.national === 0 && masks.localOnly === 0) {
+    return 'INVALID_CALLING_CODE';
+  }
 
   // Lengths valid only locally (never nationally) report as locally possible: libphonenumber testNumberLength.
-  const localOnlyMask: number =
-    getAllowedLocalOnlyLengthMask(regionIndex, regionFilter, numberTypeFilter) & ~nationalMask;
+  const localOnlyMask: number = masks.localOnly & ~masks.national;
   if (containsLength(localOnlyMask, length)) return 'IS_POSSIBLE_LOCAL_ONLY';
 
-  if (nationalMask === 0) return 'INVALID_LENGTH';
-  return validationResultFromLength(nationalMask, length);
+  if (masks.national === 0) return 'INVALID_LENGTH';
+  return validationResultFromLength(masks.national, length);
 }

--- a/packages/core/src/modules/phone-number/to-resolved-phone-number.ts
+++ b/packages/core/src/modules/phone-number/to-resolved-phone-number.ts
@@ -1,13 +1,9 @@
-import { NumberResolverSnapshot } from '../number-resolver/models';
+import { ResolvedNumberState } from '../number-resolver/resolve-number';
 import { ResolvedPhoneNumber } from './models';
 
-// Builds the query view from one snapshot, so every method reads a consistent point-in-time capture.
-export function toResolvedPhoneNumber(
-  snapshot: NumberResolverSnapshot,
-  defaultRegionIndex: number,
-  nationalPrefixPresent: boolean,
-  readAsNational: boolean,
-): ResolvedPhoneNumber {
+// Builds the query view from one resolved state, so every method reads a consistent point-in-time capture.
+export function toResolvedPhoneNumber(resolved: ResolvedNumberState, defaultRegionIndex: number): ResolvedPhoneNumber {
+  const { snapshot } = resolved;
   return {
     nationalDigits: snapshot.nationalDigits,
     callingCode: snapshot.callingCodeDigits,
@@ -16,8 +12,9 @@ export function toResolvedPhoneNumber(
     defaultRegionIndex,
     regionFilter: snapshot.regionFilter,
     numberTypeFilter: snapshot.numberTypeFilter,
-    nationalPrefixPresent,
-    readAsNational,
+    nationalPrefixPresent: resolved.nationalPrefixPresent,
+    readAsNational: resolved.readAsNational,
+    callingCodeSeeded: resolved.callingCodeSeeded,
     strict: snapshot.strict,
   };
 }


### PR DESCRIPTION
## Summary

Selector-mode `getPhoneNumber` and region-filtered queries returned incoherent `PhoneNumber`
objects (valid yet not possible, an error on a valid number, `INVALID_LENGTH` with an empty list, a
region the filter excludes). Selector mode now resolves the digits literally behind the seeded
calling code. Filtered length masks union the allowed regions. Region resolution skips excluded
regions. Adds one `ValidationError` variant, `NATIONAL_PREFIX_PRESENT`. `parsePhoneNumber` and the
code-in-input and national controllers are unchanged.

## Motivation

Live demos surfaced three coherence defects in the same family. A `PhoneNumber` must stay
self-consistent across `isValid`, `isPossible`, `getValidationError`, `getRegion`, and the formats.

## Conformance impact

Query methods only; the engine is untouched. `parsePhoneNumber` keeps exact parity, and the new
variant arises only in selector mode. `pnpm conformance` passes (24 tests).

## Checklist

- [x] Tests added (`phone-number-coherence.test.ts`; extended controller-consistency)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass (435 unit, 24 conformance)
- [x] Docs updated (`ValidationError`, `PhoneNumber`, `InputController`, guides)
- [x] Commit message follows convention