### PR TITLE
test(core): tighten the international fuzz oracles

### DIFF
--- a/packages/core/src/modules/input-controller/__tests__/fuzz-support.ts
+++ b/packages/core/src/modules/input-controller/__tests__/fuzz-support.ts
@@ -3,8 +3,8 @@ import { getCallingCodeForRegion } from '../../calling-code-for-region';
 import type { PhoneNumber } from '../../phone-number';
 import type { InputState } from '../models';
 
-// Shared pieces for the controller fuzz tests. Both controllers owe the same structural
-// guarantees. Both are driven with the same regions and payloads.
+// Shared by the two controller fuzz tests. They check the same invariants and use the same regions
+// and payloads.
 
 // Regions chosen to cover the hard cases. AR writes extra digits into the display, BY and BR hide
 // a typed digit, US and CA share one calling code. The rest are ordinary formats.
@@ -73,7 +73,7 @@ export const COMPARED_METHODS = [
   'formatRfc3966',
 ] as const;
 
-/** Deterministic generator so any failure replays from its session index alone. */
+/** The same session index always produces the same run, which is how a failure gets replayed. */
 export function createRandom(seed: number): () => number {
   let state = seed >>> 0;
   return () => {
@@ -106,7 +106,7 @@ export function caretViolation(state: InputState): string | null {
   return null;
 }
 
-/** A region whose calling code differs, so a number of `callingCode` cannot be valid under it. */
+/** Finds a region on some other calling code. A number on `callingCode` can never be valid there. */
 export function regionWithForeignCallingCode(callingCode: string | null): RegionCode {
   for (const region of REGIONS) {
     if (getCallingCodeForRegion(region) !== callingCode) return region;
@@ -121,4 +121,45 @@ export function digitsOf(value: string): string {
     if (code >= 48 && code <= 57) digits += value[index];
   }
   return digits;
+}
+
+/** The minimal controller surface the region-filter oracle needs. */
+export interface FilterableController {
+  getPhoneNumber(): PhoneNumber;
+  setRegionFilter(regions: readonly RegionCode[] | null): unknown;
+}
+
+/**
+ * If the filter still allows the region the number resolved to, nothing about the number should
+ * change. If it allows only a region on another calling code, the number should stop being valid.
+ * Clears the filter before returning.
+ */
+export function regionFilterViolation(controller: FilterableController): string | null {
+  // Clearing first makes the baseline the unfiltered answer.
+  controller.setRegionFilter(null);
+  const before: PhoneNumber = controller.getPhoneNumber();
+  const resolvedRegion: RegionCode | null = before.getRegion();
+  const baseline: Record<string, string> = methodResults(before);
+  let violation: string | null = null;
+
+  if (resolvedRegion !== null) {
+    controller.setRegionFilter([resolvedRegion]);
+    const admittedDifference: string | null = firstMethodDifference(
+      methodResults(controller.getPhoneNumber()),
+      baseline,
+    );
+
+    const foreignRegion: RegionCode = regionWithForeignCallingCode(before.getCallingCode());
+    controller.setRegionFilter([foreignRegion]);
+    const survivesExclusion: boolean = controller.getPhoneNumber().isValid();
+
+    if (admittedDifference !== null) {
+      violation = `filter [${resolvedRegion}] changed the resolution: ${admittedDifference}`;
+    } else if (survivesExclusion) {
+      violation = `filter [${foreignRegion}] left a ${resolvedRegion} number valid`;
+    }
+  }
+
+  controller.setRegionFilter(null);
+  return violation;
 }

--- a/packages/core/src/modules/input-controller/international-input-controller/__tests__/method-fuzz.test.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/__tests__/method-fuzz.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { createInternationalInputController } from '..';
 import type { NumberType, RegionCode } from '../../../../engine';
+import { getCallingCodeForRegion } from '../../../calling-code-for-region';
 import { parsePhoneNumber } from '../../../parse-phone-number';
 import {
   caretViolation,
@@ -10,6 +11,7 @@ import {
   INSERT_PAYLOADS,
   methodResults,
   NUMBER_TYPES,
+  regionFilterViolation,
   REGIONS,
 } from '../../__tests__/fuzz-support';
 import type { InputState } from '../../models';
@@ -18,10 +20,9 @@ import type { PlusPrefixMode } from '../models';
 // Calls every public controller method in a random order and re-checks the invariants after each
 // call. A session is seeded from its index. A failure prints the exact sequence that replays it.
 //
-// The two display modes answer different questions. With the calling code in the field the value
-// carries it, and getPhoneNumber must equal parsePhoneNumber of that value. In selector mode the
-// field holds only the significant number, and getPhoneNumber reads it literally, so the check
-// there is that the reported national number is exactly the digits on screen.
+// The two modes need different checks. When the calling code sits in the field, the value is the
+// whole number. parsePhoneNumber of it has to give the same answers. In selector mode the field
+// holds only the significant part. The calling code then comes from the selected region.
 
 type Controller = ReturnType<typeof createInternationalInputController>;
 
@@ -30,12 +31,21 @@ const OPERATIONS_PER_SESSION = 40;
 
 const PLUS_PREFIXES: readonly PlusPrefixMode[] = ['none', 'fixed', 'erasable'];
 
+// getPhoneNumber always reads the field as an international number. The field does not always show
+// the plus. Adding it back lets parsePhoneNumber read the value the same way.
+const forcedPlus = (value: string): string => (value.startsWith('+') ? value : `+${value}`);
+
 function runSession(session: number): string | null {
   const random = createRandom(0x85ebca6b ^ (session * 2246822519));
   const pick = <Item>(items: readonly Item[]): Item => items[Math.floor(random() * items.length)]!;
   const upTo = (bound: number): number => Math.floor(random() * bound);
 
   const selectorMode: boolean = random() < 0.35;
+  // getPhoneNumber reads the field with a forced plus and a default region at once. No single
+  // parsePhoneNumber call can do both. Without options it cannot see the region. With defaultRegion
+  // it reads the value as a national number instead. That is why a calling-code session picks a
+  // side. It either moves the region around or keeps comparing against the parser.
+  const anchoredSession: boolean = random() < 0.4;
   let region: RegionCode = pick(REGIONS);
   const plusPrefix: PlusPrefixMode = pick(PLUS_PREFIXES);
 
@@ -45,10 +55,6 @@ function runSession(session: number): string | null {
 
   const opening: string = selectorMode ? `selector(${region})` : `callingCode(plus=${plusPrefix})`;
   const history: string[] = [`new ${opening}`];
-  // getPhoneNumber resolves with hasLeadingPlus and a default region together. parsePhoneNumber
-  // cannot express that pair, since its defaultRegion option makes it read the value as a national
-  // number instead. Once setRegion anchors the controller, the parser stops being a valid oracle.
-  let comparableToParser = true;
   let regionFilterActive = false;
   let numberTypeFilterActive = false;
 
@@ -111,17 +117,28 @@ function runSession(session: number): string | null {
         break;
       }
       case 9: {
+        if (!selectorMode && !anchoredSession) {
+          const digit: string = String(upTo(10));
+          label = `insert(${digit} @${rangeStart})`;
+          state = controller.insert(value, digit, rangeStart, rangeStart);
+          break;
+        }
         region = pick(REGIONS);
-        comparableToParser = false;
         label = `setRegion(${region})`;
         state = controller.setRegion(region);
         break;
       }
       case 10: {
-        if (random() < 0.4) {
+        if (random() < 0.3) {
           label = 'setRegionFilter(null)';
           state = controller.setRegionFilter(null);
           regionFilterActive = false;
+        } else if (random() < 0.5) {
+          const violation: string | null = regionFilterViolation(controller);
+          label = 'regionFilter oracle';
+          if (violation !== null) return fail(`${label}: ${violation}`);
+          regionFilterActive = false;
+          state = controller.currentState;
         } else {
           const regions: RegionCode[] = Array.from({ length: 1 + upTo(3) }, () => pick(REGIONS));
           label = `setRegionFilter([${regions.join(',')}])`;
@@ -168,22 +185,38 @@ function runSession(session: number): string | null {
     if (caret !== null) return fail(`${label} left ${caret}`);
 
     if (selectorMode) {
+      const literal = controller.getPhoneNumber();
+      const shownDigits: string = digitsOf(state.value);
+
       // The literal read never rewrites what the field shows.
-      const reported: string = controller.getPhoneNumber().getNationalNumber();
-      if (reported !== digitsOf(state.value)) {
-        return fail(`${label} reported ${reported} for a field showing ${JSON.stringify(state.value)}`);
+      if (literal.getNationalNumber() !== shownDigits) {
+        return fail(
+          `${label} reported ${literal.getNationalNumber()} for a field showing ${JSON.stringify(state.value)}`,
+        );
+      }
+
+      // Behind the selected region's calling code the parser sees the same number. Its leniency
+      // sometimes drops digits. The two then describe different numbers, and there is nothing to
+      // compare.
+      if (!regionFilterActive && !numberTypeFilterActive && shownDigits !== '') {
+        const parsed = parsePhoneNumber(`+${getCallingCodeForRegion(region)}${state.value}`);
+        if (parsed.getNationalNumber() === shownDigits) {
+          const difference: string | null = firstMethodDifference(methodResults(literal), methodResults(parsed));
+          if (difference !== null) {
+            return fail(`${label} left the literal read disagreeing with parsePhoneNumber: ${difference}`);
+          }
+        }
       }
       continue;
     }
 
-    // getPhoneNumber reads the field as an international number, with the calling code inside it.
-    // That is exactly what parsePhoneNumber does with no options. Three cases are left out. Filters
-    // narrow validity the parser knows nothing about. An empty field resolves to nothing by design.
-    // An anchored region is covered by the comment on comparableToParser.
-    if (comparableToParser && !regionFilterActive && !numberTypeFilterActive && digitsOf(state.value) !== '') {
+    // Some states have nothing to compare against. An anchored session has no sound oracle, as
+    // noted above. A filter narrows validity in a way the parser cannot know about. An empty field
+    // resolves to nothing on purpose, while the parser would still answer from the region.
+    if (!anchoredSession && !regionFilterActive && !numberTypeFilterActive && digitsOf(state.value) !== '') {
       const difference: string | null = firstMethodDifference(
         methodResults(controller.getPhoneNumber()),
-        methodResults(parsePhoneNumber(state.value)),
+        methodResults(parsePhoneNumber(forcedPlus(state.value))),
       );
       if (difference !== null) {
         return fail(`${label} left getPhoneNumber disagreeing with parsePhoneNumber: ${difference}`);

--- a/packages/core/src/modules/input-controller/national-input-controller/__tests__/method-fuzz.test.ts
+++ b/packages/core/src/modules/input-controller/national-input-controller/__tests__/method-fuzz.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 import { createNationalInputController } from '..';
 import type { NumberType, RegionCode } from '../../../../engine';
 import { parsePhoneNumber } from '../../../parse-phone-number';
-import type { PhoneNumber } from '../../../phone-number';
 import {
   caretViolation,
   createRandom,
@@ -10,57 +9,22 @@ import {
   INSERT_PAYLOADS,
   methodResults,
   NUMBER_TYPES,
+  regionFilterViolation,
   REGIONS,
-  regionWithForeignCallingCode,
 } from '../../__tests__/fuzz-support';
 import type { InputState } from '../../models';
 
 // Calls every public controller method in a random order and re-checks the invariants after each
 // call. A session is seeded from its index. A failure prints the exact sequence that replays it.
 //
-// Invariants: the caret stays inside the value, undo then redo returns the same value, setValue of
-// the shown value changes nothing, and with no filter active getPhoneNumber answers exactly what
-// parsePhoneNumber answers for the shown value.
+// After every call a few things have to hold. The caret stays inside the value. Undo then redo
+// comes back to the same value. setValue of the value already shown changes nothing. While no
+// filter is set, getPhoneNumber answers exactly what parsePhoneNumber answers for that value.
 
 type Controller = ReturnType<typeof createNationalInputController>;
 
 const SESSIONS = 3000;
 const OPERATIONS_PER_SESSION = 40;
-
-/**
- * Checks two things about the region filter. Filtering to the region the number already resolved to
- * must change nothing. Filtering to a region with a different calling code must make it invalid.
- * Leaves the filter cleared on every path.
- */
-function regionFilterViolation(controller: Controller): string | null {
-  // Clearing first makes the baseline the unfiltered answer.
-  controller.setRegionFilter(null);
-  const before: PhoneNumber = controller.getPhoneNumber();
-  const resolvedRegion: RegionCode | null = before.getRegion();
-  const baseline: Record<string, string> = methodResults(before);
-  let violation: string | null = null;
-
-  if (resolvedRegion !== null) {
-    controller.setRegionFilter([resolvedRegion]);
-    const admittedDifference: string | null = firstMethodDifference(
-      methodResults(controller.getPhoneNumber()),
-      baseline,
-    );
-
-    const foreignRegion: RegionCode = regionWithForeignCallingCode(before.getCallingCode());
-    controller.setRegionFilter([foreignRegion]);
-    const survivesExclusion: boolean = controller.getPhoneNumber().isValid();
-
-    if (admittedDifference !== null) {
-      violation = `filter [${resolvedRegion}] changed the resolution: ${admittedDifference}`;
-    } else if (survivesExclusion) {
-      violation = `filter [${foreignRegion}] left a ${resolvedRegion} number valid`;
-    }
-  }
-
-  controller.setRegionFilter(null);
-  return violation;
-}
 
 function runSession(session: number): string | null {
   const random = createRandom(0x9e3779b9 ^ (session * 2654435761));


### PR DESCRIPTION
## Summary

The international fuzz checked less than the national one. It now runs the same region-filter oracle, which lives in the shared harness and serves both tests. Selector mode compares all eleven query methods behind the selected region's calling code, where before it only checked that the reported national number matched the digits on screen. Sessions are split so that a run either moves the region around or keeps comparing against the parser for its full length, where before the comparison died mid-session at the first `setRegion`. Test-only, no product code changes.

## Motivation

Closes #33. All three gaps were left in deliberately when the fuzz landed in #31 and recorded in the test.

A forced leading plus looked like it could give anchored sessions a parser oracle back, and it holds for ordinary numbers. It fails on a value with a leading zero, where the controller rescues the number through its region anchor while `+0190…` cannot be read as international. No single `parsePhoneNumber` call matches `getPhoneNumber` there, which is why the session split is the answer instead. The test carries that reasoning.

## Conformance impact

None. No engine or query-method behavior is touched. `pnpm conformance` passes 24 of 24 locally.

## Checklist

- [x] Tests added or updated (this change is the test)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally (459 tests)
- [x] Docs reflect the change (test-only, no public API or behavior change)
- [x] Commit message follows the project convention