### PR TITLE
docs(core): refresh the reference and guides to match input-controlle…

### DIFF
--- a/apps/docs/src/content/docs/core/guides/build-a-phone-input.mdx
+++ b/apps/docs/src/content/docs/core/guides/build-a-phone-input.mdx
@@ -22,10 +22,14 @@ const controller = createNationalInputController({ defaultRegion: 'US' });
 
 Translate the field's `beforeinput` events into controller calls. Write each returned state back:
 
+```html
+<input id="phone" type="tel" autocomplete="tel" />
+```
+
 ```ts
 import type { InputState } from '@telixon/core';
 
-const input = document.querySelector('input')!;
+const input = document.querySelector<HTMLInputElement>('#phone')!;
 
 function apply(state: InputState) {
   input.value = state.value;
@@ -50,8 +54,9 @@ input.addEventListener('beforeinput', (event) => {
 ```
 
 Typing `4155550132` leaves the field showing `(415) 555-0132`, with the caret after the last
-digit. A paste flows through the same handler. For a production binding, use
-[`@telixon/web-sdk`](/web-sdk/), the DOM adapter for controllers.
+digit. A paste flows through the same handler. This minimal handler stops at typing, paste, and
+plain deletes; word deletes, line deletes, and IME composition need branches of their own, which
+[`PhoneInput`](/web-sdk/phone-input/) from `@telixon/web-sdk` already wires for production.
 
 ## Undo and redo
 
@@ -60,9 +65,12 @@ keys to it:
 
 ```ts
 input.addEventListener('keydown', (event) => {
-  if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== 'z') return;
+  if (!event.metaKey && !event.ctrlKey) return;
+  const key = event.key.toLowerCase();
+  if (key !== 'z' && key !== 'y') return;
   event.preventDefault();
-  apply(event.shiftKey ? controller.redo() : controller.undo());
+  const isRedo = (key === 'z' && event.shiftKey) || key === 'y';
+  apply(isRedo ? controller.redo() : controller.undo());
 });
 ```
 

--- a/apps/docs/src/content/docs/core/guides/build-a-region-selector.mdx
+++ b/apps/docs/src/content/docs/core/guides/build-a-region-selector.mdx
@@ -1,10 +1,10 @@
 ---
 title: Build a region selector
-description: Pair a region dropdown with the phone field and keep the two in sync.
+description: Pair a region dropdown with the phone field and drive the region from it.
 ---
 
-A region selector pairs a dropdown with the phone field. The dropdown sets the region. The field
-holds the national number.
+A region selector pairs a dropdown with the phone field, where the dropdown sets the region and
+the field holds the digits after the calling code.
 
 ## List the regions
 
@@ -46,8 +46,7 @@ getPlaceholders('US', 'MOBILE')?.national; // '(201) 555-0123'
 
 ## Wire the dropdown to the field
 
-An international controller with the calling code kept out of the field takes its region from the
-dropdown. Call [`setRegion`](/core/reference/input-controller/#setregion) on the dropdown's
+Keep the calling code out of the field and the controller takes its region from the dropdown. Call [`setRegion`](/core/reference/input-controller/#setregion) on the dropdown's
 `change` event and write the returned state back:
 
 ```ts

--- a/apps/docs/src/content/docs/core/guides/validate-user-input.mdx
+++ b/apps/docs/src/content/docs/core/guides/validate-user-input.mdx
@@ -3,16 +3,18 @@ title: Validate user input
 description: Tolerant feedback while the user types and an exact message on submit.
 ---
 
-A phone field needs two kinds of feedback: tolerant while the user types, exact on submit. The
-possibility checks give the first. `getValidationError` gives the second.
+A phone field needs feedback that stays tolerant while the user types and turns exact on submit.
+The possibility checks give the first. `getValidationError` gives the second.
 
 ## While the user types
 
-Most values in a field are unfinished, so treat a short number as neutral. Two failures are worth
-flagging immediately, because more typing cannot fix them: a calling code that does not exist and a
-number that is already too long.
+Most values in a field are unfinished, so treat a short number as neutral. A calling code that
+does not exist and a number that is already too long are worth flagging immediately, because more
+typing cannot fix either.
 
 ```ts
+import { parsePhoneNumber } from '@telixon/core';
+
 function feedbackWhileTyping(input: string): string | null {
   const number = parsePhoneNumber(input, { defaultRegion: 'US' });
   if (number.isValid()) return null;
@@ -42,7 +44,7 @@ user can act on. The [carried payloads](/core/reference/validation-error/#carrie
 message name the fix:
 
 ```ts
-import type { ValidationError } from '@telixon/core';
+import { parsePhoneNumber, type ValidationError } from '@telixon/core';
 
 function describe(error: ValidationError): string {
   switch (error.kind) {

--- a/apps/docs/src/content/docs/core/how-it-works.mdx
+++ b/apps/docs/src/content/docs/core/how-it-works.mdx
@@ -53,7 +53,7 @@ parsePhoneNumber('+1 (415) 555-0132').formatE164(); // '+14155550132'
 
 - **[Parsing does not throw.](/core/reference/parse-phone-number/)** A walk always ends somewhere.
   Where it ends is the result.
-- **[Formatting can return `null`.](/core/reference/phone-number/#formats)** A format is a property
-  of an accepting state. A number that never reached one has no format to give.
+- **[Formatting can return `null`.](/core/reference/phone-number/#formats)** The formats follow
+  possibility, so a number whose calling code or length can never work has no format to give.
 - **[The engine loads first.](/core/load-the-engine/)** Without the tables there is nothing to
   walk.

--- a/apps/docs/src/content/docs/core/index.mdx
+++ b/apps/docs/src/content/docs/core/index.mdx
@@ -6,7 +6,7 @@ description: Install @telixon/core, load the engine, and parse a first phone num
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 `@telixon/core` parses, validates, and formats phone numbers. The same engine drives phone-number
-fields. It runs in Node.js, browsers, Deno, Bun, and edge runtimes, with no dependencies.
+fields. The package runs in Node.js, browsers, Deno, Bun, and edge runtimes, with no dependencies.
 
 ## Install
 
@@ -81,7 +81,7 @@ parsePhoneNumber('(415) 555-0132', { defaultRegion: 'US' }).formatE164(); // '+1
 
 ## Inspect invalid input
 
-`parsePhoneNumber` [never throws](/core/reference/parse-phone-number/): bad input still comes back
+`parsePhoneNumber` [never throws](/core/reference/parse-phone-number/); bad input still comes back
 as a `PhoneNumber`, with a typed reason:
 
 ```ts

--- a/apps/docs/src/content/docs/core/load-the-engine.mdx
+++ b/apps/docs/src/content/docs/core/load-the-engine.mdx
@@ -4,7 +4,7 @@ description: Load the engine with ensureEngineReady, or synchronously with ensur
 ---
 
 The engine is the compiled automaton. Every query and controller call reads it, so it must be in
-memory first. Loading is explicit: nothing loads when you import the package.
+memory first. Loading is explicit, so nothing loads when you import the package.
 
 ## ensureEngineReady
 
@@ -12,7 +12,7 @@ memory first. Loading is explicit: nothing loads when you import the package.
 function ensureEngineReady(): Promise<void>;
 ```
 
-Call it once, before the first API call. It is idempotent: later calls resolve immediately and load
+Call it once, before the first API call. It is idempotent, so later calls resolve immediately and load
 nothing. You choose the moment.
 
 ```ts
@@ -24,7 +24,7 @@ parsePhoneNumber('+1 (415) 555-0132').isValid(); // true
 ```
 
 Concurrent calls share one in-flight load. A failed load rejects with the underlying error. The
-failure is not cached: the next call starts a fresh load.
+failure is not cached, so the next call starts a fresh load.
 
 ## EngineNotReadyError
 
@@ -71,8 +71,8 @@ The package name is the same everywhere. The runtime picks the build.
 | Workers, edge, `workerd` | `index.edge.js`    |
 
 The browser and edge builds import the tables as code-split modules, then inflate them with
-`DecompressionStream`. The Node build decodes with native zlib, off the event loop.
-`ensureEngineReady` is the same call everywhere.
+`DecompressionStream`, falling back to a pure-JS inflater where the API is missing. The Node build
+decodes with native zlib, off the event loop. `ensureEngineReady` is the same call everywhere.
 
 ## ensureEngineReadySync
 
@@ -80,8 +80,9 @@ The browser and edge builds import the tables as code-split modules, then inflat
 function ensureEngineReadySync(): void;
 ```
 
-Initializes the engine synchronously, from tables embedded in the bundle. The cost is bundle size:
-the embedded tables are about [123 kB gzipped](/verified/#size). It lands only where this entry is imported.
+Initializes the engine synchronously, from tables embedded in the bundle. The cost is bundle size, with
+the embedded tables at about [122 kB gzipped](/verified/#size). That weight lands only where this
+entry is imported.
 
 ```ts
 import { ensureEngineReadySync } from '@telixon/core/sync-init';
@@ -92,8 +93,8 @@ ensureEngineReadySync();
 parsePhoneNumber('+1 (415) 555-0132').isValid(); // true
 ```
 
-Reach for this only where you cannot await: a synchronous constructor, a module-level default, a
-migration script. Everywhere else, prefer `ensureEngineReady`.
+Reach for this only where you cannot await, such as a synchronous constructor, a module-level
+default, or a migration script. Everywhere else, prefer `ensureEngineReady`.
 
 ## One engine per process
 

--- a/apps/docs/src/content/docs/core/reference/input-controller.mdx
+++ b/apps/docs/src/content/docs/core/reference/input-controller.mdx
@@ -24,12 +24,12 @@ controller.insert('', '4155550132', 0, 0);
 
 ### NationalInputControllerConfig
 
-| Field            | Type         | Meaning                                                          |
-| ---------------- | ------------ | ---------------------------------------------------------------- |
-| `defaultRegion`  | `RegionCode` | Required. The region the field formats for.                      |
-| `strict`         | `boolean`    | Restricts validity to `defaultRegion`, as in `parsePhoneNumber`. |
-| `initialValue`   | `string`     | Seeds the field with a starting value, outside the history.      |
-| `maxHistorySize` | `number`     | Bounds the undo and redo history.                                |
+| Field            | Type         | Meaning                                                                              |
+| ---------------- | ------------ | ------------------------------------------------------------------------------------ |
+| `defaultRegion`  | `RegionCode` | Required. The region the field formats for.                                          |
+| `strict`         | `boolean`    | Restricts validity to `defaultRegion`, as in `parsePhoneNumber`.                     |
+| `initialValue`   | `string`     | Seeds the field with a starting value, outside the history.                          |
+| `maxHistorySize` | `number`     | Bounds the undo and redo history; 150 entries by default, dropping the oldest first. |
 
 ## createInternationalInputController
 
@@ -62,8 +62,11 @@ code is in the field, `defaultRegion` pre-fills the field with that region's cod
 | `{ callingCodeInInput: true, plusPrefix }` | Calling-code digits, with the `+` under `plusPrefix`                                                      |
 | `{ callingCodeInInput: false }`            | The international significant number; the region comes from `defaultRegion` and [`setRegion`](#setregion) |
 
-`plusPrefix`, a `PlusPrefixMode`, renders the leading `+`: `'none'` never, `'fixed'` always,
-`'erasable'` while the value carries one. Under `'erasable'`, backspace at the start removes it.
+`plusPrefix`, a `PlusPrefixMode`, renders the leading `+`, with `'none'` never showing it,
+`'fixed'` always, and `'erasable'` while the value carries one. Under `'erasable'`, backspace
+right after the `+` removes it. Every plus-less start, an empty or omitted `initialValue`
+included, begins with the plus erased, so an empty field renders truly empty; only the
+calling-code seed from `defaultRegion` keeps the visible plus.
 
 ## InputState
 
@@ -80,8 +83,8 @@ The next value and caret to apply to the field. `value` is the formatted string.
 region the value resolves to, or `null` when none does. A field with no digits reports the
 configured default region, so clearing the value keeps the region stable. The selection indices
 point into `value`.
-Within a shared calling code, `region` reports the resolved owner of the digits: a `604` number
-reports `CA` even in a US-configured field.
+Within a shared calling code, `region` reports the resolved owner of the digits, so a `604`
+number reports `CA` even in a US-configured field.
 
 ## Edits
 
@@ -104,8 +107,8 @@ deleteBackward(value: string, selectionStart: number, selectionEnd: number): Inp
 ```
 
 Deletes the selection, or the character before the caret when the selection is empty, then
-reformats. When that character is a formatting character, the deletion steps across it to the
-nearest digit.
+reformats. When that character is a formatting character, the call snaps the caret across it to
+the nearest digit without deleting; the next delete removes the digit itself.
 
 ### deleteForward
 
@@ -160,8 +163,8 @@ leaves no possible length for the value's calling code reports
 
 ## History
 
-The four edits and `setRegion` push a new entry onto the history. The two filters replace the
-current entry.
+The four edits and `setRegion` push a new entry onto the history when they change the state. The
+two filters replace the current entry.
 
 ### undo
 
@@ -215,9 +218,11 @@ getPhoneNumber(): PhoneNumber;
 ```
 
 The current value as a [`PhoneNumber`](/core/reference/phone-number/) to query, equal to
-`parsePhoneNumber` of the displayed value. With the calling code kept out of the field
-(`callingCodeInInput: false`), the digits resolve literally as the international significant
-number behind the selected region's calling code. A typed national (trunk) prefix there reports
+`parsePhoneNumber` of the displayed value, with the national controller's `defaultRegion` and
+`strict` carried along. Active filters have no `parsePhoneNumber` equivalent and narrow the
+result further. With the calling code kept out of the field (`callingCodeInInput: false`), the
+digits resolve literally as the international significant number behind the selected region's
+calling code. A typed national (trunk) prefix there reports
 [`NATIONAL_PREFIX_PRESENT`](/core/reference/validation-error/).
 
 ### currentState

--- a/apps/docs/src/content/docs/core/reference/parse-phone-number.mdx
+++ b/apps/docs/src/content/docs/core/reference/parse-phone-number.mdx
@@ -8,9 +8,12 @@ function parsePhoneNumber(input: string, options?: ParsePhoneNumberOptions): Pho
 ```
 
 Parses a phone number to validate, format, and inspect it. A leading `+` reads as international;
-otherwise the digits resolve against `defaultRegion`. Spacing and punctuation are ignored. It never
-throws on bad input: the returned [`PhoneNumber`](/core/reference/phone-number/) reports why it is
-not valid.
+otherwise the digits resolve against `defaultRegion`, with the region's IDD prefix, a redundant
+leading calling code, and the national prefix all recognized and stripped. Spacing and punctuation
+are ignored. It never throws on bad input; the returned
+[`PhoneNumber`](/core/reference/phone-number/) reports why it is not valid. Like every entry
+point, it requires a [loaded engine](/core/load-the-engine/) and throws `EngineNotReadyError`
+before that.
 
 ```ts
 parsePhoneNumber('+1 (415) 555-0132').formatE164(); // '+14155550132'
@@ -39,8 +42,10 @@ parsePhoneNumber('415-555-0132', { defaultRegion: 'US' }).getRegion(); // 'US'
 strict?: boolean;
 ```
 
-Restricts `isValid` and `getNumberType` to `defaultRegion`. Other methods ignore it. Without
-`defaultRegion` it has no effect. It is off by default.
+Restricts validity to `defaultRegion`, so `isValid`, `getNumberType`, and
+[`getValidationError`](/core/reference/phone-number/#getvalidationerror) all follow it while the
+possibility checks and the formats ignore it. Without `defaultRegion` it has no effect. It is off
+by default.
 
 ```ts
 const number = parsePhoneNumber('(604) 555-0132', { defaultRegion: 'US', strict: true });

--- a/apps/docs/src/content/docs/core/reference/phone-number.mdx
+++ b/apps/docs/src/content/docs/core/reference/phone-number.mdx
@@ -56,7 +56,9 @@ parsePhoneNumber('+1 415').isPossibleWithReason(); // 'TOO_SHORT'
 ### getValidationError
 
 The fault to correct, or `null` when none applies. One of the nine typed
-[`ValidationError`](/core/reference/validation-error/) variants.
+[`ValidationError`](/core/reference/validation-error/) variants. A valid number can still carry
+the `NATIONAL_PREFIX_MISSING` advisory, so gate on [`isValid`](#isvalid) for validity and read the
+error for guidance.
 
 ```ts
 number.getValidationError(); // null
@@ -96,7 +98,7 @@ number.getCallingCode(); // '1'
 
 ### getNationalNumber
 
-The national significant number: digits only, with the national prefix stripped.
+The national significant number, digits only, with the national prefix stripped.
 
 ```ts
 number.getNationalNumber(); // '4155550132'
@@ -122,11 +124,15 @@ parsePhoneNumber('+1 415').formatE164(); // null
 
 ### formatE164
 
+Canonical E.164, with the calling code and no formatting.
+
 ```ts
 number.formatE164(); // '+14155550132'
 ```
 
 ### formatNational
+
+The region's own national convention.
 
 ```ts
 number.formatNational(); // '(415) 555-0132'
@@ -134,11 +140,15 @@ number.formatNational(); // '(415) 555-0132'
 
 ### formatInternational
 
+The international convention, with the calling code spelled out.
+
 ```ts
 number.formatInternational(); // '+1 415-555-0132'
 ```
 
 ### formatRfc3966
+
+An RFC 3966 `tel:` URI.
 
 ```ts
 number.formatRfc3966(); // 'tel:+1-415-555-0132'

--- a/apps/docs/src/content/docs/core/reference/region-data.mdx
+++ b/apps/docs/src/content/docs/core/reference/region-data.mdx
@@ -3,7 +3,7 @@ title: Region data
 description: REGION_CODES, NUMBER_TYPES, and the four region query functions.
 ---
 
-Static data and lookups about regions and number types: the building blocks for region dropdowns,
+Static data and lookups about regions and number types, the building blocks for region dropdowns,
 placeholders, and input constraints.
 
 ## REGION_CODES

--- a/apps/docs/src/content/docs/core/reference/validation-error.mdx
+++ b/apps/docs/src/content/docs/core/reference/validation-error.mdx
@@ -18,8 +18,9 @@ type ValidationError =
 
 The fault to correct in the input. Returned by
 [`getValidationError`](/core/reference/phone-number/#getvalidationerror), which is `null` when
-none applies. The union is discriminated on `kind`, so a `switch` over it is exhaustive. When a
-variant is added, every `switch` that misses it stops compiling. The kinds mirror libphonenumber
+none applies. The union is discriminated on `kind`, so a `switch` narrows every variant. With a
+declared return type on the switching function, a newly added variant stops compiling until every
+`switch` handles it. The kinds mirror libphonenumber
 where applicable.
 
 ## Variants
@@ -40,9 +41,9 @@ Every row is a real input and its real result.
 
 `NATIONAL_PREFIX_PRESENT` comes only from a controller holding the calling code outside the field
 (`callingCodeInInput: false`), where the digits are the international significant number. It
-reports when the typed digits begin with national-dialing digits, the trunk prefix or a carrier
-code, that dropping would leave a valid number. `prefix` is the exact leading chunk to drop; a
-Belarusian number typed as `80 29…` reports `prefix: '80'`.
+reports when a number that is not valid as typed begins with a national-dialing chunk, the trunk
+prefix or a carrier code, whose removal leaves a valid number. `prefix` is the exact leading chunk
+to drop; a Belarusian number typed as `80 29…` reports `prefix: '80'`.
 
 ## Carried data
 

--- a/packages/core/src/modules/parse-phone-number/models/index.ts
+++ b/packages/core/src/modules/parse-phone-number/models/index.ts
@@ -5,8 +5,8 @@ export interface ParsePhoneNumberOptions {
   /** The region to resolve input against when it has no leading `+`. */
   defaultRegion?: RegionCode;
   /**
-   * Restricts `isValid` and `getNumberType` to `defaultRegion`. Other methods ignore it. No effect
-   * without `defaultRegion`; off by default.
+   * Restricts validity to `defaultRegion`; `isValid`, `getNumberType`, and `getValidationError`
+   * follow it. No effect without `defaultRegion`; off by default.
    */
   strict?: boolean;
 }


### PR DESCRIPTION
## Summary

Refreshes the core reference and guides to match the merged input-controller and parse behavior. Covers the 150-entry default history, the erasable-plus empty field, the caret snap on deleting a formatting character, `getPhoneNumber` carrying `defaultRegion` and `strict` with filters narrowing further, and `strict` now governing `getValidationError`. Also syncs the one `ParsePhoneNumberOptions.strict` doc comment. Docs only, aside from that comment.

## Motivation

The reference had drifted from the behavior shipped in recent input-controller and filter fixes.

## Conformance impact

None. Documentation and a doc comment only.

## Checklist

- [x] Tests added or updated (docs; every changed claim was checked against the code)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally; `astro check` clean
- [x] Docs reflect the change (this is the docs)
- [x] Commit message follows the project convention
