### PR TITLE
fix(core): walk the seeded calling code past region and type filters

### DIFF
--- a/packages/core/src/modules/input-controller/__tests__/phone-number-coherence.test.ts
+++ b/packages/core/src/modules/input-controller/__tests__/phone-number-coherence.test.ts
@@ -33,6 +33,7 @@ const US_TOLL_FREE = getExampleNumber('US', 'TOLL_FREE');
 const BY_MOBILE = getExampleNumber('BY', 'MOBILE');
 const AU_MOBILE = getExampleNumber('AU', 'MOBILE');
 const GG_MOBILE = getExampleNumber('GG', 'MOBILE');
+const GB_MOBILE = getExampleNumber('GB', 'MOBILE');
 
 function queryAnswers(phoneNumber: PhoneNumber): Record<string, unknown> {
   const answers: Record<string, unknown> = {};
@@ -263,6 +264,42 @@ describe('Region filters keep every query coherent', () => {
 
     expectCoherent(gapNumber, 'selector', ['GG']);
     expect(gapNumber.getValidationError()).toEqual({ kind: 'INVALID_LENGTH', possibleLengths: [7, 9, 10] });
+  });
+
+  it('keeps the typed digits intact in selector mode while the filter excludes the selected region', () => {
+    const controller = createSelectorController('GB');
+    const typed = controller.setValue(GB_MOBILE);
+
+    const filtered = controller.setRegionFilter(['US']);
+    const phoneNumber = controller.getPhoneNumber();
+
+    expectCoherent(phoneNumber, 'selector', ['US']);
+    expect(filtered.value.replace(/\D/g, '')).toBe(GB_MOBILE);
+    expect(phoneNumber.getCallingCode()).toBe('44');
+    expect(phoneNumber.getNationalNumber()).toBe(GB_MOBILE);
+    expect(phoneNumber.getValidationError()?.kind).toBe('INVALID_CALLING_CODE');
+
+    const restored = controller.setRegionFilter(null);
+    expect(restored.value).toBe(typed.value);
+    expect(restored.region).toBe(typed.region);
+    expect(controller.getPhoneNumber().getValidationError()).toBeNull();
+  });
+
+  it('keeps the seeded calling code out of the national digits in national mode under an excluding filter', () => {
+    const controller = createNationalInputController({ defaultRegion: 'GB' });
+    const typed = controller.setValue(`0${GB_MOBILE}`);
+
+    controller.setRegionFilter(['US']);
+    const phoneNumber = controller.getPhoneNumber();
+
+    expectCoherent(phoneNumber, 'national');
+    expect(phoneNumber.getCallingCode()).toBe('44');
+    expect(phoneNumber.getNationalNumber()).toBe(GB_MOBILE);
+    expect(phoneNumber.getValidationError()?.kind).toBe('INVALID_CALLING_CODE');
+
+    const restored = controller.setRegionFilter(null);
+    expect(restored.value).toBe(typed.value);
+    expect(controller.getPhoneNumber().getValidationError()).toBeNull();
   });
 
   it('reports INVALID_CALLING_CODE when the filter excludes every region of the calling code', () => {

--- a/packages/core/src/modules/number-resolver/__tests__/number-resolver.test.ts
+++ b/packages/core/src/modules/number-resolver/__tests__/number-resolver.test.ts
@@ -143,6 +143,18 @@ describe('NumberResolver: filters', () => {
     expect(resolver.snapshot.numberTypeFilter).toBeNull();
   });
 
+  it('walks a seeded calling code past an excluding region filter', () => {
+    const resolver = new NumberResolver();
+    resolver.setRegionFilter(createRegionFilter(['US']));
+
+    resolver.setCallingCode('44');
+    advanceAll(resolver, '7400123456');
+
+    expect(resolver.getCallingCode()).toBe('44');
+    expect(resolver.callingCodeCompleted).toBe(true);
+    expect(resolver.getNationalNumber()).toBe('7400123456');
+  });
+
   it('setStrict toggles the strict flag in the snapshot', () => {
     const resolver = new NumberResolver();
 

--- a/packages/core/src/modules/number-resolver/number-resolver.ts
+++ b/packages/core/src/modules/number-resolver/number-resolver.ts
@@ -33,6 +33,8 @@ export class NumberResolver {
 
   private _strict: boolean = false;
 
+  private _seedingCallingCode: boolean = false;
+
   advance(digit: number): void {
     const digitChar: string = String.fromCharCode(48 + digit);
 
@@ -42,7 +44,8 @@ export class NumberResolver {
     }
 
     let state: number = stepDigit(this.engine, this._state, digit);
-    const filtersActive: boolean = this._regionFilter !== null || this._numberTypeFilter !== null;
+    const filtersActive: boolean =
+      !this._seedingCallingCode && (this._regionFilter !== null || this._numberTypeFilter !== null);
 
     if (
       state !== ENGINE_DEAD &&
@@ -80,9 +83,12 @@ export class NumberResolver {
   setCallingCode(code: string): void {
     this.reset();
 
+    // The seeded code is a fixed premise, so it walks past the filters; exclusion still reports INVALID_CALLING_CODE.
+    this._seedingCallingCode = true;
     for (let i = 0; i < code.length; i++) {
       this.advance(code.charCodeAt(i) - 48);
     }
+    this._seedingCallingCode = false;
   }
 
   reset(): void {


### PR DESCRIPTION
## Summary

The seeded calling code (selector and national modes) now walks past the region and number-type
filters. Filters keep deciding the verdicts, so an excluding filter still reports
`INVALID_CALLING_CODE`. Typed international input keeps its exact behavior.

## Motivation

A filter that excluded every region of the seeded calling code killed the seed walk. The seed
digits leaked into the national digits. In selector mode the corrupted display survived filter
removal and overwrote the last clean history entry, which made the typed number unrecoverable.

## Conformance impact

Query behavior changes only under active filters, a Telixon extension outside the parity surface.
Unfiltered resolution is byte-identical.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention
