### PR TITLE
Fix/international setvalue fixed point

### DIFF
--- a/packages/core/src/modules/input-controller/__tests__/fuzz-support.ts
+++ b/packages/core/src/modules/input-controller/__tests__/fuzz-support.ts
@@ -1,0 +1,124 @@
+import type { NumberType, RegionCode } from '../../../engine';
+import { getCallingCodeForRegion } from '../../calling-code-for-region';
+import type { PhoneNumber } from '../../phone-number';
+import type { InputState } from '../models';
+
+// Shared pieces for the controller fuzz tests. Both controllers owe the same structural
+// guarantees. Both are driven with the same regions and payloads.
+
+// Regions chosen to cover the hard cases. AR writes extra digits into the display, BY and BR hide
+// a typed digit, US and CA share one calling code. The rest are ordinary formats.
+export const REGIONS: readonly RegionCode[] = [
+  'US',
+  'CA',
+  'GB',
+  'AR',
+  'BY',
+  'BR',
+  'DE',
+  'FR',
+  'IT',
+  'ES',
+  'MX',
+  'RU',
+  'UA',
+  'AU',
+  'NL',
+  'PL',
+  'JP',
+  'IN',
+  'ZA',
+  'SE',
+];
+
+export const NUMBER_TYPES: readonly NumberType[] = [
+  'FIXED_LINE',
+  'MOBILE',
+  'FIXED_LINE_OR_MOBILE',
+  'TOLL_FREE',
+  'PREMIUM_RATE',
+  'VOIP',
+  'PAGER',
+  'UAN',
+];
+
+// Bare digits, formatted text, a leading plus, and non-digit noise all reach a real field.
+export const INSERT_PAYLOADS: readonly string[] = [
+  '5',
+  '12',
+  '007',
+  '15',
+  '+549',
+  '(201) 555',
+  '+44 20',
+  '  9-9 ',
+  '00',
+  'abc',
+  '+',
+  '() -',
+  '99999999999999',
+];
+
+export const COMPARED_METHODS = [
+  'isValid',
+  'isPossible',
+  'isPossibleWithReason',
+  'getNumberType',
+  'getNationalNumber',
+  'getCallingCode',
+  'getRegion',
+  'formatE164',
+  'formatNational',
+  'formatInternational',
+  'formatRfc3966',
+] as const;
+
+/** Deterministic generator so any failure replays from its session index alone. */
+export function createRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let mixed = Math.imul(state ^ (state >>> 15), 1 | state);
+    mixed = (mixed + Math.imul(mixed ^ (mixed >>> 7), 61 | mixed)) ^ mixed;
+    return ((mixed ^ (mixed >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function methodResults(phoneNumber: PhoneNumber): Record<string, string> {
+  const results: Record<string, string> = {};
+  const callable = phoneNumber as unknown as Record<string, () => unknown>;
+  for (const method of COMPARED_METHODS) results[method] = String(callable[method]!());
+  return results;
+}
+
+export function firstMethodDifference(actual: Record<string, string>, expected: Record<string, string>): string | null {
+  for (const method of COMPARED_METHODS) {
+    if (actual[method] !== expected[method]) return `${method} is ${actual[method]}, expected ${expected[method]}`;
+  }
+  return null;
+}
+
+export function caretViolation(state: InputState): string | null {
+  const { value, selectionStart, selectionEnd } = state;
+  if (!Number.isInteger(selectionStart) || !Number.isInteger(selectionEnd)) return 'caret is not an integer';
+  if (selectionStart < 0 || selectionStart > selectionEnd) return `caret range ${selectionStart}..${selectionEnd}`;
+  if (selectionEnd > value.length) return `caret ${selectionEnd} past ${JSON.stringify(value)}`;
+  return null;
+}
+
+/** A region whose calling code differs, so a number of `callingCode` cannot be valid under it. */
+export function regionWithForeignCallingCode(callingCode: string | null): RegionCode {
+  for (const region of REGIONS) {
+    if (getCallingCodeForRegion(region) !== callingCode) return region;
+  }
+  return REGIONS[0]!;
+}
+
+export function digitsOf(value: string): string {
+  let digits = '';
+  for (let index = 0; index < value.length; index++) {
+    const code: number = value.charCodeAt(index);
+    if (code >= 48 && code <= 57) digits += value[index];
+  }
+  return digits;
+}

--- a/packages/core/src/modules/input-controller/international-input-controller/__tests__/international-input-controller.test.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/__tests__/international-input-controller.test.ts
@@ -109,6 +109,18 @@ describe('InternationalInputController formatting modes', () => {
     expect(state.region).toBe('GB');
     expect(state.value.replace(/\D/g, '')).toBe(GB_MOBILE_E164_DIGITS);
   });
+
+  it('re-setting the shown value is a fixed point after a delete trims the separator', () => {
+    const controller = createInternationalInputController({
+      defaultRegion: 'FR',
+      display: { callingCodeInInput: false },
+    });
+    const seeded = controller.setValue('26');
+    const trimmed = controller.deleteBackward(seeded.value, seeded.value.length, seeded.value.length);
+
+    // The backward render dropped the trailing separator; re-setting that value keeps it dropped.
+    expect(controller.setValue(trimmed.value).value).toBe(trimmed.value);
+  });
 });
 
 describe('InternationalInputController region resolution', () => {

--- a/packages/core/src/modules/input-controller/international-input-controller/__tests__/method-fuzz.test.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/__tests__/method-fuzz.test.ts
@@ -1,76 +1,54 @@
 import { describe, expect, it } from 'vitest';
-import { createNationalInputController } from '..';
+import { createInternationalInputController } from '..';
 import type { NumberType, RegionCode } from '../../../../engine';
 import { parsePhoneNumber } from '../../../parse-phone-number';
-import type { PhoneNumber } from '../../../phone-number';
 import {
   caretViolation,
   createRandom,
+  digitsOf,
   firstMethodDifference,
   INSERT_PAYLOADS,
   methodResults,
   NUMBER_TYPES,
   REGIONS,
-  regionWithForeignCallingCode,
 } from '../../__tests__/fuzz-support';
 import type { InputState } from '../../models';
+import type { PlusPrefixMode } from '../models';
 
 // Calls every public controller method in a random order and re-checks the invariants after each
 // call. A session is seeded from its index. A failure prints the exact sequence that replays it.
 //
-// Invariants: the caret stays inside the value, undo then redo returns the same value, setValue of
-// the shown value changes nothing, and with no filter active getPhoneNumber answers exactly what
-// parsePhoneNumber answers for the shown value.
+// The two display modes answer different questions. With the calling code in the field the value
+// carries it, and getPhoneNumber must equal parsePhoneNumber of that value. In selector mode the
+// field holds only the significant number, and getPhoneNumber reads it literally, so the check
+// there is that the reported national number is exactly the digits on screen.
 
-type Controller = ReturnType<typeof createNationalInputController>;
+type Controller = ReturnType<typeof createInternationalInputController>;
 
 const SESSIONS = 3000;
 const OPERATIONS_PER_SESSION = 40;
 
-/**
- * Checks two things about the region filter. Filtering to the region the number already resolved to
- * must change nothing. Filtering to a region with a different calling code must make it invalid.
- * Leaves the filter cleared on every path.
- */
-function regionFilterViolation(controller: Controller): string | null {
-  // Clearing first makes the baseline the unfiltered answer.
-  controller.setRegionFilter(null);
-  const before: PhoneNumber = controller.getPhoneNumber();
-  const resolvedRegion: RegionCode | null = before.getRegion();
-  const baseline: Record<string, string> = methodResults(before);
-  let violation: string | null = null;
-
-  if (resolvedRegion !== null) {
-    controller.setRegionFilter([resolvedRegion]);
-    const admittedDifference: string | null = firstMethodDifference(
-      methodResults(controller.getPhoneNumber()),
-      baseline,
-    );
-
-    const foreignRegion: RegionCode = regionWithForeignCallingCode(before.getCallingCode());
-    controller.setRegionFilter([foreignRegion]);
-    const survivesExclusion: boolean = controller.getPhoneNumber().isValid();
-
-    if (admittedDifference !== null) {
-      violation = `filter [${resolvedRegion}] changed the resolution: ${admittedDifference}`;
-    } else if (survivesExclusion) {
-      violation = `filter [${foreignRegion}] left a ${resolvedRegion} number valid`;
-    }
-  }
-
-  controller.setRegionFilter(null);
-  return violation;
-}
+const PLUS_PREFIXES: readonly PlusPrefixMode[] = ['none', 'fixed', 'erasable'];
 
 function runSession(session: number): string | null {
-  const random = createRandom(0x9e3779b9 ^ (session * 2654435761));
+  const random = createRandom(0x85ebca6b ^ (session * 2246822519));
   const pick = <Item>(items: readonly Item[]): Item => items[Math.floor(random() * items.length)]!;
   const upTo = (bound: number): number => Math.floor(random() * bound);
 
+  const selectorMode: boolean = random() < 0.35;
   let region: RegionCode = pick(REGIONS);
-  const strict: boolean = random() < 0.25;
-  const controller: Controller = createNationalInputController({ defaultRegion: region, strict });
-  const history: string[] = [`new(${region}, strict=${strict})`];
+  const plusPrefix: PlusPrefixMode = pick(PLUS_PREFIXES);
+
+  const controller: Controller = selectorMode
+    ? createInternationalInputController({ defaultRegion: region, display: { callingCodeInInput: false } })
+    : createInternationalInputController({ display: { callingCodeInInput: true, plusPrefix } });
+
+  const opening: string = selectorMode ? `selector(${region})` : `callingCode(plus=${plusPrefix})`;
+  const history: string[] = [`new ${opening}`];
+  // getPhoneNumber resolves with hasLeadingPlus and a default region together. parsePhoneNumber
+  // cannot express that pair, since its defaultRegion option makes it read the value as a national
+  // number instead. Once setRegion anchors the controller, the parser stops being a valid oracle.
+  let comparableToParser = true;
   let regionFilterActive = false;
   let numberTypeFilterActive = false;
 
@@ -83,7 +61,7 @@ function runSession(session: number): string | null {
     let state: InputState;
     let label: string;
 
-    switch (upTo(13)) {
+    switch (upTo(12)) {
       case 0:
       case 1: {
         const payload: string = pick(INSERT_PAYLOADS);
@@ -118,7 +96,7 @@ function runSession(session: number): string | null {
         break;
       }
       case 7: {
-        const digits: string = Array.from({ length: upTo(14) }, () => String(upTo(10))).join('');
+        const digits: string = Array.from({ length: upTo(15) }, () => String(upTo(10))).join('');
         label = `setValue(${JSON.stringify(digits)})`;
         state = controller.setValue(digits);
         break;
@@ -134,21 +112,16 @@ function runSession(session: number): string | null {
       }
       case 9: {
         region = pick(REGIONS);
+        comparableToParser = false;
         label = `setRegion(${region})`;
         state = controller.setRegion(region);
         break;
       }
       case 10: {
-        if (random() < 0.35) {
+        if (random() < 0.4) {
           label = 'setRegionFilter(null)';
           state = controller.setRegionFilter(null);
           regionFilterActive = false;
-        } else if (random() < 0.5) {
-          const violation: string | null = regionFilterViolation(controller);
-          label = 'regionFilter oracle';
-          if (violation !== null) return fail(`${label}: ${violation}`);
-          regionFilterActive = false;
-          state = controller.currentState;
         } else {
           const regions: RegionCode[] = Array.from({ length: 1 + upTo(3) }, () => pick(REGIONS));
           label = `setRegionFilter([${regions.join(',')}])`;
@@ -157,20 +130,20 @@ function runSession(session: number): string | null {
         }
         break;
       }
-      case 11: {
-        if (random() < 0.35) {
-          label = 'setNumberTypeFilter(null)';
-          state = controller.setNumberTypeFilter(null);
-          numberTypeFilterActive = false;
-        } else {
-          const types: NumberType[] = Array.from({ length: 1 + upTo(3) }, () => pick(NUMBER_TYPES));
-          label = `setNumberTypeFilter([${types.join(',')}])`;
-          state = controller.setNumberTypeFilter(types);
-          numberTypeFilterActive = true;
-        }
-        break;
-      }
       default: {
+        if (random() < 0.3) {
+          if (random() < 0.4) {
+            label = 'setNumberTypeFilter(null)';
+            state = controller.setNumberTypeFilter(null);
+            numberTypeFilterActive = false;
+          } else {
+            const types: NumberType[] = Array.from({ length: 1 + upTo(3) }, () => pick(NUMBER_TYPES));
+            label = `setNumberTypeFilter([${types.join(',')}])`;
+            state = controller.setNumberTypeFilter(types);
+            numberTypeFilterActive = true;
+          }
+          break;
+        }
         if (random() < 0.2) {
           label = 'clearHistory()';
           controller.clearHistory();
@@ -194,11 +167,23 @@ function runSession(session: number): string | null {
     const caret: string | null = caretViolation(state);
     if (caret !== null) return fail(`${label} left ${caret}`);
 
-    // parsePhoneNumber knows nothing about filters. Only compare while none is set.
-    if (!regionFilterActive && !numberTypeFilterActive) {
+    if (selectorMode) {
+      // The literal read never rewrites what the field shows.
+      const reported: string = controller.getPhoneNumber().getNationalNumber();
+      if (reported !== digitsOf(state.value)) {
+        return fail(`${label} reported ${reported} for a field showing ${JSON.stringify(state.value)}`);
+      }
+      continue;
+    }
+
+    // getPhoneNumber reads the field as an international number, with the calling code inside it.
+    // That is exactly what parsePhoneNumber does with no options. Three cases are left out. Filters
+    // narrow validity the parser knows nothing about. An empty field resolves to nothing by design.
+    // An anchored region is covered by the comment on comparableToParser.
+    if (comparableToParser && !regionFilterActive && !numberTypeFilterActive && digitsOf(state.value) !== '') {
       const difference: string | null = firstMethodDifference(
         methodResults(controller.getPhoneNumber()),
-        methodResults(parsePhoneNumber(state.value, { defaultRegion: region, strict })),
+        methodResults(parsePhoneNumber(state.value)),
       );
       if (difference !== null) {
         return fail(`${label} left getPhoneNumber disagreeing with parsePhoneNumber: ${difference}`);
@@ -209,7 +194,7 @@ function runSession(session: number): string | null {
   return null;
 }
 
-describe('national controller method fuzz', () => {
+describe('international controller method fuzz', () => {
   it('holds its invariants across randomised method combinations', () => {
     const failures: string[] = [];
     for (let session = 0; session < SESSIONS && failures.length === 0; session++) {

--- a/packages/core/src/modules/input-controller/international-input-controller/international-input-controller.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/international-input-controller.ts
@@ -271,6 +271,13 @@ class InternationalInputController implements InputController {
   }
 
   setValue(value: string): InputState {
+    // Re-setting the exact current value leaves the rendering untouched and only moves the caret to the end.
+    if (value === this.#history.current.value) {
+      const end: number = value.length;
+      this.#history.updateCurrentSelection(end, end);
+      return toInputStateWithSelection(this.#history.current, end, end);
+    }
+
     // With an erasable plus, the given string decides plus visibility; an empty string resets to an empty field.
     const plusErased: boolean = this.#plusErasable && !value.startsWith('+');
 


### PR DESCRIPTION
## Summary

`setValue` on the international controller re-rendered the value forward, which appended a trailing separator when the field already showed a delete-trimmed value. A field showing `2` became `2 ` on a re-set. Setting the exact value the field already shows now leaves the rendering untouched and moves only the caret. This mirrors the fix already applied to the national controller. Also adds a seeded fuzz for the international controller, which is what surfaced the bug, plus a shared harness that the national fuzz now reuses.

## Motivation

Closes #31. The international controller had no fuzz, leaving its plus handling, in-field calling code, and selector mode covered only by the conformance enumeration.

## Conformance impact

No engine change. The only behavior change is `setValue` called with the value already on screen, which previously reformatted it. `pnpm conformance` passes 24 of 24 locally.

## Checklist

- [x] Tests added or updated (named regression test plus the fuzz; both fail with the fix reverted)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally (459 tests)
- [x] Docs reflect the change (no public API change; the reference already describes this behavior)
- [x] Commit message follows the project convention
