### PR TITLE
Fix/number type filter possibility

### DIFF
--- a/packages/core/src/modules/input-controller/__tests__/fuzz-support.ts
+++ b/packages/core/src/modules/input-controller/__tests__/fuzz-support.ts
@@ -1,6 +1,7 @@
 import type { NumberType, RegionCode } from '../../../engine';
 import { getCallingCodeForRegion } from '../../calling-code-for-region';
 import type { PhoneNumber } from '../../phone-number';
+import { getPlaceholders } from '../../placeholders';
 import type { InputState } from '../models';
 
 // Shared by the two controller fuzz tests. They check the same invariants and use the same regions
@@ -98,6 +99,29 @@ export function firstMethodDifference(actual: Record<string, string>, expected: 
   return null;
 }
 
+// A filter that admits the number should not change what the number is or whether it is valid. The
+// possibility answer is left out on purpose. Regions on a shared calling code carry different
+// lengths, and the unfiltered check reads the main region while a filter reads the resolved one, so
+// a number possible under one is not always possible under the other. The valid-implies-possible
+// check below guards the possibility side instead.
+const POSSIBILITY_METHODS: ReadonlySet<string> = new Set(['isPossible', 'isPossibleWithReason']);
+
+function admittingFilterDifference(actual: Record<string, string>, expected: Record<string, string>): string | null {
+  for (const method of COMPARED_METHODS) {
+    if (POSSIBILITY_METHODS.has(method)) continue;
+    if (actual[method] !== expected[method]) return `${method} is ${actual[method]}, expected ${expected[method]}`;
+  }
+  return null;
+}
+
+/** A valid number is always possible. This must hold in every state, with or without a filter. */
+export function consistencyViolation(phoneNumber: PhoneNumber): string | null {
+  if (phoneNumber.isValid() && !phoneNumber.isPossible()) {
+    return `valid but not possible (${phoneNumber.getNationalNumber()})`;
+  }
+  return null;
+}
+
 export function caretViolation(state: InputState): string | null {
   const { value, selectionStart, selectionEnd } = state;
   if (!Number.isInteger(selectionStart) || !Number.isInteger(selectionEnd)) return 'caret is not an integer';
@@ -127,39 +151,101 @@ export function digitsOf(value: string): string {
 export interface FilterableController {
   getPhoneNumber(): PhoneNumber;
   setRegionFilter(regions: readonly RegionCode[] | null): unknown;
+  setNumberTypeFilter(numberTypes: readonly NumberType[] | null): unknown;
 }
 
 /**
- * If the filter still allows the region the number resolved to, nothing about the number should
- * change. If it allows only a region on another calling code, the number should stop being valid.
+ * A region filter that allows only a region on another calling code must make the number invalid.
+ * The filter is not asserted to leave an admitted number untouched. Regions on a shared calling
+ * code carry different lengths and prefixes, and the unfiltered answer reads the main region, so
+ * narrowing to the resolved region legitimately shifts the length, the format, and the digits.
  * Clears the filter before returning.
  */
 export function regionFilterViolation(controller: FilterableController): string | null {
-  // Clearing first makes the baseline the unfiltered answer.
+  // Clear both filters so the number is judged on its own, not on top of a leftover filter.
   controller.setRegionFilter(null);
+  controller.setNumberTypeFilter(null);
   const before: PhoneNumber = controller.getPhoneNumber();
   const resolvedRegion: RegionCode | null = before.getRegion();
-  const baseline: Record<string, string> = methodResults(before);
+  const callingCode: string | null = before.getCallingCode();
   let violation: string | null = null;
 
-  if (resolvedRegion !== null) {
-    controller.setRegionFilter([resolvedRegion]);
-    const admittedDifference: string | null = firstMethodDifference(
-      methodResults(controller.getPhoneNumber()),
-      baseline,
-    );
+  // A number that never cleared the calling-code stage names a region without resolving there.
+  const clearedCallingCode: boolean = String(before.isPossibleWithReason()) !== 'INVALID_CALLING_CODE';
 
-    const foreignRegion: RegionCode = regionWithForeignCallingCode(before.getCallingCode());
+  if (resolvedRegion !== null && callingCode !== null && clearedCallingCode) {
+    const foreignRegion: RegionCode = regionWithForeignCallingCode(callingCode);
     controller.setRegionFilter([foreignRegion]);
-    const survivesExclusion: boolean = controller.getPhoneNumber().isValid();
-
-    if (admittedDifference !== null) {
-      violation = `filter [${resolvedRegion}] changed the resolution: ${admittedDifference}`;
-    } else if (survivesExclusion) {
+    if (controller.getPhoneNumber().isValid()) {
       violation = `filter [${foreignRegion}] left a ${resolvedRegion} number valid`;
     }
   }
 
   controller.setRegionFilter(null);
+  controller.setNumberTypeFilter(null);
   return violation;
+}
+
+/**
+ * If the filter still allows the type the number reported, nothing about the number should change.
+ * A number reporting UNKNOWN is left alone, since no filter can name that type usefully. The reason
+ * may change. Narrowing to one type answers against that type's own lengths, so a length the region
+ * calls local-only can become fully possible.
+ * Clears the filter before returning.
+ */
+export function numberTypeFilterViolation(controller: FilterableController): string | null {
+  // Clear both filters so the type filter is measured on its own, not on top of a region filter.
+  controller.setRegionFilter(null);
+  controller.setNumberTypeFilter(null);
+  const before: PhoneNumber = controller.getPhoneNumber();
+  const reportedType: NumberType = before.getNumberType();
+  const baseline: Record<string, string> = methodResults(before);
+  let violation: string | null = null;
+
+  if (reportedType !== 'UNKNOWN') {
+    controller.setNumberTypeFilter([reportedType]);
+    const difference: string | null = admittingFilterDifference(methodResults(controller.getPhoneNumber()), baseline);
+    if (difference !== null) {
+      violation = `filter [${reportedType}] changed the resolution: ${difference}`;
+    }
+  }
+
+  controller.setRegionFilter(null);
+  controller.setNumberTypeFilter(null);
+  return violation;
+}
+
+/**
+ * Widening a filter can never take validity away. A number allowed by one set is still allowed by a
+ * set containing it, and a number both sets reject stays rejected by the two together.
+ * Clears the filter before returning.
+ */
+export function filterMonotonicityViolation<Value>(
+  controller: FilterableController,
+  kind: string,
+  apply: (values: readonly Value[] | null) => unknown,
+  first: readonly Value[],
+  second: readonly Value[],
+): string | null {
+  apply(first);
+  const underFirst: boolean = controller.getPhoneNumber().isValid();
+  apply(second);
+  const underSecond: boolean = controller.getPhoneNumber().isValid();
+  apply(first.concat(second));
+  const underUnion: boolean = controller.getPhoneNumber().isValid();
+  apply(null);
+
+  if (underUnion !== (underFirst || underSecond)) {
+    return `${kind} filter is valid=${underUnion} under [${first.join(',')}]+[${second.join(',')}], but valid=${underFirst} under the first and valid=${underSecond} under the second`;
+  }
+  return null;
+}
+
+/**
+ * A real number for the region and type, as bare digits. Random digits almost never land on a valid
+ * number, which leaves the type and filter checks with nothing to work on.
+ */
+export function exampleDigits(region: RegionCode, type: NumberType): string {
+  const placeholders = getPlaceholders(region, type);
+  return digitsOf(placeholders?.national ?? placeholders?.nationalWithPrefix ?? '');
 }

--- a/packages/core/src/modules/input-controller/international-input-controller/__tests__/method-fuzz.test.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/__tests__/method-fuzz.test.ts
@@ -5,12 +5,15 @@ import { getCallingCodeForRegion } from '../../../calling-code-for-region';
 import { parsePhoneNumber } from '../../../parse-phone-number';
 import {
   caretViolation,
+  consistencyViolation,
   createRandom,
   digitsOf,
+  filterMonotonicityViolation,
   firstMethodDifference,
   INSERT_PAYLOADS,
   methodResults,
   NUMBER_TYPES,
+  numberTypeFilterViolation,
   regionFilterViolation,
   REGIONS,
 } from '../../__tests__/fuzz-support';
@@ -138,6 +141,21 @@ function runSession(session: number): string | null {
           label = 'regionFilter oracle';
           if (violation !== null) return fail(`${label}: ${violation}`);
           regionFilterActive = false;
+          numberTypeFilterActive = false;
+          state = controller.currentState;
+        } else if (random() < 0.35) {
+          const first: RegionCode[] = Array.from({ length: 1 + upTo(2) }, () => pick(REGIONS));
+          const second: RegionCode[] = Array.from({ length: 1 + upTo(2) }, () => pick(REGIONS));
+          const violation: string | null = filterMonotonicityViolation<RegionCode>(
+            controller,
+            'region',
+            (values) => controller.setRegionFilter(values),
+            first,
+            second,
+          );
+          label = 'regionFilter monotonicity';
+          if (violation !== null) return fail(`${label}: ${violation}`);
+          regionFilterActive = false;
           state = controller.currentState;
         } else {
           const regions: RegionCode[] = Array.from({ length: 1 + upTo(3) }, () => pick(REGIONS));
@@ -149,10 +167,31 @@ function runSession(session: number): string | null {
       }
       default: {
         if (random() < 0.3) {
-          if (random() < 0.4) {
+          const roll: number = random();
+          if (roll < 0.3) {
             label = 'setNumberTypeFilter(null)';
             state = controller.setNumberTypeFilter(null);
             numberTypeFilterActive = false;
+          } else if (roll < 0.5) {
+            const violation: string | null = numberTypeFilterViolation(controller);
+            label = 'numberTypeFilter oracle';
+            if (violation !== null) return fail(`${label}: ${violation}`);
+            numberTypeFilterActive = false;
+            state = controller.currentState;
+          } else if (roll < 0.65) {
+            const first: NumberType[] = Array.from({ length: 1 + upTo(2) }, () => pick(NUMBER_TYPES));
+            const second: NumberType[] = Array.from({ length: 1 + upTo(2) }, () => pick(NUMBER_TYPES));
+            const violation: string | null = filterMonotonicityViolation<NumberType>(
+              controller,
+              'number type',
+              (values) => controller.setNumberTypeFilter(values),
+              first,
+              second,
+            );
+            label = 'numberTypeFilter monotonicity';
+            if (violation !== null) return fail(`${label}: ${violation}`);
+            numberTypeFilterActive = false;
+            state = controller.currentState;
           } else {
             const types: NumberType[] = Array.from({ length: 1 + upTo(3) }, () => pick(NUMBER_TYPES));
             label = `setNumberTypeFilter([${types.join(',')}])`;
@@ -183,6 +222,9 @@ function runSession(session: number): string | null {
 
     const caret: string | null = caretViolation(state);
     if (caret !== null) return fail(`${label} left ${caret}`);
+
+    const inconsistency: string | null = consistencyViolation(controller.getPhoneNumber());
+    if (inconsistency !== null) return fail(`${label} left the number ${inconsistency}`);
 
     if (selectorMode) {
       const literal = controller.getPhoneNumber();

--- a/packages/core/src/modules/input-controller/national-input-controller/__tests__/method-fuzz.test.ts
+++ b/packages/core/src/modules/input-controller/national-input-controller/__tests__/method-fuzz.test.ts
@@ -4,11 +4,15 @@ import type { NumberType, RegionCode } from '../../../../engine';
 import { parsePhoneNumber } from '../../../parse-phone-number';
 import {
   caretViolation,
+  consistencyViolation,
   createRandom,
+  exampleDigits,
+  filterMonotonicityViolation,
   firstMethodDifference,
   INSERT_PAYLOADS,
   methodResults,
   NUMBER_TYPES,
+  numberTypeFilterViolation,
   regionFilterViolation,
   REGIONS,
 } from '../../__tests__/fuzz-support';
@@ -18,8 +22,9 @@ import type { InputState } from '../../models';
 // call. A session is seeded from its index. A failure prints the exact sequence that replays it.
 //
 // After every call a few things have to hold. The caret stays inside the value. Undo then redo
-// comes back to the same value. setValue of the value already shown changes nothing. While no
-// filter is set, getPhoneNumber answers exactly what parsePhoneNumber answers for that value.
+// comes back to the same value. setValue of the value already shown changes nothing. A valid number
+// is always possible. While no filter is set, getPhoneNumber answers exactly what parsePhoneNumber
+// answers for that value. The filter oracles cover the region and type filters on their own.
 
 type Controller = ReturnType<typeof createNationalInputController>;
 
@@ -37,6 +42,16 @@ function runSession(session: number): string | null {
   const history: string[] = [`new(${region}, strict=${strict})`];
   let regionFilterActive = false;
   let numberTypeFilterActive = false;
+
+  // Most sessions start from a real number for the region. The filter and type checks need a number
+  // that actually resolves, which random digits almost never give.
+  if (random() < 0.6) {
+    const seed: string = exampleDigits(region, pick(NUMBER_TYPES));
+    if (seed !== '') {
+      controller.setValue(seed);
+      history.push(`seed(${seed})`);
+    }
+  }
 
   const fail = (reason: string): string => `session ${session}: ${reason}\n  after: ${history.join(' ')}`;
 
@@ -103,13 +118,29 @@ function runSession(session: number): string | null {
         break;
       }
       case 10: {
-        if (random() < 0.35) {
+        const roll: number = random();
+        if (roll < 0.3) {
           label = 'setRegionFilter(null)';
           state = controller.setRegionFilter(null);
           regionFilterActive = false;
-        } else if (random() < 0.5) {
+        } else if (roll < 0.5) {
           const violation: string | null = regionFilterViolation(controller);
           label = 'regionFilter oracle';
+          if (violation !== null) return fail(`${label}: ${violation}`);
+          regionFilterActive = false;
+          numberTypeFilterActive = false;
+          state = controller.currentState;
+        } else if (roll < 0.65) {
+          const first: RegionCode[] = Array.from({ length: 1 + upTo(2) }, () => pick(REGIONS));
+          const second: RegionCode[] = Array.from({ length: 1 + upTo(2) }, () => pick(REGIONS));
+          const violation: string | null = filterMonotonicityViolation<RegionCode>(
+            controller,
+            'region',
+            (values) => controller.setRegionFilter(values),
+            first,
+            second,
+          );
+          label = 'regionFilter monotonicity';
           if (violation !== null) return fail(`${label}: ${violation}`);
           regionFilterActive = false;
           state = controller.currentState;
@@ -122,10 +153,32 @@ function runSession(session: number): string | null {
         break;
       }
       case 11: {
-        if (random() < 0.35) {
+        const roll: number = random();
+        if (roll < 0.3) {
           label = 'setNumberTypeFilter(null)';
           state = controller.setNumberTypeFilter(null);
           numberTypeFilterActive = false;
+        } else if (roll < 0.5) {
+          const violation: string | null = numberTypeFilterViolation(controller);
+          label = 'numberTypeFilter oracle';
+          if (violation !== null) return fail(`${label}: ${violation}`);
+          regionFilterActive = false;
+          numberTypeFilterActive = false;
+          state = controller.currentState;
+        } else if (roll < 0.65) {
+          const first: NumberType[] = Array.from({ length: 1 + upTo(2) }, () => pick(NUMBER_TYPES));
+          const second: NumberType[] = Array.from({ length: 1 + upTo(2) }, () => pick(NUMBER_TYPES));
+          const violation: string | null = filterMonotonicityViolation<NumberType>(
+            controller,
+            'number type',
+            (values) => controller.setNumberTypeFilter(values),
+            first,
+            second,
+          );
+          label = 'numberTypeFilter monotonicity';
+          if (violation !== null) return fail(`${label}: ${violation}`);
+          numberTypeFilterActive = false;
+          state = controller.currentState;
         } else {
           const types: NumberType[] = Array.from({ length: 1 + upTo(3) }, () => pick(NUMBER_TYPES));
           label = `setNumberTypeFilter([${types.join(',')}])`;
@@ -158,10 +211,14 @@ function runSession(session: number): string | null {
     const caret: string | null = caretViolation(state);
     if (caret !== null) return fail(`${label} left ${caret}`);
 
+    const phoneNumber = controller.getPhoneNumber();
+    const inconsistency: string | null = consistencyViolation(phoneNumber);
+    if (inconsistency !== null) return fail(`${label} left the number ${inconsistency}`);
+
     // parsePhoneNumber knows nothing about filters. Only compare while none is set.
     if (!regionFilterActive && !numberTypeFilterActive) {
       const difference: string | null = firstMethodDifference(
-        methodResults(controller.getPhoneNumber()),
+        methodResults(phoneNumber),
         methodResults(parsePhoneNumber(state.value, { defaultRegion: region, strict })),
       );
       if (difference !== null) {

--- a/packages/core/src/modules/input-controller/national-input-controller/__tests__/possible-number-formatting.test.ts
+++ b/packages/core/src/modules/input-controller/national-input-controller/__tests__/possible-number-formatting.test.ts
@@ -62,3 +62,24 @@ describe('national controller: possible-but-not-valid numbers still group', () =
     },
   );
 });
+
+// A number-type filter that admits the number's own type must not turn it impossible or report the
+// calling code invalid. The possibility reason may sharpen from local-only to fully possible.
+describe('national controller: a number-type filter admitting the reported type stays consistent', () => {
+  it('keeps a resolved number possible and formattable under its own type', () => {
+    const controller = createNationalInputController({ defaultRegion: 'CA' });
+    controller.setValue('3101234');
+
+    const before = controller.getPhoneNumber();
+    expect(before.getNumberType()).toBe('UAN');
+    expect(before.isValid()).toBe(true);
+
+    controller.setNumberTypeFilter(['UAN']);
+    const after = controller.getPhoneNumber();
+
+    expect(after.isValid()).toBe(true);
+    expect(after.isPossible()).toBe(true);
+    expect(after.isPossibleWithReason()).not.toBe('INVALID_CALLING_CODE');
+    expect(after.formatE164()).toBe(before.formatE164());
+  });
+});

--- a/packages/core/src/modules/number-resolver/utils/resolve-possibility-length-masks.ts
+++ b/packages/core/src/modules/number-resolver/utils/resolve-possibility-length-masks.ts
@@ -11,15 +11,14 @@ export interface PossibilityLengthMasks {
   readonly localOnly: number;
 }
 
-// Unfiltered, the masks read the calling code's main region (libphonenumber testNumberLength); a
-// region filter unions the allowed regions instead, so a number valid for an allowed region is always possible.
+// Unfiltered, the masks read the calling code's main region (libphonenumber testNumberLength).
 export function resolvePossibilityLengthMasks(
   callingCodeState: number,
   defaultRegionIndex: number,
   regionFilter: BinaryFilter | null,
   numberTypeFilter: BinaryFilter | null,
 ): PossibilityLengthMasks {
-  if (regionFilter === null || callingCodeState === -1) {
+  if ((regionFilter === null && numberTypeFilter === null) || callingCodeState === -1) {
     const regionIndex: number = resolvePrimaryRegionIndex(callingCodeState, defaultRegionIndex);
     return {
       national: getAllowedLengthMask(regionIndex, regionFilter, numberTypeFilter),
@@ -27,11 +26,14 @@ export function resolvePossibilityLengthMasks(
     };
   }
 
+  // Under a filter the union over the calling code's regions keeps a number possible wherever an
+  // allowed region admits it. Regions sharing a calling code do not carry the same number types,
+  // and the main region alone would call a type it lacks impossible for every region.
   const regions: Uint8Array = getCallingCodeStateRegions(getResourceProvider().engine, callingCodeState);
   let national = 0;
   let localOnly = 0;
   for (const regionIndex of regions) {
-    if (regionFilter[regionIndex] === 0) continue;
+    if (regionFilter !== null && regionFilter[regionIndex] === 0) continue;
     national |= getAllowedLengthMask(regionIndex, null, numberTypeFilter);
     localOnly |= getAllowedLocalOnlyLengthMask(regionIndex, null, numberTypeFilter);
   }


### PR DESCRIPTION
## Summary

Under a number-type filter, possibility was measured against the calling code's main region instead of the regions the code actually covers. A Canada UAN number came back impossible with `INVALID_CALLING_CODE` while still reporting `isValid` true, because the main region for `+1` is the US, which has no UAN type. The length masks now union the calling code's regions whenever a filter is active, the way they already did for a region filter. Query behavior with no filter is unchanged. The rest of the change is test coverage: an oracle for the number-type filter, an oracle that widening a filter never removes validity, and a `valid implies possible` check run after every operation, all wired into both controller fuzzes.

## Motivation

Closes #36 and #35. The number-type filter oracle added here is what caught the bug.

## Conformance impact

One query-method path changes: possibility under an active filter now unions the calling code's regions. Unfiltered possibility is untouched. `pnpm conformance` passes 24 of 24 locally.

## Checklist

- [x] Tests added or updated (named regression test plus the fuzz oracles; the fuzz fails with the fix reverted)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally (460 tests)
- [x] Docs reflect the change (no public API change; the filter is a documented Telixon extension)
- [x] Commit message follows the project convention
