### PR TITLE
fix(web-sdk): fall back to defaultRegion for the placeholder when the…

### DIFF
--- a/packages/web-sdk/src/modules/phone-input/__tests__/placeholder.test.ts
+++ b/packages/web-sdk/src/modules/phone-input/__tests__/placeholder.test.ts
@@ -90,6 +90,28 @@ describe('PhoneInput placeholder', () => {
     cleanup();
   });
 
+  it('falls back to defaultRegion when the value resolves no region', () => {
+    const { input, cleanup } = attachInput();
+
+    const phone = createPhoneInput({
+      input,
+      mode: 'international',
+      display: { callingCodeInInput: true, plusPrefix: 'erasable' },
+      defaultRegion: 'US',
+    });
+    expect(phone.getState().placeholder).toBe('+1 201-555-0123');
+
+    input.setSelectionRange(0, input.value.length);
+    input.dispatchEvent(
+      new InputEvent('beforeinput', { inputType: 'deleteContentBackward', bubbles: true, cancelable: true }),
+    );
+    expect(phone.getState().value).toBe('');
+    expect(phone.getState().placeholder).toBe('+1 201-555-0123');
+
+    phone.destroy();
+    cleanup();
+  });
+
   it('placeholderNumberType option overrides the default MOBILE type', () => {
     const { input, cleanup } = attachInput();
 

--- a/packages/web-sdk/src/modules/phone-input/phone-input.ts
+++ b/packages/web-sdk/src/modules/phone-input/phone-input.ts
@@ -50,16 +50,19 @@ export function createPhoneInput(options: PhoneInputOptions): PhoneInput {
   let currentRegionFilter: readonly RegionCode[] | null = options.regionFilter ?? null;
   let currentNumberTypeFilter: readonly NumberType[] | null = options.numberTypeFilter ?? null;
 
-  let cachedPlaceholderRegion: RegionCode | null = inputController.currentState.region;
+  // The placeholder follows the resolved region; an unresolved value falls back to `defaultRegion`.
+  const placeholderFallbackRegion: RegionCode | null = options.defaultRegion ?? null;
+  let cachedPlaceholderRegion: RegionCode | null = inputController.currentState.region ?? placeholderFallbackRegion;
   let cachedPlaceholder: string | null = resolvePlaceholder(cachedPlaceholderRegion, placeholderConfig);
 
   if (currentRegionFilter !== null) inputController.setRegionFilter(currentRegionFilter);
   if (currentNumberTypeFilter !== null) inputController.setNumberTypeFilter(currentNumberTypeFilter);
 
   function currentPlaceholder(region: RegionCode | null): string | null {
-    if (region === cachedPlaceholderRegion) return cachedPlaceholder;
-    cachedPlaceholderRegion = region;
-    cachedPlaceholder = resolvePlaceholder(region, placeholderConfig);
+    const effectiveRegion: RegionCode | null = region ?? placeholderFallbackRegion;
+    if (effectiveRegion === cachedPlaceholderRegion) return cachedPlaceholder;
+    cachedPlaceholderRegion = effectiveRegion;
+    cachedPlaceholder = resolvePlaceholder(effectiveRegion, placeholderConfig);
     return cachedPlaceholder;
   }
 


### PR DESCRIPTION
## Summary

When a PhoneInput value resolves no region, `state.placeholder` was `null`. It now falls back to the configured `defaultRegion`, so an empty field still shows an example. A field with a resolved region is unchanged.

## Motivation

An empty or too-short field left the placeholder blank even when `defaultRegion` was set, so there was nothing to show until the first digit resolved.

## Conformance impact

None. Web-sdk placeholder behavior only; no engine or query-method path is touched.

## Checklist

- [x] Tests added or updated (empty field with `defaultRegion` shows the example, and again after a full delete)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (phone-input reference already documents the fallback)
- [x] Commit message follows the project convention