### PR TITLE
docs(web-sdk): refine the reference, guides, and demos

### DIFF
--- a/apps/docs/src/components/demos/complete-field.css
+++ b/apps/docs/src/components/demos/complete-field.css
@@ -154,6 +154,13 @@
   font-variant-numeric: tabular-nums;
 }
 
+#complete-field li.phone-field-empty {
+  justify-content: center;
+  color: var(--muted);
+  cursor: default;
+  pointer-events: none;
+}
+
 #complete-field .phone-field-status {
   margin: 0.5rem 0 0;
   min-height: 1.25rem;

--- a/apps/docs/src/components/demos/complete-field.js
+++ b/apps/docs/src/components/demos/complete-field.js
@@ -42,6 +42,14 @@ function renderTrigger() {
 
 // Full rebuild when the search changes the option set.
 function renderList(state) {
+  if (state.options.length === 0) {
+    const empty = document.createElement('li');
+    empty.className = 'phone-field-empty';
+    empty.textContent = 'No matches';
+    list.replaceChildren(empty);
+    return;
+  }
+
   list.replaceChildren(
     ...state.options.map((option) => {
       const row = document.createElement('li');

--- a/apps/docs/src/components/demos/phone-field.js
+++ b/apps/docs/src/components/demos/phone-field.js
@@ -20,7 +20,7 @@ function renderStatus(state) {
   }
 
   if (state.validationError === null) {
-    status.textContent = 'Valid: ' + phone.getPhoneNumber().formatE164();
+    status.textContent = 'Valid: ' + state.region + ' ' + phone.getPhoneNumber().formatE164();
     status.dataset.tone = 'valid';
     return;
   }

--- a/apps/docs/src/components/demos/region-picker.css
+++ b/apps/docs/src/components/demos/region-picker.css
@@ -72,6 +72,13 @@
   font-variant-numeric: tabular-nums;
 }
 
+#region-picker li.region-picker-empty {
+  justify-content: center;
+  color: var(--muted);
+  cursor: default;
+  pointer-events: none;
+}
+
 #region-picker .region-picker-status {
   margin: 0.5rem 0 0;
   min-height: 1.25rem;

--- a/apps/docs/src/components/demos/region-picker.js
+++ b/apps/docs/src/components/demos/region-picker.js
@@ -16,6 +16,14 @@ let selected = 'US';
 
 // Full rebuild when the search changes the option set.
 function renderList(state) {
+  if (state.options.length === 0) {
+    const empty = document.createElement('li');
+    empty.className = 'region-picker-empty';
+    empty.textContent = 'No matches';
+    list.replaceChildren(empty);
+    return;
+  }
+
   list.replaceChildren(
     ...state.options.map((option) => {
       const row = document.createElement('li');

--- a/apps/docs/src/content/docs/web-sdk/guides/complete-field.mdx
+++ b/apps/docs/src/content/docs/web-sdk/guides/complete-field.mdx
@@ -9,23 +9,21 @@ import html from '../../../../components/demos/complete-field.html?raw';
 import css from '../../../../components/demos/complete-field.css?raw';
 import code from '../../../../components/demos/complete-field.js?raw';
 
-The [phone field](/web-sdk/guides/phone-field/) and the
-[region picker](/web-sdk/guides/region-picker/) combine into one control, with the calling code
-moved from the field into the region button. The button sits on the left, its searchable popup
-opens below, and the formatted number fills the field to the right.
+This guide wires the [phone field](/web-sdk/guides/phone-field/) and the
+[region picker](/web-sdk/guides/region-picker/) into one widget. The phone input runs in selector
+mode, which keeps the calling code in the region button on the left rather than the field. The
+searchable popup opens below the button, and the formatted number fills the field to the right.
 
 ## Live demo
 
-Click the flag, type `canada` into the search, and pick the row. The button shows the Canadian
-flag with the same `+1` while the empty field's placeholder turns into a Canadian example. Type
-`6045550132` and the field formats to `604-555-0132` as the status reports `Valid: +16045550132`.
-Now reopen the picker and choose United States. The `604` digits still resolve to Canada, so the
-flag flips straight back.
+Open the picker, search `canada`, and pick it. The button shows the Canadian flag on `+1`, and the
+empty field's placeholder becomes a Canadian example. Type `6045550132` and the field reads `604-555-0132` with
+the status `Valid: +16045550132`. Reopen the picker and choose United States. `604` still belongs
+to Canada, which flips the flag straight back.
 
-The keyboard drives all of it too. Clear the field, reopen the picker, type `united k`, and press
-Enter; the arrow keys walk the list the same way. With the United Kingdom selected, type
-`07400123456` with its national trunk zero. That zero does not belong after `+44`, so the status
-pinpoints `NATIONAL_PREFIX_PRESENT`.
+The keyboard works throughout. Search `united k` and press Enter, or walk the rows with the arrow
+keys. Select the United Kingdom and type `07400123456`. The leading zero is a trunk prefix with no
+place after `+44`. The status reads `NATIONAL_PREFIX_PRESENT`.
 
 <CompleteFieldDemo />
 
@@ -34,17 +32,16 @@ pinpoints `NATIONAL_PREFIX_PRESENT`.
 The demo runs these exact files. One bordered field holds the region button and the phone input.
 The popup carries the search box and the list.
 [`callingCodeInInput: false`](/core/reference/input-controller/#internationalinputcontrollerconfig)
-keeps the calling code out of the input, so the selected region supplies it. A click on a row calls `select`, which updates the trigger,
-hands the region to [`setRegion`](/web-sdk/phone-input/#setregion), closes the popup, and returns
-focus to the input. The search box doubles as the keyboard cursor, where the arrow keys walk the
+keeps the calling code out of the input, leaving the selected region to supply it. A click on a row
+calls `select`, which updates the button, hands the region to
+[`setRegion`](/web-sdk/phone-input/#setregion), closes the popup, and returns focus to the input. The search box doubles as the keyboard cursor, where the arrow keys walk the
 rows through `aria-activedescendant` and Enter picks the active one. Escape closes the popup and
 hands focus back to the region button, while an outside press or focus moving out of the widget
 closes it too.
 
-The subscriber keeps the trigger on the resolved
-[`state.region`](/web-sdk/phone-input/#phoneinputstate), so digits that resolve to another region
-on the same calling code move the flag with them. The stylesheet is self-contained, so retune its
-custom properties to your design. Inside a framework component, call each machine's
+The subscriber follows the resolved
+[`state.region`](/web-sdk/phone-input/#phoneinputstate), moving the flag when the digits land in
+another region on the same calling code. Inside a framework component, call each machine's
 [`destroy`](/web-sdk/phone-input/#destroy) on unmount and remove the document-level press listener
 with them. Package installation and engine loading live in [Getting started](/web-sdk/).
 
@@ -65,5 +62,5 @@ with them. Package installation and engine loading live in [Getting started](/we
 </Tabs>
 
 The two machines never learn about each other. All the wiring lives in the demo's own functions,
-where `select` hands the picked region to the phone while the subscriber moves the list highlight
-to follow the resolved digits.
+where `select` hands the picked region to the phone while the subscriber moves the flag to follow
+the resolved digits.

--- a/apps/docs/src/content/docs/web-sdk/guides/phone-field.mdx
+++ b/apps/docs/src/content/docs/web-sdk/guides/phone-field.mdx
@@ -9,23 +9,20 @@ import html from '../../../../components/demos/phone-field.html?raw';
 import css from '../../../../components/demos/phone-field.css?raw';
 import code from '../../../../components/demos/phone-field.js?raw';
 
-[`createPhoneInput`](/web-sdk/phone-input/#createphoneinput) attaches to a plain `<input>`; this
-guide runs it as an international field. The library handles the events, the caret, and the
-history while your `renderStatus` function draws the rest.
+[`createPhoneInput`](/web-sdk/phone-input/#createphoneinput) binds a plain `<input>` to a core
+input controller; this guide runs it as an international field. The `PhoneInput` handles the events,
+the caret, and the history while your `renderStatus` function draws the rest.
 
 ## Live demo
 
-The empty field shows the `+1 201-555-0123` placeholder. Type
-`+14155550132` and watch each keystroke reformat in place until the field reads `+1 415-555-0132`
-and the status reports `Valid: +14155550132`. Select everything and delete it. The erasable plus
-goes with the digits and the placeholder returns. Now type `+442071838750` and the same field
-becomes the United Kingdom's `+44 20 7183 8750`, because the calling code decides the region.
+Type `+14155550132`. The field formats it live to `+1 415-555-0132` and the status reads
+`Valid: US +14155550132`. Type `+442071838750` instead and it switches to the UK
+`+44 20 7183 8750`, since the calling code picks the region.
 
-Every editing habit is covered too. Edit in the middle of the value and the caret stays on the
-digit you touched while the groups reflow. Paste a number in any notation. Deletion works
-backward, forward, and a word at a time. Whenever the value falls short, the status reports a
-typed `TOO_SHORT` error. Every edit lands in the field's own history. Undo and redo work with the
-native shortcuts, Cmd/Ctrl+Z and Cmd/Ctrl+Shift+Z.
+The rest behaves the way a real field should. The caret holds its digit through a mid-value edit
+while the groups reflow. Paste accepts any notation. Deletion runs backward, forward, or a word at
+a time. Undo and redo use Cmd/Ctrl+Z and Cmd/Ctrl+Shift+Z. A value that falls short reads
+`TOO_SHORT`.
 
 <PhoneFieldDemo />
 
@@ -35,8 +32,8 @@ The demo and the source are the same three files. The markup is an input with a 
 placeholder and a status line. The script is one `createPhoneInput` call in international mode,
 where the [erasable plus](/core/reference/input-controller/#internationalinputcontrollerconfig)
 renders only while the value carries one. `renderStatus` draws the status from each emitted
-[state](/web-sdk/phone-input/#phoneinputstate). The library writes the value and the caret
-itself. Restyle by changing the custom properties in the stylesheet.
+[state](/web-sdk/phone-input/#phoneinputstate). The machine writes the value and the caret
+itself.
 
 <Tabs syncKey="source">
 

--- a/apps/docs/src/content/docs/web-sdk/guides/region-picker.mdx
+++ b/apps/docs/src/content/docs/web-sdk/guides/region-picker.mdx
@@ -10,7 +10,7 @@ import css from '../../../../components/demos/region-picker.css?raw';
 import code from '../../../../components/demos/region-picker.js?raw';
 
 [`createRegionList`](/web-sdk/region-list/#createregionlist) turns the engine's region data into
-picker rows. The library filters, searches, sorts, and prioritizes the list. Your `renderList`
+picker rows. The `RegionList` filters, searches, sorts, and prioritizes the list. Your `renderList`
 function draws the rows.
 
 ## Live demo
@@ -29,8 +29,7 @@ The demo and the source are the same three files. The markup is a search input, 
 pinning US, CA, and GB and a `dataFactory` putting a
 [flag emoji](/web-sdk/region-list/#regiontoflagemoji) in each option's `data` slot. The search box
 feeds [`search`](/web-sdk/region-list/#search). `renderList` rebuilds the rows from each emitted
-[state](/web-sdk/region-list/#regionliststate). Restyle by changing the custom properties in the
-stylesheet.
+[state](/web-sdk/region-list/#regionliststate).
 
 <Tabs syncKey="source">
 

--- a/apps/docs/src/content/docs/web-sdk/index.mdx
+++ b/apps/docs/src/content/docs/web-sdk/index.mdx
@@ -59,7 +59,7 @@ Your code imports both packages, since the engine loads through `@telixon/core` 
 
 ## Load the engine
 
-Both machines read the engine, so [load it](/core/load-the-engine/) first:
+Both machines run on the engine. [Load it](/core/load-the-engine/) before you create either one:
 
 ```ts
 import { ensureEngineReady } from '@telixon/core';

--- a/apps/docs/src/content/docs/web-sdk/phone-input.mdx
+++ b/apps/docs/src/content/docs/web-sdk/phone-input.mdx
@@ -6,7 +6,7 @@ description: The phone-number controller attached to a DOM input.
 A core [`InputController`](/core/reference/input-controller/) attached to a DOM `<input>`. It wires
 the field's events, writes each new value and caret back, and emits a
 [`PhoneInputState`](#phoneinputstate) snapshot to subscribers. No emit fires at construction. The
-initial state is applied straight to the DOM, so read it with [`getState`](#getstate).
+initial state is applied straight to the DOM. Read it with [`getState`](#getstate).
 
 ## createPhoneInput
 
@@ -65,8 +65,8 @@ restrictions.
 `placeholder` is the example number for the resolved region, in the field's own display shape.
 While the value resolves no region, it falls back to the configured `defaultRegion`. It is `null`
 without a region to fall back to, or when the region's metadata carries no example for the
-configured type. It lives in the state only; the DOM `placeholder` attribute stays untouched, so
-render it yourself. A national US field gets `'(201) 555-0123'`. An international field with the
+configured type. It lives in the state only. The DOM `placeholder` attribute stays untouched, and
+you render it yourself. A national US field gets `'(201) 555-0123'`. An international field with the
 calling code inside gets `'1 201-555-0123'`.
 
 `validationError` is


### PR DESCRIPTION
## Summary

Follow-up polish to the web-sdk docs. Tightens the guides and reference, drops the static-placeholder mention and the boilerplate restyle note, names the machine instead of "the library", and rewrites the complete-field intro to say the two machines are wired together rather than merged. The demos gain two touches: the phone field now shows the resolved region in its valid status, and both pickers show a "No matches" row on an empty search. Docs and demo assets only.

## Motivation

Copy and framing gaps left after the initial web-sdk docs landed in #41.

## Conformance impact

None. Documentation and demo assets only.

## Checklist

- [x] Tests added or updated (docs; demo behavior verified by running it, empty-search and status output checked)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally; `astro check` clean
- [x] Docs reflect the change (this is the docs)
- [x] Commit message follows the project convention