### PR TITLE
fix(core): stop filters from deleting selected digits and report the …

### DIFF
--- a/apps/docs/src/content/docs/core/reference/input-controller.mdx
+++ b/apps/docs/src/content/docs/core/reference/input-controller.mdx
@@ -77,7 +77,9 @@ interface InputState {
 ```
 
 The next value and caret to apply to the field. `value` is the formatted string. `region` is the
-region the value resolves to, or `null` when none does. The selection indices point into `value`.
+region the value resolves to, or `null` when none does. A field with no digits reports the
+configured default region, so clearing the value keeps the region stable. The selection indices
+point into `value`.
 Within a shared calling code, `region` reports the resolved owner of the digits: a `604` number
 reports `CA` even in a US-configured field.
 

--- a/packages/core/src/modules/input-controller/__tests__/filter-recompute.test.ts
+++ b/packages/core/src/modules/input-controller/__tests__/filter-recompute.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { createInternationalInputController } from '../international-input-controller';
+import { createNationalInputController } from '../national-input-controller';
+
+// The filter setters re-render the current value; they must never act on the stored range selection.
+
+describe('Filter recompute with a stored range selection', () => {
+  it('keeps every digit and the selection after undo restores a range (international)', () => {
+    const controller = createInternationalInputController({ defaultRegion: 'US' });
+    const seeded = controller.setValue('12015550123');
+
+    controller.deleteBackward(seeded.value, 2, 7);
+    const restored = controller.undo();
+    expect(restored.value).toBe(seeded.value);
+    expect([restored.selectionStart, restored.selectionEnd]).toEqual([2, 7]);
+
+    const regionFiltered = controller.setRegionFilter(['US', 'CA']);
+    expect(regionFiltered.value).toBe(seeded.value);
+    expect([regionFiltered.selectionStart, regionFiltered.selectionEnd]).toEqual([2, 7]);
+
+    const typeFiltered = controller.setNumberTypeFilter(['MOBILE']);
+    expect(typeFiltered.value).toBe(seeded.value);
+    expect([typeFiltered.selectionStart, typeFiltered.selectionEnd]).toEqual([2, 7]);
+  });
+
+  it('keeps every digit and the selection after undo restores a range (national)', () => {
+    const controller = createNationalInputController({ defaultRegion: 'US' });
+    const seeded = controller.setValue('2015550123');
+
+    controller.deleteBackward(seeded.value, 1, 6);
+    const restored = controller.undo();
+    expect(restored.value).toBe(seeded.value);
+    expect([restored.selectionStart, restored.selectionEnd]).toEqual([1, 6]);
+
+    const typeFiltered = controller.setNumberTypeFilter(['MOBILE']);
+    expect(typeFiltered.value).toBe(seeded.value);
+    expect([typeFiltered.selectionStart, typeFiltered.selectionEnd]).toEqual([1, 6]);
+
+    const regionFiltered = controller.setRegionFilter(['US']);
+    expect(regionFiltered.value).toBe(seeded.value);
+  });
+
+  it('moves to the rendered caret when the excluding filter changes the rendered value', () => {
+    const controller = createInternationalInputController({
+      defaultRegion: 'UA',
+      display: { callingCodeInInput: false },
+    });
+    const seeded = controller.setValue('501234567');
+
+    controller.deleteBackward(seeded.value, 0, 4);
+    const restored = controller.undo();
+    expect(restored.value).toBe(seeded.value);
+
+    // The excluding filter drops formatting, and every digit survives with a collapsed caret.
+    const filtered = controller.setRegionFilter(['US']);
+    expect(filtered.value.replace(/\D/g, '')).toBe('501234567');
+    expect(filtered.selectionStart).toBe(filtered.selectionEnd);
+
+    const cleared = controller.setRegionFilter(null);
+    expect(cleared.value).toBe(seeded.value);
+  });
+});

--- a/packages/core/src/modules/input-controller/international-input-controller/__tests__/international-input-controller.test.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/__tests__/international-input-controller.test.ts
@@ -149,6 +149,27 @@ describe('InternationalInputController region resolution', () => {
     // No digits are added by setRegion alone: value stays empty.
     expect(state.value).toBe('');
   });
+
+  it('reports the default region while the field holds no digits', () => {
+    const controller = createInternationalInputController({ defaultRegion: 'US' });
+
+    expect(controller.setValue('').region).toBe('US');
+    expect(controller.setValue('+').region).toBe('US');
+  });
+
+  it('reports null for an empty field without a default region', () => {
+    const controller = createInternationalInputController();
+
+    expect(controller.currentState.region).toBe(null);
+  });
+
+  it('keeps null once digits are present and resolve nothing', () => {
+    const controller = createInternationalInputController({ defaultRegion: 'US' });
+    // '0' opens no calling code, so the walk dies with a digit in the field.
+    const state = controller.setValue('+0');
+
+    expect(state.region).toBe(null);
+  });
 });
 
 describe('InternationalInputController caret across boundaries', () => {

--- a/packages/core/src/modules/input-controller/international-input-controller/international-input-controller.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/international-input-controller.ts
@@ -109,6 +109,7 @@ class InternationalInputController implements InputController {
       this.config.display,
       direction,
       plusErased,
+      this.#defaultRegionIndex,
     );
   }
 
@@ -324,17 +325,21 @@ class InternationalInputController implements InputController {
 
   #recomputeState(): InputState {
     const { value, selectionStart, selectionEnd } = this.#history.current;
+    // A pure re-render of the current value; the collapsed caret keeps the stored range out of the edit path.
     const nextState: InputControllerState = this.#resolveState(
       value,
       {
         insertText: '',
         selectionStart,
-        selectionEnd,
+        selectionEnd: selectionStart,
       },
       'forward',
       this.#plusErased,
     );
-    this.#history.replaceCurrent(nextState);
+    // An unchanged render keeps the stored selection, so a filter call never moves the caret.
+    const renderedState: InputControllerState =
+      nextState.value === value ? { ...nextState, selectionStart, selectionEnd } : nextState;
+    this.#history.replaceCurrent(renderedState);
     return toInputState(this.#history.current);
   }
 

--- a/packages/core/src/modules/input-controller/international-input-controller/utils/resolve-international-controller-state.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/utils/resolve-international-controller-state.ts
@@ -25,6 +25,7 @@ export function resolveInternationalControllerState(
   display: InternationalDisplayConfig = DEFAULT_DISPLAY,
   direction: FormattingDirection = 'forward',
   plusErased: boolean = false,
+  defaultRegionIndex: number = -1,
 ): InputControllerState {
   const resourceProvider = getResourceProvider();
 
@@ -88,6 +89,9 @@ export function resolveInternationalControllerState(
     const primaryRegionIndex: number = resolvePrimaryRegionIndex(snapshot.callingCodeState, -1);
 
     region = resourceProvider.regionIds[primaryRegionIndex] ?? null;
+  } else if (snapshot.callingCodeDigits === '' && snapshot.nationalDigits === '') {
+    // A field with no digits reports the configured default region, matching the seeded modes.
+    region = resourceProvider.regionIds[defaultRegionIndex] ?? null;
   }
 
   let value: string;

--- a/packages/core/src/modules/input-controller/models/index.ts
+++ b/packages/core/src/modules/input-controller/models/index.ts
@@ -6,7 +6,7 @@ import { PhoneNumber } from '../../phone-number/models';
 export interface InputState {
   /** The formatted string to place in the field. */
   readonly value: string;
-  /** The region the value resolves to, or `null` when none does. */
+  /** The region the value resolves to, or `null` when none does; a field with no digits reports the configured default region. */
   readonly region: RegionCode | null;
   /** Caret start, as an index into `value`. */
   readonly selectionStart: number;

--- a/packages/core/src/modules/input-controller/national-input-controller/national-input-controller.ts
+++ b/packages/core/src/modules/input-controller/national-input-controller/national-input-controller.ts
@@ -277,12 +277,16 @@ class NationalInputController implements InputController {
 
   #recomputeState(): InputState {
     const { value, selectionStart, selectionEnd } = this.#history.current;
+    // A pure re-render of the current value; the collapsed caret keeps the stored range out of the edit path.
     const nextState: InputControllerState = this.#resolveState(value, {
       insertText: '',
       selectionStart,
-      selectionEnd,
+      selectionEnd: selectionStart,
     });
-    this.#history.replaceCurrent(nextState);
+    // An unchanged render keeps the stored selection, so a filter call never moves the caret.
+    const renderedState: InputControllerState =
+      nextState.value === value ? { ...nextState, selectionStart, selectionEnd } : nextState;
+    this.#history.replaceCurrent(renderedState);
     return toInputState(this.#history.current);
   }
 


### PR DESCRIPTION
## Summary

Two input-controller state fixes. The filter setters now re-render the current value through a
collapsed caret, so a stored range selection is never replayed as an edit; when the render is
unchanged they also keep the selection in place. `InputState.region` reports the configured
`defaultRegion` while the field holds no digits; typed digits keep deciding the region.

## Motivation

Calling `setRegionFilter` or `setNumberTypeFilter` after an undo silently deleted the digits
inside the restored selection in both controllers. An empty field reported `region: null` even
with a configured `defaultRegion`, so region-bound UI blinked on every clear.

## Conformance impact

Controller state only; engine and query methods are untouched. The CI parity gate covers the PR.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention