### PR TITLE
test(web-sdk): fuzz the phone input through DOM events

### DIFF
--- a/packages/web-sdk/src/modules/phone-input/__tests__/differential-fuzz.test.ts
+++ b/packages/web-sdk/src/modules/phone-input/__tests__/differential-fuzz.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment happy-dom
+
+import { getExampleNumber } from '@telixon/core/testing';
+import { describe, expect, it } from 'vitest';
+import { INSERT_PAYLOADS, NUMBER_TYPES, randomSource, REGIONS, type RandomSource } from './support/random';
+import {
+  caretViolation,
+  consistencyViolation,
+  createWebField,
+  differentialViolation,
+  syncViolation,
+  type WebField,
+  type WebFieldConfig,
+} from './support/web-field';
+
+// The adapter's beforeinput handler passes what it reads off the element straight to the controller.
+// So the same operation driven through DOM events must land where the controller lands when driven
+// through its methods. Every pass-through operation feeds both, and the two are compared after each.
+
+const SESSIONS = 800;
+const OPERATIONS_PER_SESSION = 30;
+const INSERT_INPUT_TYPES = ['insertText', 'insertFromPaste', 'insertReplacementText', 'insertFromDrop'];
+
+function sessionConfig(random: RandomSource): WebFieldConfig {
+  const strict: boolean = random.chance(0.25);
+  if (random.chance(0.5)) return { mode: 'national', defaultRegion: random.pick(REGIONS), strict };
+  if (random.chance(0.5)) {
+    return {
+      mode: 'international',
+      defaultRegion: random.pick(REGIONS),
+      display: { callingCodeInInput: false },
+      strict,
+    };
+  }
+  const plusPrefix = random.pick(['none', 'fixed', 'erasable'] as const);
+  return { mode: 'international', display: { callingCodeInInput: true, plusPrefix }, strict };
+}
+
+function runSession(session: number): string | null {
+  const random: RandomSource = randomSource(session);
+  const config: WebFieldConfig = sessionConfig(random);
+  const field: WebField = createWebField(config);
+  const trail: string[] = [JSON.stringify(config)];
+
+  const fail = (reason: string): string => `session ${session}: ${reason}\n  after: ${trail.join(' ')}`;
+
+  try {
+    // Most sessions start from a real number for the region, so the caret has structure to move over.
+    if (config.defaultRegion && random.chance(0.6)) {
+      const seed: string = getExampleNumber(config.defaultRegion, 'MOBILE');
+      field.setValue(seed);
+      trail.push(`setValue(${seed})`);
+    }
+
+    for (let step = 0; step < OPERATIONS_PER_SESSION; step++) {
+      const length: number = field.value.length;
+      const start: number = random.upTo(length + 1);
+      const end: number = Math.min(length, start + random.upTo(4));
+
+      switch (random.upTo(9)) {
+        case 0:
+        case 1: {
+          const text: string = random.pick(INSERT_PAYLOADS);
+          const inputType: string = random.pick(INSERT_INPUT_TYPES);
+          trail.push(`insert(${JSON.stringify(text)} as ${inputType} @${start}..${end})`);
+          field.insert(text, inputType, start, end);
+          break;
+        }
+        case 2: {
+          trail.push(`deleteBackward(${start}..${end})`);
+          field.deleteBackward(start, end);
+          break;
+        }
+        case 3: {
+          trail.push(`deleteForward(${start}..${end})`);
+          field.deleteForward(start, end);
+          break;
+        }
+        case 4: {
+          trail.push('undoByKeyboard');
+          field.undoByKeyboard();
+          break;
+        }
+        case 5: {
+          trail.push('redoByKeyboard');
+          field.redoByKeyboard();
+          break;
+        }
+        case 6: {
+          const digits: string = Array.from({ length: random.upTo(12) }, () => String(random.upTo(10))).join('');
+          trail.push(`setValue(${JSON.stringify(digits)})`);
+          field.setValue(digits);
+          break;
+        }
+        case 7: {
+          if (random.chance(0.5)) {
+            const regions = random.chance(0.3) ? null : [random.pick(REGIONS), random.pick(REGIONS)];
+            trail.push(`setRegionFilter(${regions ? `[${regions.join(',')}]` : 'null'})`);
+            field.setRegionFilter(regions);
+          } else {
+            const types = random.chance(0.3) ? null : [random.pick(NUMBER_TYPES)];
+            trail.push(`setNumberTypeFilter(${types ? `[${types.join(',')}]` : 'null'})`);
+            field.setNumberTypeFilter(types);
+          }
+          break;
+        }
+        default: {
+          const region = random.pick(REGIONS);
+          trail.push(`setRegion(${region})`);
+          field.setRegion(region);
+          break;
+        }
+      }
+
+      const label: string = trail[trail.length - 1]!;
+      const differential: string | null = differentialViolation(field);
+      if (differential !== null) return fail(`${label}: element diverged from the controller: ${differential}`);
+      const sync: string | null = syncViolation(field);
+      if (sync !== null) return fail(`${label}: ${sync}`);
+      const caret: string | null = caretViolation(field);
+      if (caret !== null) return fail(`${label}: ${caret}`);
+      const consistency: string | null = consistencyViolation(field);
+      if (consistency !== null) return fail(`${label}: the number is ${consistency}`);
+    }
+  } finally {
+    field.destroy();
+  }
+
+  return null;
+}
+
+describe('phone input differential fuzz', () => {
+  it('drives DOM events and controller methods to the same state', () => {
+    const failures: string[] = [];
+    for (let session = 0; session < SESSIONS && failures.length === 0; session++) {
+      const failure: string | null = runSession(session);
+      if (failure !== null) failures.push(failure);
+    }
+    expect(failures).toEqual([]);
+  });
+});

--- a/packages/web-sdk/src/modules/phone-input/__tests__/event-robustness-fuzz.test.ts
+++ b/packages/web-sdk/src/modules/phone-input/__tests__/event-robustness-fuzz.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment happy-dom
+
+import { getExampleNumber } from '@telixon/core/testing';
+import { describe, expect, it } from 'vitest';
+import { NUMBER_TYPES, randomSource, REGIONS, type RandomSource } from './support/random';
+import {
+  caretViolation,
+  consistencyViolation,
+  createWebField,
+  syncViolation,
+  type WebField,
+  type WebFieldConfig,
+} from './support/web-field';
+
+// Fires every beforeinput type the adapter handles, plus composition and the keyboard shortcuts, in
+// random order. There is no controller to compare against here, since word and line deletes are the
+// adapter's own translation. Instead it checks that the adapter never throws, the element stays in
+// step with the reported state, the caret stays in range, and a valid number stays possible.
+
+const SESSIONS = 800;
+const OPERATIONS_PER_SESSION = 30;
+
+const INSERT_TYPES = ['insertText', 'insertReplacementText', 'insertFromPaste', 'insertFromDrop', 'insertFromYank'];
+
+const NON_INSERT_TYPES = [
+  'deleteContentBackward',
+  'deleteByCut',
+  'deleteContent',
+  'deleteByDrag',
+  'deleteContentForward',
+  'deleteWordBackward',
+  'deleteWordForward',
+  'deleteSoftLineBackward',
+  'deleteHardLineBackward',
+  'deleteSoftLineForward',
+  'deleteHardLineForward',
+  'deleteEntireSoftLine',
+  'deleteEntireHardLine',
+  'historyUndo',
+  'historyRedo',
+];
+
+const DIGITS = ['5', '90', '415', '2', '0'];
+
+function sessionConfig(random: RandomSource): WebFieldConfig {
+  const strict: boolean = random.chance(0.25);
+  if (random.chance(0.5)) return { mode: 'national', defaultRegion: random.pick(REGIONS), strict };
+  if (random.chance(0.5)) {
+    return {
+      mode: 'international',
+      defaultRegion: random.pick(REGIONS),
+      display: { callingCodeInInput: false },
+      strict,
+    };
+  }
+  const plusPrefix = random.pick(['none', 'fixed', 'erasable'] as const);
+  return { mode: 'international', display: { callingCodeInInput: true, plusPrefix }, strict };
+}
+
+function runSession(session: number): string | null {
+  const random: RandomSource = randomSource(session);
+  const config: WebFieldConfig = sessionConfig(random);
+  const field: WebField = createWebField(config);
+  const trail: string[] = [JSON.stringify(config)];
+
+  const fail = (reason: string): string => `session ${session}: ${reason}\n  after: ${trail.join(' ')}`;
+
+  try {
+    if (config.defaultRegion && random.chance(0.6)) {
+      const seed: string = getExampleNumber(config.defaultRegion, 'MOBILE');
+      field.setValue(seed);
+      trail.push(`setValue(${seed})`);
+    }
+
+    for (let step = 0; step < OPERATIONS_PER_SESSION; step++) {
+      const length: number = field.value.length;
+      const start: number = random.upTo(length + 1);
+      const end: number = Math.min(length, start + random.upTo(4));
+      let label: string;
+
+      try {
+        switch (random.upTo(10)) {
+          case 0:
+          case 1:
+          case 2: {
+            const text: string = random.pick(DIGITS);
+            const inputType: string = random.pick(INSERT_TYPES);
+            label = `insert(${JSON.stringify(text)} as ${inputType} @${start}..${end})`;
+            field.insert(text, inputType, start, end);
+            break;
+          }
+          case 3:
+          case 4:
+          case 5:
+          case 6: {
+            const inputType: string = random.pick(NON_INSERT_TYPES);
+            label = `${inputType} @${start}..${end}`;
+            field.dispatchInputType(inputType, start, end);
+            break;
+          }
+          case 7: {
+            const text: string = random.pick(DIGITS);
+            label = `composition(${JSON.stringify(text)} @${start}..${end})`;
+            field.composition(text, start, end);
+            break;
+          }
+          case 8: {
+            if (random.chance(0.5)) {
+              label = 'undoByKeyboard';
+              field.undoByKeyboard();
+            } else {
+              label = 'redoByKeyboard';
+              field.redoByKeyboard();
+            }
+            break;
+          }
+          default: {
+            if (random.chance(0.4)) {
+              const region = random.pick(REGIONS);
+              label = `setRegion(${region})`;
+              field.setRegion(region);
+            } else if (random.chance(0.5)) {
+              const regions = random.chance(0.3) ? null : [random.pick(REGIONS)];
+              label = `setRegionFilter(${regions ? `[${regions.join(',')}]` : 'null'})`;
+              field.setRegionFilter(regions);
+            } else {
+              const types = random.chance(0.3) ? null : [random.pick(NUMBER_TYPES)];
+              label = `setNumberTypeFilter(${types ? `[${types.join(',')}]` : 'null'})`;
+              field.setNumberTypeFilter(types);
+            }
+            break;
+          }
+        }
+      } catch (error) {
+        return fail(`${trail[trail.length - 1] ?? 'op'} threw: ${(error as Error).message}`);
+      }
+
+      trail.push(label);
+
+      const sync: string | null = syncViolation(field);
+      if (sync !== null) return fail(`${label}: ${sync}`);
+      const caret: string | null = caretViolation(field);
+      if (caret !== null) return fail(`${label}: ${caret}`);
+      const consistency: string | null = consistencyViolation(field);
+      if (consistency !== null) return fail(`${label}: the number is ${consistency}`);
+    }
+  } finally {
+    field.destroy();
+  }
+
+  return null;
+}
+
+describe('phone input event robustness fuzz', () => {
+  it('holds under every handled event kind', () => {
+    const failures: string[] = [];
+    for (let session = 0; session < SESSIONS && failures.length === 0; session++) {
+      const failure: string | null = runSession(session);
+      if (failure !== null) failures.push(failure);
+    }
+    expect(failures).toEqual([]);
+  });
+});

--- a/packages/web-sdk/src/modules/phone-input/__tests__/support/dom-events.ts
+++ b/packages/web-sdk/src/modules/phone-input/__tests__/support/dom-events.ts
@@ -1,0 +1,31 @@
+// Faithful DOM events for the phone input. The adapter reads the element value and caret at event
+// time, then cancels the event and writes the result back, so a test only has to place the caret and
+// dispatch the same event a browser would.
+
+export function placeCaret(input: HTMLInputElement, start: number, end: number): void {
+  input.setSelectionRange(start, end);
+}
+
+export function dispatchBeforeInput(input: HTMLInputElement, inputType: string, data: string | null = null): void {
+  input.dispatchEvent(new InputEvent('beforeinput', { inputType, data, isComposing: false, cancelable: true }));
+}
+
+export function dispatchCompositionEnd(input: HTMLInputElement, data: string): void {
+  input.dispatchEvent(new CompositionEvent('compositionend', { data }));
+}
+
+export function dispatchKeyDown(
+  input: HTMLInputElement,
+  key: string,
+  modifiers: { ctrlKey?: boolean; metaKey?: boolean; shiftKey?: boolean } = {},
+): void {
+  input.dispatchEvent(
+    new KeyboardEvent('keydown', {
+      key,
+      ctrlKey: modifiers.ctrlKey ?? false,
+      metaKey: modifiers.metaKey ?? false,
+      shiftKey: modifiers.shiftKey ?? false,
+      cancelable: true,
+    }),
+  );
+}

--- a/packages/web-sdk/src/modules/phone-input/__tests__/support/random.ts
+++ b/packages/web-sdk/src/modules/phone-input/__tests__/support/random.ts
@@ -1,0 +1,35 @@
+import type { NumberType, RegionCode } from '@telixon/core';
+
+// A seeded generator so a failing session replays from its index alone.
+export function createRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let mixed = Math.imul(state ^ (state >>> 15), 1 | state);
+    mixed = (mixed + Math.imul(mixed ^ (mixed >>> 7), 61 | mixed)) ^ mixed;
+    return ((mixed ^ (mixed >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export interface RandomSource {
+  pick<Item>(items: readonly Item[]): Item;
+  upTo(bound: number): number;
+  chance(probability: number): boolean;
+}
+
+export function randomSource(seed: number): RandomSource {
+  const next = createRandom(seed);
+  return {
+    pick: (items) => items[Math.floor(next() * items.length)]!,
+    upTo: (bound) => Math.floor(next() * bound),
+    chance: (probability) => next() < probability,
+  };
+}
+
+// Regions that stress the format: mask literals, trunk stripping, and a shared calling code.
+export const REGIONS: readonly RegionCode[] = ['US', 'CA', 'GB', 'AR', 'BY', 'BR', 'DE', 'FR', 'JP', 'AU'];
+
+export const NUMBER_TYPES: readonly NumberType[] = ['FIXED_LINE', 'MOBILE', 'TOLL_FREE', 'PREMIUM_RATE', 'VOIP'];
+
+// Bare digits, formatted text, a leading plus, and non-digit noise all reach a real field.
+export const INSERT_PAYLOADS: readonly string[] = ['5', '12', '007', '+549', '(201) 555', ' 9-9 ', 'ab', '+'];

--- a/packages/web-sdk/src/modules/phone-input/__tests__/support/web-field.ts
+++ b/packages/web-sdk/src/modules/phone-input/__tests__/support/web-field.ts
@@ -1,0 +1,218 @@
+import type { InputController, InternationalDisplayConfig, NumberType, PhoneNumber, RegionCode } from '@telixon/core';
+import { createInternationalInputController, createNationalInputController } from '@telixon/core';
+import { readonlyArraysEqual } from '../../../../utils/readonly-arrays-equal';
+import type { PhoneInput, PhoneInputState } from '../../models';
+import { createPhoneInput } from '../../phone-input';
+import { dispatchBeforeInput, dispatchCompositionEnd, dispatchKeyDown, placeCaret } from './dom-events';
+
+export interface WebFieldConfig {
+  readonly mode: 'national' | 'international';
+  readonly defaultRegion?: RegionCode;
+  readonly display?: InternationalDisplayConfig;
+  readonly strict?: boolean;
+}
+
+/**
+ * A phone input driven through DOM events, paired with a bare controller driven through its methods.
+ * The adapter's `beforeinput` handler is a pass-through, so the same operation on both must land on
+ * the same value and caret. The differential ops below feed both; the event-only ops feed just the
+ * element, for cases the adapter translates on its own (word and line deletes, composition).
+ */
+export interface WebField {
+  readonly value: string;
+  readonly selectionStart: number;
+  readonly selectionEnd: number;
+  readonly state: PhoneInputState;
+  readonly phoneNumber: PhoneNumber;
+
+  readonly mirrorValue: string;
+  readonly mirrorSelectionStart: number;
+  readonly mirrorSelectionEnd: number;
+
+  insert(text: string, inputType: string, start: number, end: number): void;
+  deleteBackward(start: number, end: number): void;
+  deleteForward(start: number, end: number): void;
+  undoByKeyboard(): void;
+  redoByKeyboard(): void;
+  setValue(next: string): void;
+  setRegion(region: RegionCode): void;
+  setRegionFilter(regions: readonly RegionCode[] | null): void;
+  setNumberTypeFilter(numberTypes: readonly NumberType[] | null): void;
+
+  dispatchInputType(inputType: string, start: number, end: number): void;
+  composition(text: string, start: number, end: number): void;
+
+  destroy(): void;
+}
+
+type CallingCodeDisplay = Extract<InternationalDisplayConfig, { callingCodeInInput: true }>;
+
+// Builds the DOM-bound input and a bare mirror controller from one config, so both see the same
+// core options. Optional fields are omitted rather than passed as undefined.
+function createControllers(
+  config: WebFieldConfig,
+  input: HTMLInputElement,
+): { phone: PhoneInput; mirror: InputController } {
+  const strict: boolean = config.strict === true;
+
+  if (config.mode === 'national') {
+    const core = { defaultRegion: config.defaultRegion ?? ('US' as RegionCode), strict };
+    return {
+      phone: createPhoneInput({ input, mode: 'national', ...core }),
+      mirror: createNationalInputController(core),
+    };
+  }
+
+  if (config.display?.callingCodeInInput === false) {
+    const core = { defaultRegion: config.defaultRegion ?? ('US' as RegionCode), strict, display: config.display };
+    return {
+      phone: createPhoneInput({ input, mode: 'international', ...core }),
+      mirror: createInternationalInputController(core),
+    };
+  }
+
+  const core: { strict: boolean; defaultRegion?: RegionCode; display?: CallingCodeDisplay } = { strict };
+  if (config.defaultRegion) core.defaultRegion = config.defaultRegion;
+  if (config.display?.callingCodeInInput === true) core.display = config.display;
+  return {
+    phone: createPhoneInput({ input, mode: 'international', ...core }),
+    mirror: createInternationalInputController(core),
+  };
+}
+
+export function createWebField(config: WebFieldConfig): WebField {
+  const input: HTMLInputElement = document.createElement('input');
+  input.type = 'tel';
+  document.body.appendChild(input);
+
+  const { phone, mirror } = createControllers(config, input);
+  let lastRegionFilter: readonly RegionCode[] | null = null;
+  let lastNumberTypeFilter: readonly NumberType[] | null = null;
+
+  return {
+    get value(): string {
+      return input.value;
+    },
+    get selectionStart(): number {
+      return input.selectionStart ?? 0;
+    },
+    get selectionEnd(): number {
+      return input.selectionEnd ?? 0;
+    },
+    get state(): PhoneInputState {
+      return phone.getState();
+    },
+    get phoneNumber(): PhoneNumber {
+      return phone.getPhoneNumber();
+    },
+    get mirrorValue(): string {
+      return mirror.currentState.value;
+    },
+    get mirrorSelectionStart(): number {
+      return mirror.currentState.selectionStart;
+    },
+    get mirrorSelectionEnd(): number {
+      return mirror.currentState.selectionEnd;
+    },
+
+    insert(text: string, inputType: string, start: number, end: number): void {
+      const value: string = input.value;
+      placeCaret(input, start, end);
+      dispatchBeforeInput(input, inputType, text);
+      mirror.insert(value, text, start, end);
+    },
+    deleteBackward(start: number, end: number): void {
+      const value: string = input.value;
+      placeCaret(input, start, end);
+      dispatchBeforeInput(input, 'deleteContentBackward');
+      mirror.deleteBackward(value, start, end);
+    },
+    deleteForward(start: number, end: number): void {
+      const value: string = input.value;
+      placeCaret(input, start, end);
+      dispatchBeforeInput(input, 'deleteContentForward');
+      mirror.deleteForward(value, start, end);
+    },
+    undoByKeyboard(): void {
+      dispatchKeyDown(input, 'z', { ctrlKey: true });
+      if (mirror.canUndo) mirror.undo();
+    },
+    redoByKeyboard(): void {
+      dispatchKeyDown(input, 'z', { ctrlKey: true, shiftKey: true });
+      if (mirror.canRedo) mirror.redo();
+    },
+    setValue(next: string): void {
+      phone.setValue(next);
+      mirror.setValue(next);
+    },
+    setRegion(region: RegionCode): void {
+      phone.setRegion(region);
+      mirror.setRegion(region);
+    },
+    setRegionFilter(regions: readonly RegionCode[] | null): void {
+      phone.setRegionFilter(regions);
+      // The public setter caches by value; mirror the same no-op so the two stay in lockstep.
+      if (!readonlyArraysEqual(regions, lastRegionFilter)) mirror.setRegionFilter(regions);
+      lastRegionFilter = regions;
+    },
+    setNumberTypeFilter(numberTypes: readonly NumberType[] | null): void {
+      phone.setNumberTypeFilter(numberTypes);
+      if (!readonlyArraysEqual(numberTypes, lastNumberTypeFilter)) mirror.setNumberTypeFilter(numberTypes);
+      lastNumberTypeFilter = numberTypes;
+    },
+
+    dispatchInputType(inputType: string, start: number, end: number): void {
+      placeCaret(input, start, end);
+      dispatchBeforeInput(input, inputType);
+    },
+    composition(text: string, start: number, end: number): void {
+      placeCaret(input, start, end);
+      dispatchCompositionEnd(input, text);
+    },
+
+    destroy(): void {
+      phone.destroy();
+      input.remove();
+    },
+  };
+}
+
+// The element value must always mirror the reported state, since the value only ever changes through
+// an event the adapter applies. The caret is not compared here: a no-op event leaves the caret where
+// the test placed it while the state keeps its own, exactly as a real caret sits apart between edits.
+export function syncViolation(field: WebField): string | null {
+  const { value, state } = field;
+  if (value !== state.value) return `element value ${JSON.stringify(value)} !== state ${JSON.stringify(state.value)}`;
+  return null;
+}
+
+/** The caret on the element stays inside the value. */
+export function caretViolation(field: WebField): string | null {
+  const { value, selectionStart, selectionEnd } = field;
+  if (!Number.isInteger(selectionStart) || !Number.isInteger(selectionEnd)) return 'caret is not an integer';
+  if (selectionStart < 0 || selectionStart > selectionEnd) return `caret range ${selectionStart}..${selectionEnd}`;
+  if (selectionEnd > value.length) return `caret ${selectionEnd} past ${JSON.stringify(value)}`;
+  return null;
+}
+
+/** A valid number is always possible. */
+export function consistencyViolation(field: WebField): string | null {
+  const phoneNumber: PhoneNumber = field.phoneNumber;
+  if (phoneNumber.isValid() && !phoneNumber.isPossible())
+    return `valid but not possible (${phoneNumber.getNationalNumber()})`;
+  return null;
+}
+
+/** The element driven by events must match the controller driven by methods. */
+export function differentialViolation(field: WebField): string | null {
+  if (field.value !== field.mirrorValue) {
+    return `value ${JSON.stringify(field.value)} !== mirror ${JSON.stringify(field.mirrorValue)}`;
+  }
+  if (field.selectionStart !== field.mirrorSelectionStart) {
+    return `caret start ${field.selectionStart} !== mirror ${field.mirrorSelectionStart}`;
+  }
+  if (field.selectionEnd !== field.mirrorSelectionEnd) {
+    return `caret end ${field.selectionEnd} !== mirror ${field.mirrorSelectionEnd}`;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Adds two fuzzes for the web-sdk phone input, which drives a DOM `<input>` and had no property coverage. The differential fuzz leans on the adapter being a pass-through: the same operation driven through `beforeinput` events must land where the bare controller lands when driven through its methods, so it feeds both and compares. The robustness fuzz fires every handled input type, plus composition and the keyboard shortcuts, and checks the adapter never throws, the element tracks the reported state, the caret stays in range, and a valid number stays possible. Reusable entities back both: a faithful event driver, a seeded random source, and a web field that pairs the element with a mirror controller. Test-only.

## Motivation

Closes #38. The controllers are fuzzed through their methods; the DOM event translation and write-back above them were not covered.

## Conformance impact

None. No engine or query-method behavior is touched. `pnpm conformance` passes 24 of 24 locally.

## Checklist

- [x] Tests added or updated (this change is the tests)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally (461 tests)
- [x] Docs reflect the change (test-only, no public API or behavior change)
- [x] Commit message follows the project convention