### PR TITLE
docs(web-sdk): add the reference and guides with live demos

### DIFF
--- a/apps/docs/src/components/CompleteFieldDemo.astro
+++ b/apps/docs/src/components/CompleteFieldDemo.astro
@@ -1,0 +1,11 @@
+---
+import DemoFrame from './DemoFrame.astro';
+import './demos/complete-field.css';
+import html from './demos/complete-field.html?raw';
+---
+
+<DemoFrame><Fragment set:html={html} /></DemoFrame>
+
+<script>
+  import './demos/complete-field.js';
+</script>

--- a/apps/docs/src/components/DemoFrame.astro
+++ b/apps/docs/src/components/DemoFrame.astro
@@ -1,0 +1,34 @@
+---
+// Frame for live guide demos: the page shows a demo's source files and runs the same files inside
+// this box. Each demo's stylesheet is self-contained with light values; the block below retunes
+// its custom properties for the site's dark theme.
+---
+
+<div class="demo-frame not-content">
+  <slot />
+</div>
+
+<style>
+  .demo-frame {
+    margin-top: 1rem;
+    padding: 1.5rem;
+    border: 1px solid var(--sl-color-hairline);
+    border-radius: 0.5rem;
+    background: #ffffff;
+  }
+
+  :global([data-theme='dark']) .demo-frame {
+    background: #1b1d1e;
+  }
+</style>
+
+<style is:global>
+  [data-theme='dark'] .demo-frame :is(#phone-field, #region-picker, #complete-field) {
+    --surface: #131516;
+    --text: var(--sl-color-white);
+    --muted: var(--sl-color-gray-3);
+    --border: var(--sl-color-gray-5);
+    --valid: var(--brand-solid);
+    --error: #e5484d;
+  }
+</style>

--- a/apps/docs/src/components/PhoneFieldDemo.astro
+++ b/apps/docs/src/components/PhoneFieldDemo.astro
@@ -1,0 +1,11 @@
+---
+import DemoFrame from './DemoFrame.astro';
+import './demos/phone-field.css';
+import html from './demos/phone-field.html?raw';
+---
+
+<DemoFrame><Fragment set:html={html} /></DemoFrame>
+
+<script>
+  import './demos/phone-field.js';
+</script>

--- a/apps/docs/src/components/RegionPickerDemo.astro
+++ b/apps/docs/src/components/RegionPickerDemo.astro
@@ -1,0 +1,11 @@
+---
+import DemoFrame from './DemoFrame.astro';
+import './demos/region-picker.css';
+import html from './demos/region-picker.html?raw';
+---
+
+<DemoFrame><Fragment set:html={html} /></DemoFrame>
+
+<script>
+  import './demos/region-picker.js';
+</script>

--- a/apps/docs/src/components/demos/complete-field.css
+++ b/apps/docs/src/components/demos/complete-field.css
@@ -1,0 +1,170 @@
+#complete-field {
+  --surface: #ffffff;
+  --text: #1c1f1e;
+  --muted: #66716d;
+  --border: #c9d1ce;
+  --accent: #26997b;
+  --valid: #1d7a5f;
+  --error: #b3384f;
+
+  position: relative;
+  color: var(--text);
+}
+
+#complete-field label {
+  display: block;
+  margin-bottom: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+#complete-field .phone-field-control {
+  display: flex;
+  align-items: stretch;
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  background: var(--surface);
+}
+
+#complete-field .phone-field-control:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
+#complete-field .phone-field-control input {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1rem;
+  font-variant-numeric: tabular-nums;
+  outline: none;
+}
+
+#complete-field input::placeholder {
+  color: var(--muted);
+}
+
+#complete-field .phone-field-region {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0 0.75rem;
+  border: none;
+  border-right: 1px solid var(--border);
+  border-radius: 0.375rem 0 0 0.375rem;
+  background: transparent;
+  color: inherit;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+#complete-field .phone-field-region:hover {
+  background: color-mix(in srgb, var(--text) 5%, transparent);
+}
+
+#complete-field .phone-field-flag {
+  font-size: 1.125rem;
+  line-height: 1;
+}
+
+#complete-field .phone-field-code {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+#complete-field .phone-field-chevron {
+  width: 0.625rem;
+  height: 0.375rem;
+  color: var(--muted);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  #complete-field .phone-field-chevron {
+    transition: transform 150ms ease;
+  }
+}
+
+#complete-field .phone-field-region[aria-expanded='true'] .phone-field-chevron {
+  transform: rotate(180deg);
+}
+
+#complete-field .phone-field-menu {
+  position: absolute;
+  z-index: 10;
+  margin-top: 0.375rem;
+  width: min(24rem, 100%);
+  padding: 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--surface);
+  box-shadow:
+    0 1px 2px rgb(0 0 0 / 0.06),
+    0 8px 24px rgb(0 0 0 / 0.1);
+}
+
+#complete-field .phone-field-menu input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  background: var(--surface);
+  color: inherit;
+  font-size: 0.875rem;
+}
+
+#complete-field .phone-field-menu input:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
+#complete-field ul {
+  margin: 0.5rem 0 0;
+  padding: 0;
+  list-style: none;
+  max-height: 15rem;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+#complete-field li {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+#complete-field li:hover,
+#complete-field li[data-active='true'] {
+  background: rgb(38 153 123 / 0.08);
+}
+
+#complete-field li[aria-selected='true'] {
+  background: rgb(38 153 123 / 0.14);
+}
+
+#complete-field li .phone-field-option-code {
+  margin-left: auto;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+#complete-field .phone-field-status {
+  margin: 0.5rem 0 0;
+  min-height: 1.25rem;
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+
+#complete-field .phone-field-status[data-tone='valid'] {
+  color: var(--valid);
+}
+
+#complete-field .phone-field-status[data-tone='error'] {
+  color: var(--error);
+}

--- a/apps/docs/src/components/demos/complete-field.html
+++ b/apps/docs/src/components/demos/complete-field.html
@@ -1,0 +1,34 @@
+<div id="complete-field" class="phone-field">
+  <label for="phone-field-input">Phone number</label>
+  <div class="phone-field-control">
+    <button
+      class="phone-field-region"
+      type="button"
+      aria-haspopup="listbox"
+      aria-expanded="false"
+      aria-controls="phone-field-listbox"
+      aria-label="Select region"
+    >
+      <span class="phone-field-flag"></span>
+      <span class="phone-field-code"></span>
+      <svg class="phone-field-chevron" viewBox="0 0 10 6" aria-hidden="true">
+        <path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" />
+      </svg>
+    </button>
+    <input id="phone-field-input" type="tel" />
+  </div>
+  <div class="phone-field-menu" hidden>
+    <input
+      class="phone-field-search"
+      type="text"
+      role="combobox"
+      aria-expanded="true"
+      aria-controls="phone-field-listbox"
+      aria-autocomplete="list"
+      aria-label="Search regions"
+      placeholder="Search regions"
+    />
+    <ul id="phone-field-listbox" role="listbox" aria-label="Regions"></ul>
+  </div>
+  <p class="phone-field-status"></p>
+</div>

--- a/apps/docs/src/components/demos/complete-field.js
+++ b/apps/docs/src/components/demos/complete-field.js
@@ -1,0 +1,219 @@
+import { ensureEngineReady, getCallingCodeForRegion } from '@telixon/core';
+import { createPhoneInput, createRegionList, regionToFlagEmoji } from '@telixon/web-sdk';
+
+await ensureEngineReady();
+
+// Elements of the field and its popup.
+const root = document.querySelector('#complete-field');
+const trigger = root.querySelector('.phone-field-region');
+const flag = root.querySelector('.phone-field-flag');
+const code = root.querySelector('.phone-field-code');
+const input = root.querySelector('#phone-field-input');
+const status = root.querySelector('.phone-field-status');
+const popup = root.querySelector('.phone-field-menu');
+const control = root.querySelector('.phone-field-control');
+const search = root.querySelector('.phone-field-search');
+const list = root.querySelector('ul');
+
+// The picker and the phone are independent machines.
+const regions = createRegionList({
+  prioritize: ['US', 'CA', 'GB'],
+  dataFactory: ({ region }) => regionToFlagEmoji(region),
+});
+
+const phone = createPhoneInput({
+  mode: 'international',
+  defaultRegion: 'US',
+  display: { callingCodeInInput: false },
+  input,
+});
+
+// The selected region in one shared shape.
+function regionOption(region) {
+  return { region, callingCode: getCallingCodeForRegion(region), data: regionToFlagEmoji(region) };
+}
+
+let selected = regionOption('US');
+
+function renderTrigger() {
+  flag.textContent = selected.data;
+  code.textContent = '+' + selected.callingCode;
+}
+
+// Full rebuild when the search changes the option set.
+function renderList(state) {
+  list.replaceChildren(
+    ...state.options.map((option) => {
+      const row = document.createElement('li');
+      row.id = 'phone-field-option-' + option.region;
+      row.dataset.region = option.region;
+      row.setAttribute('role', 'option');
+      row.setAttribute('aria-selected', String(option.region === selected.region));
+
+      const rowFlag = document.createElement('span');
+      rowFlag.textContent = option.data;
+      const rowName = document.createElement('span');
+      rowName.textContent = option.displayName;
+      const rowCode = document.createElement('span');
+      rowCode.className = 'phone-field-option-code';
+      rowCode.textContent = '+' + option.callingCode;
+
+      row.append(rowFlag, rowName, rowCode);
+      return row;
+    }),
+  );
+}
+
+// Move the highlight without rebuilding the list.
+function markSelected(region) {
+  const previous = list.querySelector('[aria-selected="true"]');
+  if (previous) previous.setAttribute('aria-selected', 'false');
+  const next = list.querySelector(`[data-region="${region}"]`);
+  if (next) next.setAttribute('aria-selected', 'true');
+}
+
+// The keyboard cursor. Focus stays in the search while aria-activedescendant names the active row.
+let activeRegion = null;
+
+function setActive(region) {
+  const previous = list.querySelector('[data-active="true"]');
+  if (previous) previous.removeAttribute('data-active');
+  search.removeAttribute('aria-activedescendant');
+  activeRegion = null;
+
+  const next = region === null ? null : list.querySelector(`[data-region="${region}"]`);
+  if (next === null) return;
+  activeRegion = region;
+  next.setAttribute('data-active', 'true');
+  search.setAttribute('aria-activedescendant', next.id);
+  // Scroll the list only; scrollIntoView would drag every scrollable ancestor, the page included.
+  const rowRect = next.getBoundingClientRect();
+  const listRect = list.getBoundingClientRect();
+  if (rowRect.top < listRect.top) list.scrollTop += rowRect.top - listRect.top;
+  else if (rowRect.bottom > listRect.bottom) list.scrollTop += rowRect.bottom - listRect.bottom;
+}
+
+// Wraps past either end; without a cursor, Down starts at the first row and Up at the last.
+function moveActive(step) {
+  const rows = [...list.children];
+  if (rows.length === 0) return;
+  const index = rows.findIndex((row) => row.dataset.region === activeRegion);
+  const nextIndex = index === -1 ? (step > 0 ? 0 : rows.length - 1) : (index + step + rows.length) % rows.length;
+  setActive(rows[nextIndex].dataset.region);
+}
+
+function renderStatus(state) {
+  input.placeholder = state.placeholder ?? '';
+
+  if (state.value === '') {
+    status.textContent = 'Type a number.';
+    status.dataset.tone = '';
+    return;
+  }
+
+  if (state.validationError === null) {
+    status.textContent = 'Valid: ' + phone.getPhoneNumber().formatE164();
+    status.dataset.tone = 'valid';
+    return;
+  }
+
+  status.textContent = state.validationError.kind;
+  status.dataset.tone = 'error';
+}
+
+// Reflect the chosen region in the button and the list.
+function applySelection(region) {
+  selected = regionOption(region);
+  renderTrigger();
+  markSelected(region);
+}
+
+// Under a shared calling code the digits decide the region, so follow it.
+function followResolvedRegion(region) {
+  if (region === null || region === selected.region) return;
+  applySelection(region);
+}
+
+// Flip the popup above the field when the viewport below cannot fit it.
+function positionPopup() {
+  popup.style.bottom = '';
+  const controlRect = control.getBoundingClientRect();
+  const needed = popup.offsetHeight + 8;
+  if (window.innerHeight - controlRect.bottom < needed && controlRect.top > needed) {
+    popup.style.bottom = `${root.offsetHeight - control.offsetTop + 6}px`;
+  }
+}
+
+function openPopup() {
+  popup.hidden = false;
+  trigger.setAttribute('aria-expanded', 'true');
+  search.value = '';
+  regions.search('');
+  list.scrollTop = 0;
+  positionPopup();
+  setActive(selected.region);
+  search.focus({ preventScroll: true });
+}
+
+function closePopup() {
+  popup.hidden = true;
+  trigger.setAttribute('aria-expanded', 'false');
+  setActive(null);
+}
+
+// The only bridge from the picker to the phone.
+function select(region) {
+  applySelection(region);
+  phone.setRegion(region);
+  closePopup();
+  input.focus();
+}
+
+trigger.addEventListener('click', () => (popup.hidden ? openPopup() : closePopup()));
+search.addEventListener('input', () => regions.search(search.value));
+search.addEventListener('keydown', (event) => {
+  if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+    event.preventDefault();
+    moveActive(event.key === 'ArrowDown' ? 1 : -1);
+    return;
+  }
+  if (event.key === 'Enter' && activeRegion !== null) {
+    event.preventDefault();
+    select(activeRegion);
+  }
+});
+list.addEventListener('click', (event) => {
+  const row = event.target.closest('li');
+  if (row) select(row.dataset.region);
+});
+root.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && !popup.hidden) {
+    closePopup();
+    trigger.focus();
+  }
+});
+// Dismiss on the press itself, so releasing a text-selection drag outside never closes the popup.
+// In a framework component, remove this document listener on unmount, next to each machine's destroy.
+function dismissOnOutsidePress(event) {
+  if (!popup.hidden && !root.contains(event.target)) closePopup();
+}
+document.addEventListener('pointerdown', dismissOnOutsidePress);
+// Tabbing out of the widget closes the popup; a null relatedTarget means a click, which the handlers above own.
+root.addEventListener('focusout', (event) => {
+  if (!popup.hidden && event.relatedTarget && !root.contains(event.relatedTarget)) closePopup();
+});
+
+// A new option set moves the cursor to the first row, so Enter picks the top match.
+regions.subscribe((state) => {
+  renderList(state);
+  setActive(state.options.length > 0 ? state.options[0].region : null);
+});
+phone.subscribe((state) => {
+  followResolvedRegion(state.region);
+  renderStatus(state);
+});
+
+// The subscriptions fire only on later changes, so render the initial state manually.
+renderTrigger();
+renderList(regions.getState());
+renderStatus(phone.getState());

--- a/apps/docs/src/components/demos/phone-field.css
+++ b/apps/docs/src/components/demos/phone-field.css
@@ -1,0 +1,54 @@
+#phone-field {
+  --surface: #ffffff;
+  --text: #1c1f1e;
+  --muted: #66716d;
+  --border: #c9d1ce;
+  --accent: #26997b;
+  --valid: #1d7a5f;
+  --error: #b3384f;
+
+  color: var(--text);
+}
+
+#phone-field label {
+  display: block;
+  margin-bottom: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+#phone-field input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  background: var(--surface);
+  color: inherit;
+  font-size: 1rem;
+  font-variant-numeric: tabular-nums;
+}
+
+#phone-field input:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
+#phone-field input::placeholder {
+  color: var(--muted);
+}
+
+#phone-field .phone-field-status {
+  margin: 0.5rem 0 0;
+  min-height: 1.25rem;
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+
+#phone-field .phone-field-status[data-tone='valid'] {
+  color: var(--valid);
+}
+
+#phone-field .phone-field-status[data-tone='error'] {
+  color: var(--error);
+}

--- a/apps/docs/src/components/demos/phone-field.html
+++ b/apps/docs/src/components/demos/phone-field.html
@@ -1,0 +1,5 @@
+<div id="phone-field">
+  <label for="phone-field-input">Phone number</label>
+  <input id="phone-field-input" type="tel" placeholder="+1 201-555-0123" />
+  <p class="phone-field-status"></p>
+</div>

--- a/apps/docs/src/components/demos/phone-field.js
+++ b/apps/docs/src/components/demos/phone-field.js
@@ -1,0 +1,33 @@
+import { ensureEngineReady } from '@telixon/core';
+import { createPhoneInput } from '@telixon/web-sdk';
+
+await ensureEngineReady();
+
+const input = document.querySelector('#phone-field input');
+const status = document.querySelector('#phone-field .phone-field-status');
+
+const phone = createPhoneInput({
+  mode: 'international',
+  display: { callingCodeInInput: true, plusPrefix: 'erasable' },
+  input,
+});
+
+function renderStatus(state) {
+  if (state.value === '') {
+    status.textContent = 'Type a number.';
+    status.dataset.tone = '';
+    return;
+  }
+
+  if (state.validationError === null) {
+    status.textContent = 'Valid: ' + phone.getPhoneNumber().formatE164();
+    status.dataset.tone = 'valid';
+    return;
+  }
+
+  status.textContent = state.validationError.kind;
+  status.dataset.tone = 'error';
+}
+
+phone.subscribe(renderStatus);
+renderStatus(phone.getState());

--- a/apps/docs/src/components/demos/region-picker.css
+++ b/apps/docs/src/components/demos/region-picker.css
@@ -1,0 +1,80 @@
+#region-picker {
+  --surface: #ffffff;
+  --text: #1c1f1e;
+  --muted: #66716d;
+  --border: #c9d1ce;
+  --accent: #26997b;
+
+  color: var(--text);
+}
+
+#region-picker label {
+  display: block;
+  margin-bottom: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+#region-picker input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  background: var(--surface);
+  color: inherit;
+  font-size: 1rem;
+}
+
+#region-picker input:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
+#region-picker input::placeholder {
+  color: var(--muted);
+}
+
+#region-picker ul {
+  margin: 0.75rem 0 0;
+  padding: 0.375rem;
+  list-style: none;
+  max-height: 16rem;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--surface);
+}
+
+#region-picker li {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+#region-picker li:hover,
+#region-picker li[data-active='true'] {
+  background: rgb(38 153 123 / 0.08);
+}
+
+#region-picker li[aria-selected='true'] {
+  background: rgb(38 153 123 / 0.14);
+}
+
+#region-picker li .region-picker-code {
+  margin-left: auto;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+#region-picker .region-picker-status {
+  margin: 0.5rem 0 0;
+  min-height: 1.25rem;
+  font-size: 0.875rem;
+  color: var(--muted);
+}

--- a/apps/docs/src/components/demos/region-picker.html
+++ b/apps/docs/src/components/demos/region-picker.html
@@ -1,0 +1,14 @@
+<div id="region-picker">
+  <label for="region-picker-search">Region</label>
+  <input
+    id="region-picker-search"
+    type="text"
+    role="combobox"
+    aria-expanded="true"
+    aria-controls="region-picker-listbox"
+    aria-autocomplete="list"
+    placeholder="Search regions"
+  />
+  <ul id="region-picker-listbox" role="listbox" aria-label="Regions"></ul>
+  <p class="region-picker-status"></p>
+</div>

--- a/apps/docs/src/components/demos/region-picker.js
+++ b/apps/docs/src/components/demos/region-picker.js
@@ -1,0 +1,112 @@
+import { ensureEngineReady } from '@telixon/core';
+import { createRegionList, regionToFlagEmoji } from '@telixon/web-sdk';
+
+await ensureEngineReady();
+
+const search = document.querySelector('#region-picker input');
+const list = document.querySelector('#region-picker ul');
+const status = document.querySelector('#region-picker .region-picker-status');
+
+const regions = createRegionList({
+  prioritize: ['US', 'CA', 'GB'],
+  dataFactory: ({ region }) => regionToFlagEmoji(region),
+});
+
+let selected = 'US';
+
+// Full rebuild when the search changes the option set.
+function renderList(state) {
+  list.replaceChildren(
+    ...state.options.map((option) => {
+      const row = document.createElement('li');
+      row.id = 'region-picker-option-' + option.region;
+      row.dataset.region = option.region;
+      row.setAttribute('role', 'option');
+      row.setAttribute('aria-selected', String(option.region === selected));
+
+      const flag = document.createElement('span');
+      flag.textContent = option.data;
+      const name = document.createElement('span');
+      name.textContent = option.displayName;
+      const code = document.createElement('span');
+      code.className = 'region-picker-code';
+      code.textContent = '+' + option.callingCode;
+
+      row.append(flag, name, code);
+      return row;
+    }),
+  );
+}
+
+// Move the highlight without rebuilding the list.
+function markSelected(region) {
+  const previous = list.querySelector('[aria-selected="true"]');
+  if (previous) previous.setAttribute('aria-selected', 'false');
+  const next = list.querySelector(`[data-region="${region}"]`);
+  if (next) next.setAttribute('aria-selected', 'true');
+}
+
+// The keyboard cursor. Focus stays in the search while aria-activedescendant names the active row.
+let activeRegion = null;
+
+function setActive(region) {
+  const previous = list.querySelector('[data-active="true"]');
+  if (previous) previous.removeAttribute('data-active');
+  search.removeAttribute('aria-activedescendant');
+  activeRegion = null;
+
+  const next = region === null ? null : list.querySelector(`[data-region="${region}"]`);
+  if (next === null) return;
+  activeRegion = region;
+  next.setAttribute('data-active', 'true');
+  search.setAttribute('aria-activedescendant', next.id);
+  // Scroll the list only; scrollIntoView would drag every scrollable ancestor, the page included.
+  const rowRect = next.getBoundingClientRect();
+  const listRect = list.getBoundingClientRect();
+  if (rowRect.top < listRect.top) list.scrollTop += rowRect.top - listRect.top;
+  else if (rowRect.bottom > listRect.bottom) list.scrollTop += rowRect.bottom - listRect.bottom;
+}
+
+// Wraps past either end; without a cursor, Down starts at the first row and Up at the last.
+function moveActive(step) {
+  const rows = [...list.children];
+  if (rows.length === 0) return;
+  const index = rows.findIndex((row) => row.dataset.region === activeRegion);
+  const nextIndex = index === -1 ? (step > 0 ? 0 : rows.length - 1) : (index + step + rows.length) % rows.length;
+  setActive(rows[nextIndex].dataset.region);
+}
+
+function select(region) {
+  const option = regions.getState().options.find((candidate) => candidate.region === region);
+  if (option === undefined) return;
+  selected = region;
+  markSelected(region);
+  status.textContent = 'Selected: ' + option.displayName + ' (+' + option.callingCode + ')';
+}
+
+search.addEventListener('input', () => regions.search(search.value));
+search.addEventListener('keydown', (event) => {
+  if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+    event.preventDefault();
+    moveActive(event.key === 'ArrowDown' ? 1 : -1);
+    return;
+  }
+  if (event.key === 'Enter' && activeRegion !== null) {
+    event.preventDefault();
+    select(activeRegion);
+  }
+});
+list.addEventListener('click', (event) => {
+  const row = event.target.closest('li');
+  if (row) select(row.dataset.region);
+});
+
+// A new option set moves the cursor to the first row, so Enter picks the top match.
+regions.subscribe((state) => {
+  renderList(state);
+  setActive(state.options.length > 0 ? state.options[0].region : null);
+});
+
+// The subscription fires only on later changes, so render the initial state manually.
+renderList(regions.getState());
+status.textContent = 'Selected: United States (+1)';

--- a/apps/docs/src/content/docs/web-sdk/guides/complete-field.mdx
+++ b/apps/docs/src/content/docs/web-sdk/guides/complete-field.mdx
@@ -1,0 +1,69 @@
+---
+title: Build the complete field
+description: A working phone field with a region picker wired to drive the region.
+---
+
+import { Code, TabItem, Tabs } from '@astrojs/starlight/components';
+import CompleteFieldDemo from '../../../../components/CompleteFieldDemo.astro';
+import html from '../../../../components/demos/complete-field.html?raw';
+import css from '../../../../components/demos/complete-field.css?raw';
+import code from '../../../../components/demos/complete-field.js?raw';
+
+The [phone field](/web-sdk/guides/phone-field/) and the
+[region picker](/web-sdk/guides/region-picker/) combine into one control, with the calling code
+moved from the field into the region button. The button sits on the left, its searchable popup
+opens below, and the formatted number fills the field to the right.
+
+## Live demo
+
+Click the flag, type `canada` into the search, and pick the row. The button shows the Canadian
+flag with the same `+1` while the empty field's placeholder turns into a Canadian example. Type
+`6045550132` and the field formats to `604-555-0132` as the status reports `Valid: +16045550132`.
+Now reopen the picker and choose United States. The `604` digits still resolve to Canada, so the
+flag flips straight back.
+
+The keyboard drives all of it too. Clear the field, reopen the picker, type `united k`, and press
+Enter; the arrow keys walk the list the same way. With the United Kingdom selected, type
+`07400123456` with its national trunk zero. That zero does not belong after `+44`, so the status
+pinpoints `NATIONAL_PREFIX_PRESENT`.
+
+<CompleteFieldDemo />
+
+## The code
+
+The demo runs these exact files. One bordered field holds the region button and the phone input.
+The popup carries the search box and the list.
+[`callingCodeInInput: false`](/core/reference/input-controller/#internationalinputcontrollerconfig)
+keeps the calling code out of the input, so the selected region supplies it. A click on a row calls `select`, which updates the trigger,
+hands the region to [`setRegion`](/web-sdk/phone-input/#setregion), closes the popup, and returns
+focus to the input. The search box doubles as the keyboard cursor, where the arrow keys walk the
+rows through `aria-activedescendant` and Enter picks the active one. Escape closes the popup and
+hands focus back to the region button, while an outside press or focus moving out of the widget
+closes it too.
+
+The subscriber keeps the trigger on the resolved
+[`state.region`](/web-sdk/phone-input/#phoneinputstate), so digits that resolve to another region
+on the same calling code move the flag with them. The stylesheet is self-contained, so retune its
+custom properties to your design. Inside a framework component, call each machine's
+[`destroy`](/web-sdk/phone-input/#destroy) on unmount and remove the document-level press listener
+with them. Package installation and engine loading live in [Getting started](/web-sdk/).
+
+<Tabs syncKey="source">
+
+<TabItem label="HTML">
+  <Code lang="html" code={html} />
+</TabItem>
+
+<TabItem label="CSS">
+  <Code lang="css" code={css} />
+</TabItem>
+
+<TabItem label="JS">
+  <Code lang="js" code={code} />
+</TabItem>
+
+</Tabs>
+
+The two machines never learn about each other. All the wiring lives in the demo's own functions,
+where `select` hands the picked region to the phone while the subscriber moves the list highlight
+to follow the resolved digits.

--- a/apps/docs/src/content/docs/web-sdk/guides/phone-field.mdx
+++ b/apps/docs/src/content/docs/web-sdk/guides/phone-field.mdx
@@ -1,0 +1,59 @@
+---
+title: Build a phone field
+description: An international phone field built from a plain input, one createPhoneInput call, and a small render function.
+---
+
+import { Code, TabItem, Tabs } from '@astrojs/starlight/components';
+import PhoneFieldDemo from '../../../../components/PhoneFieldDemo.astro';
+import html from '../../../../components/demos/phone-field.html?raw';
+import css from '../../../../components/demos/phone-field.css?raw';
+import code from '../../../../components/demos/phone-field.js?raw';
+
+[`createPhoneInput`](/web-sdk/phone-input/#createphoneinput) attaches to a plain `<input>`; this
+guide runs it as an international field. The library handles the events, the caret, and the
+history while your `renderStatus` function draws the rest.
+
+## Live demo
+
+The empty field shows the `+1 201-555-0123` placeholder. Type
+`+14155550132` and watch each keystroke reformat in place until the field reads `+1 415-555-0132`
+and the status reports `Valid: +14155550132`. Select everything and delete it. The erasable plus
+goes with the digits and the placeholder returns. Now type `+442071838750` and the same field
+becomes the United Kingdom's `+44 20 7183 8750`, because the calling code decides the region.
+
+Every editing habit is covered too. Edit in the middle of the value and the caret stays on the
+digit you touched while the groups reflow. Paste a number in any notation. Deletion works
+backward, forward, and a word at a time. Whenever the value falls short, the status reports a
+typed `TOO_SHORT` error. Every edit lands in the field's own history. Undo and redo work with the
+native shortcuts, Cmd/Ctrl+Z and Cmd/Ctrl+Shift+Z.
+
+<PhoneFieldDemo />
+
+## The code
+
+The demo and the source are the same three files. The markup is an input with a static
+placeholder and a status line. The script is one `createPhoneInput` call in international mode,
+where the [erasable plus](/core/reference/input-controller/#internationalinputcontrollerconfig)
+renders only while the value carries one. `renderStatus` draws the status from each emitted
+[state](/web-sdk/phone-input/#phoneinputstate). The library writes the value and the caret
+itself. Restyle by changing the custom properties in the stylesheet.
+
+<Tabs syncKey="source">
+
+<TabItem label="HTML">
+  <Code lang="html" code={html} />
+</TabItem>
+
+<TabItem label="CSS">
+  <Code lang="css" code={css} />
+</TabItem>
+
+<TabItem label="JS">
+  <Code lang="js" code={code} />
+</TabItem>
+
+</Tabs>
+
+Paste, cut, drop, IME composition, word deletes, and native undo are already wired;
+[Covered events](/web-sdk/phone-input/#covered-events) lists them. The field is one half of the
+classic widget, and [Build a region picker](/web-sdk/guides/region-picker/) is the other.

--- a/apps/docs/src/content/docs/web-sdk/guides/region-picker.mdx
+++ b/apps/docs/src/content/docs/web-sdk/guides/region-picker.mdx
@@ -1,0 +1,52 @@
+---
+title: Build a region picker
+description: A region picker built from one createRegionList call, a flag dataFactory, and a small render function.
+---
+
+import { Code, TabItem, Tabs } from '@astrojs/starlight/components';
+import RegionPickerDemo from '../../../../components/RegionPickerDemo.astro';
+import html from '../../../../components/demos/region-picker.html?raw';
+import css from '../../../../components/demos/region-picker.css?raw';
+import code from '../../../../components/demos/region-picker.js?raw';
+
+[`createRegionList`](/web-sdk/region-list/#createregionlist) turns the engine's region data into
+picker rows. The library filters, searches, sorts, and prioritizes the list. Your `renderList`
+function draws the rows.
+
+## Live demo
+
+All 245 regions are in the list, with US, CA, and GB pinned on top. Search `united` and the list
+narrows to three rows. The match runs over names, region codes, and calling codes, so `+44` finds
+the United Kingdom too. Click a row and the status reports the selection, while the arrow keys
+walk the list from the search box and Enter picks the active row.
+
+<RegionPickerDemo />
+
+## The code
+
+The demo and the source are the same three files. The markup is a search input, an empty list, and a status line.
+`createRegionList` builds the rows, with [`prioritize`](/web-sdk/region-list/#regionlistoptions)
+pinning US, CA, and GB and a `dataFactory` putting a
+[flag emoji](/web-sdk/region-list/#regiontoflagemoji) in each option's `data` slot. The search box
+feeds [`search`](/web-sdk/region-list/#search). `renderList` rebuilds the rows from each emitted
+[state](/web-sdk/region-list/#regionliststate). Restyle by changing the custom properties in the
+stylesheet.
+
+<Tabs syncKey="source">
+
+<TabItem label="HTML">
+  <Code lang="html" code={html} />
+</TabItem>
+
+<TabItem label="CSS">
+  <Code lang="css" code={css} />
+</TabItem>
+
+<TabItem label="JS">
+  <Code lang="js" code={code} />
+</TabItem>
+
+</Tabs>
+
+The picker so far only reports the selection.
+[Build the complete field](/web-sdk/guides/complete-field/) wires it to a phone input.

--- a/apps/docs/src/content/docs/web-sdk/index.md
+++ b/apps/docs/src/content/docs/web-sdk/index.md
@@ -1,7 +1,0 @@
----
-title: Getting started
-description: Bind the Telixon input controller to a DOM input with @telixon/web-sdk.
----
-
-`@telixon/web-sdk` binds the core input controller to a DOM `<input>` element. It ships no CSS and
-no image assets; rendering stays yours.

--- a/apps/docs/src/content/docs/web-sdk/index.mdx
+++ b/apps/docs/src/content/docs/web-sdk/index.mdx
@@ -1,0 +1,114 @@
+---
+title: Getting started
+description: Install @telixon/web-sdk and bind a phone input and a region list to the DOM.
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+`@telixon/web-sdk` is the DOM adapter for [`@telixon/core`](/core/). It ships two headless state
+machines for the web, where [`PhoneInput`](/web-sdk/phone-input/) drives a real `<input>` and
+[`RegionList`](/web-sdk/region-list/) feeds region pickers.
+
+## Install
+
+<Tabs syncKey="pkg">
+
+<TabItem label="npm">
+
+```sh
+npm install @telixon/core @telixon/web-sdk
+```
+
+</TabItem>
+
+<TabItem label="pnpm">
+
+```sh
+pnpm add @telixon/core @telixon/web-sdk
+```
+
+</TabItem>
+
+<TabItem label="Yarn">
+
+```sh
+yarn add @telixon/core @telixon/web-sdk
+```
+
+</TabItem>
+
+<TabItem label="Bun">
+
+```sh
+bun add @telixon/core @telixon/web-sdk
+```
+
+</TabItem>
+
+<TabItem label="Deno">
+
+```sh
+deno add npm:@telixon/core npm:@telixon/web-sdk
+```
+
+</TabItem>
+
+</Tabs>
+
+Your code imports both packages, since the engine loads through `@telixon/core` directly.
+
+## Load the engine
+
+Both machines read the engine, so [load it](/core/load-the-engine/) first:
+
+```ts
+import { ensureEngineReady } from '@telixon/core';
+
+await ensureEngineReady();
+```
+
+## Attach a phone input
+
+```ts
+import { createPhoneInput } from '@telixon/web-sdk';
+
+const input = document.querySelector('input')!;
+
+const phone = createPhoneInput({ mode: 'national', defaultRegion: 'US', input });
+
+phone.subscribe((state) => {
+  input.classList.toggle('invalid', state.validationError !== null);
+});
+```
+
+Typing `4155550132` leaves the field showing `(415) 555-0132`; the class drops at the tenth digit.
+The last emitted [state](/web-sdk/phone-input/#phoneinputstate):
+
+```ts
+// {
+//   value: '(415) 555-0132',
+//   region: 'US',
+//   selectionStart: 14,
+//   selectionEnd: 14,
+//   regionFilter: null,
+//   numberTypeFilter: null,
+//   placeholder: '(201) 555-0123',
+//   validationError: null,
+// }
+```
+
+## List the regions
+
+```ts
+import { createRegionList } from '@telixon/web-sdk';
+
+const regions = createRegionList();
+
+regions.getState().options[0];
+// { region: 'AF', callingCode: '93', displayName: 'Afghanistan', data: undefined }
+```
+
+The guides turn these into working fields with live demos:
+[Build a phone field](/web-sdk/guides/phone-field/),
+[Build a region picker](/web-sdk/guides/region-picker/), and
+[Build the complete field](/web-sdk/guides/complete-field/).

--- a/apps/docs/src/content/docs/web-sdk/phone-input.mdx
+++ b/apps/docs/src/content/docs/web-sdk/phone-input.mdx
@@ -1,0 +1,211 @@
+---
+title: PhoneInput
+description: The phone-number controller attached to a DOM input.
+---
+
+A core [`InputController`](/core/reference/input-controller/) attached to a DOM `<input>`. It wires
+the field's events, writes each new value and caret back, and emits a
+[`PhoneInputState`](#phoneinputstate) snapshot to subscribers. No emit fires at construction. The
+initial state is applied straight to the DOM, so read it with [`getState`](#getstate).
+
+## createPhoneInput
+
+```ts
+function createPhoneInput(options: PhoneInputOptions): PhoneInput;
+```
+
+Attaches to an `<input type="text">` or `<input type="tel">`; any other type throws. A second
+attach to the same element throws. Before the engine is loaded it throws `EngineNotReadyError`; see
+[Load the engine](/core/load-the-engine/). [`destroy`](#destroy) releases the element.
+
+```ts
+const phone = createPhoneInput({
+  mode: 'national',
+  defaultRegion: 'US',
+  input: document.querySelector('input')!,
+});
+
+phone.getState().placeholder; // '(201) 555-0123'
+```
+
+## PhoneInputOptions
+
+A discriminated union on `mode`. `'national'` extends
+[`NationalInputControllerConfig`](/core/reference/input-controller/#nationalinputcontrollerconfig);
+`'international'` extends
+[`InternationalInputControllerConfig`](/core/reference/input-controller/#internationalinputcontrollerconfig).
+The adapter adds four fields:
+
+| Field                   | Type                            | Meaning                                                              |
+| ----------------------- | ------------------------------- | -------------------------------------------------------------------- |
+| `input`                 | `PhoneInputElement`             | Required. The `<input>` to attach to, `type="text"` or `type="tel"`. |
+| `regionFilter`          | `readonly RegionCode[] \| null` | Region filter applied at construction.                               |
+| `numberTypeFilter`      | `readonly NumberType[] \| null` | Number-type filter applied at construction.                          |
+| `placeholderNumberType` | `NumberType`                    | The type the placeholder demonstrates; `'MOBILE'` by default.        |
+
+## PhoneInputState
+
+```ts
+type PhoneInputState = {
+  readonly value: string;
+  readonly region: RegionCode | null;
+  readonly selectionStart: number;
+  readonly selectionEnd: number;
+  readonly regionFilter: readonly RegionCode[] | null;
+  readonly numberTypeFilter: readonly NumberType[] | null;
+  readonly placeholder: string | null;
+  readonly validationError: ValidationError | null;
+};
+```
+
+`value`, `region`, and the selection mirror the core
+[`InputState`](/core/reference/input-controller/#inputstate). The two filters echo the active
+restrictions.
+
+`placeholder` is the example number for the resolved region, in the field's own display shape.
+While the value resolves no region, it falls back to the configured `defaultRegion`. It is `null`
+without a region to fall back to, or when the region's metadata carries no example for the
+configured type. It lives in the state only; the DOM `placeholder` attribute stays untouched, so
+render it yourself. A national US field gets `'(201) 555-0123'`. An international field with the
+calling code inside gets `'1 201-555-0123'`.
+
+`validationError` is
+[`getValidationError`](/core/reference/phone-number/#getvalidationerror) for the current value. An
+empty national field reports `TOO_SHORT` under its region.
+
+## Covered events
+
+- Typing, including IME composition (`insertText`, `insertReplacementText`, `compositionend`)
+- Paste, drop, yank (`insertFromPaste`, `insertFromDrop`, `insertFromYank`)
+- Deletes, including cut and drag-out (`deleteContentBackward`, `deleteContentForward`,
+  `deleteByCut`, `deleteByDrag`, `deleteContent`)
+- Word deletes (`deleteWordBackward`, `deleteWordForward`): each consumes one digit group, skipping
+  adjacent formatting
+- Line deletes (`deleteSoftLineBackward`, `deleteHardLineForward`, `deleteEntireSoftLine`, and the
+  rest of the family)
+- Undo and redo: the native `historyUndo` and `historyRedo` input types, plus Cmd/Ctrl+Z,
+  Cmd/Ctrl+Shift+Z, and Cmd/Ctrl+Y
+
+## Members
+
+### subscribe
+
+```ts
+subscribe(listener: (state: PhoneInputState) => void): () => void;
+```
+
+Subscribes to state changes. Returns an unsubscribe function.
+
+### getState
+
+```ts
+getState(): PhoneInputState;
+```
+
+The current state, without subscribing.
+
+### setValue
+
+```ts
+setValue(value: string): void;
+```
+
+Replaces the value through the controller's
+[`setValue`](/core/reference/input-controller/#setvalue), writes the result back, then emits.
+Values written outside the event stream, browser autofill included, bypass the controller; push
+them through this method.
+
+### setRegion
+
+```ts
+setRegion(region: RegionCode): void;
+```
+
+Switches the region through the controller's
+[`setRegion`](/core/reference/input-controller/#setregion), then emits.
+
+### setRegionFilter
+
+```ts
+setRegionFilter(regions: readonly RegionCode[] | null): void;
+```
+
+Applies the [region filter](/core/reference/input-controller/#setregionfilter), then emits. An
+equal filter value is a no-op.
+
+### setNumberTypeFilter
+
+```ts
+setNumberTypeFilter(numberTypes: readonly NumberType[] | null): void;
+```
+
+Applies the [number-type filter](/core/reference/input-controller/#setnumbertypefilter), then
+emits. An equal filter value is a no-op.
+
+### undo
+
+```ts
+undo(): void;
+```
+
+Steps the controller [history](/core/reference/input-controller/#history) back, then emits. With
+nothing to undo, it is a no-op.
+
+### redo
+
+```ts
+redo(): void;
+```
+
+Steps the history forward again, then emits. With nothing to redo, it is a no-op.
+
+### canUndo
+
+```ts
+canUndo(): boolean;
+```
+
+Whether an undo step exists.
+
+### canRedo
+
+```ts
+canRedo(): boolean;
+```
+
+Whether a redo step exists.
+
+### clearHistory
+
+```ts
+clearHistory(): void;
+```
+
+Drops the undo and redo history, then emits.
+
+### getPhoneNumber
+
+```ts
+getPhoneNumber(): PhoneNumber;
+```
+
+The current value as a [`PhoneNumber`](/core/reference/phone-number/) to query.
+
+```ts
+phone.getPhoneNumber().formatE164(); // '+14155550132'
+```
+
+### destroy
+
+```ts
+destroy(): void;
+```
+
+Detaches the DOM listeners, releases the element, and clears subscribers. Idempotent. After it, the
+field behaves as a plain input again.
+
+## Pair with a region picker
+
+A [`RegionList`](/web-sdk/region-list/) supplies the rows; the picker's selection hands its region
+to [`setRegion`](#setregion). The full wiring, with a popup and a live demo, is in
+[Build the complete field](/web-sdk/guides/complete-field/).

--- a/apps/docs/src/content/docs/web-sdk/region-list.mdx
+++ b/apps/docs/src/content/docs/web-sdk/region-list.mdx
@@ -1,0 +1,190 @@
+---
+title: RegionList
+description: The headless state machine behind region pickers.
+---
+
+A headless state machine for region pickers. It produces the option rows a dropdown renders and
+emits a [`RegionListState`](#regionliststate) snapshot on every change. Each change recomputes the
+options through one pipeline of region filter, number-type filter, search, sort, and prioritized
+pins. No emit fires at construction; read the bootstrap with [`getState`](#getstate).
+
+## createRegionList
+
+```ts
+function createRegionList<T = undefined>(options?: RegionListOptions<T>): RegionList<T>;
+```
+
+Before the engine is loaded it throws `EngineNotReadyError`; see
+[Load the engine](/core/load-the-engine/).
+
+```ts
+const regions = createRegionList();
+
+regions.getState().options[0];
+// { region: 'AF', callingCode: '93', displayName: 'Afghanistan', data: undefined }
+```
+
+## RegionListOptions
+
+| Field              | Type                            | Meaning                                                                                                                |
+| ------------------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `dataFactory`      | `(input) => T`                  | Produces the `data` slot from the option's `region`, `callingCode`, and `displayName`; its return type flows into `T`. |
+| `regionFilter`     | `readonly RegionCode[] \| null` | Restricts the list to these regions.                                                                                   |
+| `numberTypeFilter` | `readonly NumberType[] \| null` | Keeps regions that assign at least one of these types.                                                                 |
+| `searchQuery`      | `string`                        | Initial search query.                                                                                                  |
+| `searchFn`         | `(query, option) => boolean`    | Custom search predicate; the default is described under [Search matching](#search-matching).                           |
+| `locale`           | `string`                        | Locale for display names; `'en'` by default.                                                                           |
+| `sort`             | `RegionListSort`                | `'alphabetical'` (default), `'callingCode'`, or a comparator.                                                          |
+| `prioritize`       | `readonly RegionCode[]`         | Regions pinned to the top, in the given order.                                                                         |
+
+For both filters, `null` lifts the restriction; `[]` matches nothing.
+
+## RegionOption
+
+```ts
+type RegionOption<T = undefined> = {
+  readonly region: RegionCode;
+  readonly callingCode: string;
+  readonly displayName: string;
+  readonly data: T;
+};
+```
+
+`displayName` comes from `Intl.DisplayNames` for the active locale, falling back to the region
+code. The exact string depends on the runtime's ICU data. `data` carries whatever the
+`dataFactory` produced.
+
+## RegionListState
+
+```ts
+type RegionListState<T = undefined> = {
+  readonly options: readonly RegionOption<T>[];
+  readonly regionFilter: readonly RegionCode[] | null;
+  readonly numberTypeFilter: readonly NumberType[] | null;
+  readonly searchQuery: string;
+  readonly locale: string;
+};
+```
+
+`options` is the list as currently rendered, with the filters, search, sort, and prioritization
+already applied.
+
+## Search matching
+
+The default predicate runs a contains match over the display name, the region code, and the
+calling code, with diacritics ignored, everything lowercased, and a leading `+` stripped from the
+query.
+
+```ts
+regions.search('united');
+
+regions
+  .getState()
+  .options.slice(0, 3)
+  .map((option) => option.region); // ['AE', 'GB', 'US']
+```
+
+Pass `searchFn` to replace the predicate; empty and whitespace-only queries short-circuit without
+calling it.
+
+## Sort and prioritize
+
+```ts
+createRegionList({ sort: 'callingCode' }).getState().options[0];
+// { region: 'AS', callingCode: '1', displayName: 'American Samoa', data: undefined }
+
+createRegionList({ prioritize: ['US', 'CA'] })
+  .getState()
+  .options.slice(0, 3)
+  .map((option) => option.region); // ['US', 'CA', 'AF']
+```
+
+The built-in comparators collate display names in the list's locale and break ties by region code.
+`prioritize` moves its regions to the top after sorting; the rest keep their order.
+
+## regionToFlagEmoji
+
+```ts
+function regionToFlagEmoji(region: RegionCode): string;
+```
+
+The region's flag emoji, built from the two Unicode regional indicator symbols for its letters. Platforms
+without flag emoji, notably Windows, render the two letters; for a flag on every platform, ship an
+SVG set keyed by the region code.
+
+```ts
+regionToFlagEmoji('US'); // '🇺🇸'
+
+createRegionList({ dataFactory: ({ region }) => regionToFlagEmoji(region) }).getState().options[0];
+// { region: 'AF', callingCode: '93', displayName: 'Afghanistan', data: '🇦🇫' }
+```
+
+## Members
+
+### subscribe
+
+```ts
+subscribe(listener: (state: RegionListState<T>) => void): () => void;
+```
+
+Subscribes to state changes. Returns an unsubscribe function.
+
+### getState
+
+```ts
+getState(): RegionListState<T>;
+```
+
+The current state, without subscribing.
+
+### search
+
+```ts
+search(query: string): void;
+```
+
+Updates the query and re-runs the pipeline. An unchanged query is a no-op.
+
+### localize
+
+```ts
+localize(locale: string): void;
+```
+
+Switches the locale, recomputes display names and `data`, then re-runs the pipeline. An unchanged
+locale is a no-op.
+
+### refresh
+
+```ts
+refresh(): void;
+```
+
+Recomputes the base set and emits, always. Use it when external state read by `dataFactory` has
+changed.
+
+### setRegionFilter
+
+```ts
+setRegionFilter(value: readonly RegionCode[] | null): void;
+```
+
+Replaces the region filter. An equal value is a no-op.
+
+### setNumberTypeFilter
+
+```ts
+setNumberTypeFilter(value: readonly NumberType[] | null): void;
+```
+
+Replaces the number-type filter, matched via
+[`regionSupportsNumberTypes`](/core/reference/region-data/#regionsupportsnumbertypes). An equal
+value is a no-op.
+
+### destroy
+
+```ts
+destroy(): void;
+```
+
+Clears all subscribers. Idempotent.

--- a/apps/docs/src/package-registry.ts
+++ b/apps/docs/src/package-registry.ts
@@ -52,7 +52,22 @@ export const PACKAGES: readonly DocsPackage[] = [
       'verified',
     ],
   },
-  { base: 'web-sdk', name: '@telixon/web-sdk', label: 'Web SDK' },
+  {
+    base: 'web-sdk',
+    name: '@telixon/web-sdk',
+    label: 'Web SDK',
+    sidebar: [
+      'web-sdk',
+      {
+        label: 'Guides',
+        items: ['web-sdk/guides/phone-field', 'web-sdk/guides/region-picker', 'web-sdk/guides/complete-field'],
+      },
+      {
+        label: 'Reference',
+        items: ['web-sdk/phone-input', 'web-sdk/region-list'],
+      },
+    ],
+  },
   { name: '@telixon/web-anatomy', label: 'Web Anatomy' },
   { name: '@telixon/web-theme', label: 'Web Theme' },
   { name: '@telixon/web-components', label: 'Web Components', logo: 'stencil' },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,16 @@ export default [
     },
   },
   {
+    // Client-side demo scripts shipped by the docs app run in the browser.
+    files: ['apps/docs/src/components/demos/**/*.js'],
+    languageOptions: {
+      globals: {
+        document: 'readonly',
+        window: 'readonly',
+      },
+    },
+  },
+  {
     files: ['scripts/**/*.{mjs,js}', '**/*.config.{mjs,js}'],
     languageOptions: {
       globals: {


### PR DESCRIPTION
## Summary

Documents `@telixon/web-sdk`: reference pages for `PhoneInput` and `RegionList`, three guides that build a phone field, a region picker, and the combined control, and the live demos behind them. Each guide embeds its real demo files, so the shown code is what runs. Docs and demos only; no library code changes.

## Motivation

The web-sdk package had a placeholder page and no reference or guides.

## Conformance impact

None. Documentation and demo assets only.

## Checklist

- [x] Tests added or updated (docs only; every reference claim and example output was runtime-verified against the built library)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally; `astro check` clean
- [x] Docs reflect the change (this is the docs)
- [x] Commit message follows the project convention