### PR TITLE
docs: tighten the core pages and generate the size figures from size-limit

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "astro build",
+    "build": "node ../../scripts/generate-size.mjs && astro build",
     "check:links": "node ../../scripts/check-links.mjs dist",
     "dev": "astro dev",
     "preview": "astro preview",

--- a/apps/docs/src/content/docs/core/guides/build-a-phone-input.mdx
+++ b/apps/docs/src/content/docs/core/guides/build-a-phone-input.mdx
@@ -86,7 +86,7 @@ controller.getPhoneNumber().formatE164(); // '+14155550132'
 ```
 
 While the value is unfinished, prefer the tolerant checks; see
-[Validate user input](/core/guides/validate-user-input/).
+[Validate a phone number](/core/guides/validate-a-phone-number/).
 
 ## The international field
 

--- a/apps/docs/src/content/docs/core/guides/build-a-region-selector.mdx
+++ b/apps/docs/src/content/docs/core/guides/build-a-region-selector.mdx
@@ -46,25 +46,24 @@ getPlaceholders('US', 'MOBILE')?.national; // '(201) 555-0123'
 
 ## Wire the dropdown to the field
 
-Keep the calling code out of the field and the controller takes its region from the dropdown. Call [`setRegion`](/core/reference/input-controller/#setregion) on the dropdown's
-`change` event and write the returned state back:
+With the calling code kept out of the field, the controller takes its region from the dropdown.
+Call [`setRegion`](/core/reference/input-controller/#setregion) on the dropdown's `change` event
+and write the returned state back:
 
 ```ts
 import { createInternationalInputController } from '@telixon/core';
 
-const field = createInternationalInputController({
+const controller = createInternationalInputController({
   defaultRegion: 'US',
   display: { callingCodeInInput: false },
 });
 
-field.setRegion('CA');
-field.insert('', '6045550132', 0, 0);
+controller.setRegion('CA');
+controller.insert('', '6045550132', 0, 0);
 // { value: '604-555-0132', region: 'CA', selectionStart: 12, selectionEnd: 12 }
 
-field.getPhoneNumber().formatE164(); // '+16045550132'
+controller.getPhoneNumber().formatE164(); // '+16045550132'
 ```
-
-The field shows the digits after the calling code. The selected region supplies that code.
 
 ## Pin the field to the selection
 
@@ -72,8 +71,11 @@ The field shows the digits after the calling code. The selected region supplies 
 dropdown's choice. Digits from any other region stop validating:
 
 ```ts
-field.setRegionFilter(['CA']);
-field.getPhoneNumber().isValid(); // true
+controller.setRegionFilter(['CA']);
+controller.getPhoneNumber().isValid(); // true
+
+controller.setValue('2015550123');
+controller.getPhoneNumber().isValid(); // false, a US number under a Canadian filter
 ```
 
 The full member list is in the [`InputController` reference](/core/reference/input-controller/).

--- a/apps/docs/src/content/docs/core/guides/validate-a-phone-number.mdx
+++ b/apps/docs/src/content/docs/core/guides/validate-a-phone-number.mdx
@@ -1,16 +1,15 @@
 ---
-title: Validate user input
+title: Validate a phone number
 description: Tolerant feedback while the user types and an exact message on submit.
 ---
 
-A phone field needs feedback that stays tolerant while the user types and turns exact on submit.
-The possibility checks give the first. `getValidationError` gives the second.
+The possibility checks stay tolerant while the user types. `getValidationError` names the exact
+fault on submit.
 
 ## While the user types
 
-Most values in a field are unfinished, so treat a short number as neutral. A calling code that
-does not exist and a number that is already too long are worth flagging immediately, because more
-typing cannot fix either.
+Flag only the failures that more typing cannot fix. A calling code that does not exist and a number
+that is already too long qualify; a short number is still on its way.
 
 ```ts
 import { parsePhoneNumber } from '@telixon/core';
@@ -39,9 +38,9 @@ The six reason codes are under
 
 ## On submit
 
-Require [`isValid`](/core/reference/phone-number/#isvalid) and turn the failure into a message the
-user can act on. The [carried payloads](/core/reference/validation-error/#carried-data) let each
-message name the fix:
+Require [`isValid`](/core/reference/phone-number/#isvalid), then turn the failure into a message.
+The [carried payloads](/core/reference/validation-error/) let each message name the
+fix:
 
 ```ts
 import { parsePhoneNumber, type ValidationError } from '@telixon/core';
@@ -75,6 +74,9 @@ if (!number.isValid()) {
 }
 ```
 
+To restrict validity to the form's own region at parse time, use
+[`strict`](/core/reference/parse-phone-number/#strict).
+
 ## Store the number
 
 Store the canonical E.164 string. It parses back with no options:
@@ -83,6 +85,3 @@ Store the canonical E.164 string. It parses back with no options:
 parsePhoneNumber('(415) 555-0132', { defaultRegion: 'US' }).formatE164(); // '+14155550132'
 parsePhoneNumber('+14155550132').isValid(); // true
 ```
-
-To restrict validity to the form's own region at parse time, use
-[`strict`](/core/reference/parse-phone-number/#strict).

--- a/apps/docs/src/content/docs/core/how-it-works.mdx
+++ b/apps/docs/src/content/docs/core/how-it-works.mdx
@@ -5,7 +5,7 @@ description: Digits walk one automaton. Validity is an accepting state. The pars
 
 Google libphonenumber's metadata is compiled ahead of time into a single
 [deterministic finite automaton](https://en.wikipedia.org/wiki/Deterministic_finite_automaton)
-(DFA), stored as binary tables. Everything the API does is defined by that automaton.
+(DFA), stored as binary tables. Every answer about a phone number comes from that automaton.
 
 ## Parsing
 
@@ -14,7 +14,7 @@ the region, the number type, whether the number is valid, and how to format it.
 
 ```ts
 const number = parsePhoneNumber('+1 (415) 555-0132');
-// the walk has already happened; every answer below derives from its end state
+// the walk has already happened
 
 number.getRegion(); // 'US'
 number.getNumberType(); // 'FIXED_LINE_OR_MOBILE'
@@ -38,8 +38,8 @@ records exactly that. The nine variants are in
 ## Parser and controller consistency
 
 `parsePhoneNumber` walks the automaton once, over a whole string. An input controller walks it
-again on every keystroke, over the value as it stands. It is the same walk. A controller can hand
-you a `PhoneNumber` at any moment, mid-typing. Its answers agree with the parser's by construction.
+again on every keystroke, over the value as it stands. It is the same walk, which makes their
+answers agree by construction. A controller can hand you a `PhoneNumber` at any moment, mid-typing.
 
 ```ts
 const controller = createInternationalInputController();
@@ -51,9 +51,9 @@ parsePhoneNumber('+1 (415) 555-0132').formatE164(); // '+14155550132'
 
 ## Consequences
 
-- **[Parsing does not throw.](/core/reference/parse-phone-number/)** A walk always ends somewhere.
-  Where it ends is the result.
+- **[Bad input does not throw.](/core/reference/parse-phone-number/)** A walk always ends
+  somewhere. Where it ends is the result.
 - **[Formatting can return `null`.](/core/reference/phone-number/#formats)** The formats follow
-  possibility, so a number whose calling code or length can never work has no format to give.
+  possibility. A number whose calling code or length can never work has no format to give.
 - **[The engine loads first.](/core/load-the-engine/)** Without the tables there is nothing to
   walk.

--- a/apps/docs/src/content/docs/core/index.mdx
+++ b/apps/docs/src/content/docs/core/index.mdx
@@ -5,8 +5,9 @@ description: Install @telixon/core, load the engine, and parse a first phone num
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-`@telixon/core` parses, validates, and formats phone numbers. The same engine drives phone-number
-fields. The package runs in Node.js, browsers, Deno, Bun, and edge runtimes, with no dependencies.
+`@telixon/core` parses, validates, and formats phone numbers, while its input controllers give a
+flexible API for entering them. All of it runs in Node.js, browsers, Deno, Bun, and edge runtimes,
+with no dependencies.
 
 ## Install
 
@@ -81,8 +82,8 @@ parsePhoneNumber('(415) 555-0132', { defaultRegion: 'US' }).formatE164(); // '+1
 
 ## Inspect invalid input
 
-`parsePhoneNumber` [never throws](/core/reference/parse-phone-number/); bad input still comes back
-as a `PhoneNumber`, with a typed reason:
+Bad input [never throws](/core/reference/parse-phone-number/). It comes back as a `PhoneNumber`
+carrying a typed reason:
 
 ```ts
 const wrongLength = parsePhoneNumber('+57 321 123 456');
@@ -95,7 +96,7 @@ Colombia dials numbers of 8, 10, and 11 digits. Nine digits falls in a gap. The 
 lengths that exist.
 
 [`ValidationError`](/core/reference/validation-error/) lists all nine variants.
-[Validate user input](/core/guides/validate-user-input/) turns them into messages.
+[Validate a phone number](/core/guides/validate-a-phone-number/) turns them into messages.
 
 ## Drive an input
 

--- a/apps/docs/src/content/docs/core/load-the-engine.mdx
+++ b/apps/docs/src/content/docs/core/load-the-engine.mdx
@@ -3,8 +3,10 @@ title: Load the engine
 description: Load the engine with ensureEngineReady, or synchronously with ensureEngineReadySync.
 ---
 
-The engine is the compiled automaton. Every query and controller call reads it, so it must be in
-memory first. Loading is explicit, so nothing loads when you import the package.
+import size from '../../../generated/size.json';
+
+The engine is the compiled automaton that every query and controller reads. Importing the package
+does not load it.
 
 ## ensureEngineReady
 
@@ -12,8 +14,8 @@ memory first. Loading is explicit, so nothing loads when you import the package.
 function ensureEngineReady(): Promise<void>;
 ```
 
-Call it once, before the first API call. It is idempotent, so later calls resolve immediately and load
-nothing. You choose the moment.
+Call it once, before the first API call. It is idempotent; a later call resolves immediately while
+concurrent calls share one in-flight load.
 
 ```ts
 import { ensureEngineReady, parsePhoneNumber } from '@telixon/core';
@@ -23,8 +25,8 @@ await ensureEngineReady();
 parsePhoneNumber('+1 (415) 555-0132').isValid(); // true
 ```
 
-Concurrent calls share one in-flight load. A failed load rejects with the underlying error. The
-failure is not cached, so the next call starts a fresh load.
+A failed load rejects with the underlying error, leaving nothing cached. The next call starts a
+fresh load.
 
 ## EngineNotReadyError
 
@@ -59,30 +61,15 @@ import { isEngineReady } from '@telixon/core';
 isEngineReady(); // false before ensureEngineReady() resolves
 ```
 
-## Runtime builds
-
-The package name is the same everywhere. The runtime picks the build.
-
-| Runtime                  | Build resolved     |
-| ------------------------ | ------------------ |
-| Node.js                  | `index.node.js`    |
-| Deno, Bun                | `index.node.js`    |
-| Browsers and bundlers    | `index.browser.js` |
-| Workers, edge, `workerd` | `index.edge.js`    |
-
-The browser and edge builds import the tables as code-split modules, then inflate them with
-`DecompressionStream`, falling back to a pure-JS inflater where the API is missing. The Node build
-decodes with native zlib, off the event loop. `ensureEngineReady` is the same call everywhere.
-
 ## ensureEngineReadySync
 
 ```ts
 function ensureEngineReadySync(): void;
 ```
 
-Initializes the engine synchronously, from tables embedded in the bundle. The cost is bundle size, with
-the embedded tables at about [122 kB gzipped](/verified/#size). That weight lands only where this
-entry is imported.
+Initializes the engine synchronously, from tables embedded in the bundle. Those tables add about
+[{size.engineTables} gzipped](/verified/#size), a weight that lands only where this entry is
+imported.
 
 ```ts
 import { ensureEngineReadySync } from '@telixon/core/sync-init';
@@ -94,9 +81,27 @@ parsePhoneNumber('+1 (415) 555-0132').isValid(); // true
 ```
 
 Reach for this only where you cannot await, such as a synchronous constructor, a module-level
-default, or a migration script. Everywhere else, prefer `ensureEngineReady`.
+default, or a migration script.
+
+## Runtime builds
+
+The package name is the same everywhere. The runtime picks the build behind `@telixon/core`.
+
+| Runtime                  | Build resolved     |
+| ------------------------ | ------------------ |
+| Node.js                  | `index.node.js`    |
+| Deno, Bun                | `index.node.js`    |
+| Browsers and bundlers    | `index.browser.js` |
+| Workers, edge, `workerd` | `index.edge.js`    |
+
+Under `ensureEngineReady`, the browser and edge builds import the tables as code-split modules,
+then inflate them with `DecompressionStream`, falling back to a pure-JS inflater where the API is
+missing. The Node build decodes with native zlib, off the event loop.
+
+`@telixon/core/sync-init` resolves two builds of its own. Node decodes with native zlib; every
+other runtime uses the pure-JS inflater.
 
 ## One engine per process
 
-`ensureEngineReady` and `ensureEngineReadySync` fill the same process-wide engine. Loading it in
-two places loads it once. There is no instance to pass around.
+`ensureEngineReady` and `ensureEngineReadySync` fill the same process-wide engine. There is no
+instance to pass around.

--- a/apps/docs/src/content/docs/core/reference/input-controller.mdx
+++ b/apps/docs/src/content/docs/core/reference/input-controller.mdx
@@ -65,7 +65,7 @@ code is in the field, `defaultRegion` pre-fills the field with that region's cod
 `plusPrefix`, a `PlusPrefixMode`, renders the leading `+`, with `'none'` never showing it,
 `'fixed'` always, and `'erasable'` while the value carries one. Under `'erasable'`, backspace
 right after the `+` removes it. Every plus-less start, an empty or omitted `initialValue`
-included, begins with the plus erased, so an empty field renders truly empty; only the
+included, begins with the plus erased, leaving an empty field truly empty; only the
 calling-code seed from `defaultRegion` keeps the visible plus.
 
 ## InputState
@@ -79,17 +79,18 @@ interface InputState {
 }
 ```
 
-The next value and caret to apply to the field. `value` is the formatted string. `region` is the
-region the value resolves to, or `null` when none does. A field with no digits reports the
-configured default region, so clearing the value keeps the region stable. The selection indices
-point into `value`.
-Within a shared calling code, `region` reports the resolved owner of the digits, so a `604`
-number reports `CA` even in a US-configured field.
+The next value and caret to apply to the field. `value` is the formatted string; the selection
+indices point into it.
+
+`region` is the region the value resolves to, or `null` when none does. Within a shared calling
+code it reports the resolved owner of the digits, where a `604` number comes back as `CA` even in a
+US-configured field. A field with no digits reports the configured default region, keeping the
+region stable when the value is cleared.
 
 ## Edits
 
-All four take the field's value as an argument, so the controller works from what the field
-actually shows.
+All four take the field's value as an argument, keeping the controller working from what the
+field actually shows.
 
 ### insert
 
@@ -180,7 +181,7 @@ Steps back to the previous state in history. With nothing to undo, it returns th
 redo(): InputState;
 ```
 
-Steps forward again after an [`undo`](#undo).
+Steps forward again after an [`undo`](#undo). With nothing to redo, it returns the current state.
 
 ### canUndo
 
@@ -188,8 +189,8 @@ Steps forward again after an [`undo`](#undo).
 readonly canUndo: boolean;
 ```
 
-Whether there is history to undo. `initialValue` seeds the field outside the history, so a freshly
-created controller reports `false`.
+Whether there is history to undo. `initialValue` seeds the field outside the history, leaving a
+freshly created controller at `false`.
 
 ### canRedo
 
@@ -219,10 +220,12 @@ getPhoneNumber(): PhoneNumber;
 
 The current value as a [`PhoneNumber`](/core/reference/phone-number/) to query, equal to
 `parsePhoneNumber` of the displayed value, with the national controller's `defaultRegion` and
-`strict` carried along. Active filters have no `parsePhoneNumber` equivalent and narrow the
-result further. With the calling code kept out of the field (`callingCodeInInput: false`), the
-digits resolve literally as the international significant number behind the selected region's
-calling code. A typed national (trunk) prefix there reports
+`strict` carried along. Active filters have no `parsePhoneNumber` equivalent and narrow the result
+further.
+
+With the calling code kept out of the field (`callingCodeInInput: false`), the digits resolve
+literally as the international significant number behind the selected region's calling code. A
+typed national (trunk) prefix there reports
 [`NATIONAL_PREFIX_PRESENT`](/core/reference/validation-error/).
 
 ### currentState
@@ -236,6 +239,6 @@ The value and caret as they stand.
 ## Conformance
 
 The conformance suite types enumerated inputs through a controller, character by character,
-requiring the [`getPhoneNumber`](#getphonenumber) equality on every input. `parsePhoneNumber` is
-the Google-compared path, so the controllers are held to the same parity; see
+requiring the [`getPhoneNumber`](#getphonenumber) equality on every input. Since `parsePhoneNumber`
+is the Google-compared path, the controllers are held to the same parity; see
 [Verified](/verified/#conformance).

--- a/apps/docs/src/content/docs/core/reference/parse-phone-number.mdx
+++ b/apps/docs/src/content/docs/core/reference/parse-phone-number.mdx
@@ -1,6 +1,6 @@
 ---
 title: parsePhoneNumber
-description: The parsing entry point and its two options.
+description: The parsing entry point, with defaultRegion and strict.
 ---
 
 ```ts
@@ -22,13 +22,20 @@ parsePhoneNumber('(415) 555-0132', { defaultRegion: 'US' }).isValid(); // true
 
 ## ParsePhoneNumberOptions
 
+```ts
+interface ParsePhoneNumberOptions {
+  defaultRegion?: RegionCode;
+  strict?: boolean;
+}
+```
+
 ### defaultRegion
 
 ```ts
 defaultRegion?: RegionCode;
 ```
 
-The region input without a `+` resolves against. Without it, plus-less digits read as
+The region that a number without a `+` resolves against. Without it, those digits read as
 international, calling code first:
 
 ```ts
@@ -42,7 +49,7 @@ parsePhoneNumber('415-555-0132', { defaultRegion: 'US' }).getRegion(); // 'US'
 strict?: boolean;
 ```
 
-Restricts validity to `defaultRegion`, so `isValid`, `getNumberType`, and
+Restricts validity to `defaultRegion`. `isValid`, `getNumberType`, and
 [`getValidationError`](/core/reference/phone-number/#getvalidationerror) all follow it while the
 possibility checks and the formats ignore it. Without `defaultRegion` it has no effect. It is off
 by default.

--- a/apps/docs/src/content/docs/core/reference/phone-number.mdx
+++ b/apps/docs/src/content/docs/core/reference/phone-number.mdx
@@ -25,7 +25,7 @@ number.isValid(); // true
 
 ### isValidForRegion
 
-Whether the number is valid for one region specifically. Mirrors libphonenumber's
+Whether the number is valid for one region specifically. Mirrors Google libphonenumber's
 `isValidNumberForRegion`.
 
 ```ts
@@ -36,7 +36,7 @@ number.isValidForRegion('CA'); // false
 ### isPossible
 
 Whether the calling code resolves and the length is one the region dials. The digits themselves go
-unchecked, so a possible number can still be invalid.
+unchecked. A possible number can still be invalid.
 
 ```ts
 number.isPossible(); // true
@@ -45,7 +45,7 @@ parsePhoneNumber('+1 123-456-7890').isPossible(); // true, ten digits is a US le
 
 ### isPossibleWithReason
 
-The possibility check as a [`PossibilityResult`](#possibilityresult) reason code, so a failed
+The possibility check as a [`PossibilityResult`](#possibilityresult) reason code. A failed
 `isPossible` says why.
 
 ```ts
@@ -57,7 +57,7 @@ parsePhoneNumber('+1 415').isPossibleWithReason(); // 'TOO_SHORT'
 
 The fault to correct, or `null` when none applies. One of the nine typed
 [`ValidationError`](/core/reference/validation-error/) variants. A valid number can still carry
-the `NATIONAL_PREFIX_MISSING` advisory, so gate on [`isValid`](#isvalid) for validity and read the
+the `NATIONAL_PREFIX_MISSING` advisory. Gate on [`isValid`](#isvalid) for validity and read the
 error for guidance.
 
 ```ts
@@ -65,9 +65,10 @@ number.getValidationError(); // null
 parsePhoneNumber('+1 415').getValidationError(); // { kind: 'TOO_SHORT', minLength: 10 }
 ```
 
-### PossibilityResult
+## PossibilityResult
 
-The six reason codes `isPossibleWithReason` returns. Mirrors libphonenumber's `ValidationResult`.
+The six reason codes `isPossibleWithReason` returns. Mirrors Google libphonenumber's
+`ValidationResult`.
 
 | Value                    | Meaning                                                        |
 | ------------------------ | -------------------------------------------------------------- |
@@ -90,7 +91,8 @@ number.getRegion(); // 'US'
 
 ### getCallingCode
 
-The country calling code read from the digits, without the `+`, or `null` when there are none.
+The country calling code read from the digits, without the `+`, or `null` when the digits carry
+none.
 
 ```ts
 number.getCallingCode(); // '1'
@@ -106,8 +108,9 @@ number.getNationalNumber(); // '4155550132'
 
 ### getNumberType
 
-The line type, such as `MOBILE` or `FIXED_LINE`. `UNKNOWN` when the number is not valid or the type
-is ambiguous. The full value list is [`NUMBER_TYPES`](/core/reference/region-data/#number_types).
+The line type, such as `MOBILE` or `FIXED_LINE`, or `FIXED_LINE_OR_MOBILE` where a region assigns
+both. `UNKNOWN` means the number is not valid. The full value list is
+[`NUMBER_TYPES`](/core/reference/region-data/#number_types).
 
 ```ts
 number.getNumberType(); // 'FIXED_LINE_OR_MOBILE'
@@ -156,7 +159,7 @@ number.formatRfc3966(); // 'tel:+1-415-555-0132'
 
 ## Conformance
 
-Twelve of the thirteen methods have a libphonenumber counterpart, each compared with Google's
-implementation on every corpus input. `getValidationError` is Telixon's own surface, with no
+Twelve of the thirteen methods have a Google libphonenumber counterpart, each compared with
+Google's implementation on every corpus input. `getValidationError` is Telixon's own surface, with no
 counterpart to compare. The numbers, the method, and the cadence are on
 [Verified](/verified/#conformance).

--- a/apps/docs/src/content/docs/core/reference/region-data.mdx
+++ b/apps/docs/src/content/docs/core/reference/region-data.mdx
@@ -19,8 +19,7 @@ REGION_CODES.slice(0, 3); // ['AC', 'AD', 'AE']
 REGION_CODES.includes('US'); // true
 ```
 
-`RegionCode` is the union of exactly these codes, so a plain string needs narrowing before it is
-one:
+`RegionCode` is the union of exactly these codes. Narrow a plain string before using it as one:
 
 ```ts
 function isRegionCode(value: string): value is RegionCode {
@@ -49,7 +48,7 @@ function getCallingCodeForRegion(region: RegionCode): string;
 ```
 
 The country calling code `region` dials under, without the `+`, or `'0'` for a region the engine
-does not know. Mirrors libphonenumber's `getCountryCodeForRegion`.
+does not know. Mirrors Google libphonenumber's `getCountryCodeForRegion`.
 
 ```ts
 getCallingCodeForRegion('US'); // '1'
@@ -76,7 +75,7 @@ getPlaceholders('US', 'FIXED_LINE');
 | -------------------- | --------------------------------------------------------------- |
 | `national`           | National format, without the national (trunk) prefix            |
 | `nationalWithPrefix` | National format, with the national (trunk) prefix               |
-| `international`      | International format: the digits after `+` and the calling code |
+| `international`      | International format, the digits after `+` and the calling code |
 
 Each field is absent when the region has no such form.
 

--- a/apps/docs/src/content/docs/core/reference/validation-error.mdx
+++ b/apps/docs/src/content/docs/core/reference/validation-error.mdx
@@ -18,10 +18,10 @@ type ValidationError =
 
 The fault to correct in the input. Returned by
 [`getValidationError`](/core/reference/phone-number/#getvalidationerror), which is `null` when
-none applies. The union is discriminated on `kind`, so a `switch` narrows every variant. With a
+none applies. Five of the nine variants carry data that names the fix. Since the union is
+discriminated on `kind`, a `switch` narrows every variant. With a
 declared return type on the switching function, a newly added variant stops compiling until every
-`switch` handles it. The kinds mirror libphonenumber
-where applicable.
+`switch` handles it. The kinds mirror Google libphonenumber where applicable.
 
 ## Variants
 
@@ -30,7 +30,7 @@ Every row is a real input and its real result.
 | Input                                                         | `getValidationError()`                                     | Meaning                                                       |
 | ------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------- |
 | `''`                                                          | `{ kind: 'EMPTY' }`                                        | No digits to resolve                                          |
-| `'+999 123'`                                                  | `{ kind: 'INVALID_CALLING_CODE' }`                         | The digits begin with no known country calling code           |
+| `'+999 123'`                                                  | `{ kind: 'INVALID_CALLING_CODE' }`                         | The digits begin with no known calling code                   |
 | `'+1 21'`                                                     | `{ kind: 'TOO_SHORT', minLength: 10 }`                     | Fewer digits than the region's shortest number                |
 | `'+1 21255512345678'`                                         | `{ kind: 'TOO_LONG', maxLength: 10 }`                      | More digits than the region's longest number                  |
 | `'+57 321 123 456'`                                           | `{ kind: 'INVALID_LENGTH', possibleLengths: [8, 10, 11] }` | The length falls in a gap between valid lengths               |
@@ -43,30 +43,15 @@ Every row is a real input and its real result.
 (`callingCodeInInput: false`), where the digits are the international significant number. It
 reports when a number that is not valid as typed begins with a national-dialing chunk, the trunk
 prefix or a carrier code, whose removal leaves a valid number. `prefix` is the exact leading chunk
-to drop; a Belarusian number typed as `80 29…` reports `prefix: '80'`.
-
-## Carried data
-
-The five data-carrying variants name what would fix the input:
+to drop; a Belarusian number typed as `80 29…` reports `prefix: '80'`. Reproducing it takes a
+controller rather than `parsePhoneNumber`:
 
 ```ts
-parsePhoneNumber('+1 21').getValidationError();
-// { kind: 'TOO_SHORT', minLength: 10 }
-
-parsePhoneNumber('+1 21255512345678').getValidationError();
-// { kind: 'TOO_LONG', maxLength: 10 }
-
-parsePhoneNumber('+57 321 123 456').getValidationError();
-// { kind: 'INVALID_LENGTH', possibleLengths: [8, 10, 11] }
-
-parsePhoneNumber('501234567', { defaultRegion: 'AE' }).getValidationError();
-// { kind: 'NATIONAL_PREFIX_MISSING', expectedPrefix: '0' }
-
-const field = createInternationalInputController({
+const controller = createInternationalInputController({
   defaultRegion: 'AE',
   display: { callingCodeInInput: false },
 });
-field.setValue('0501234567');
-field.getPhoneNumber().getValidationError();
+controller.setValue('0501234567');
+controller.getPhoneNumber().getValidationError();
 // { kind: 'NATIONAL_PREFIX_PRESENT', prefix: '0' }
 ```

--- a/apps/docs/src/content/docs/verified.mdx
+++ b/apps/docs/src/content/docs/verified.mdx
@@ -3,23 +3,26 @@ title: Verified
 description: Conformance, performance, and size, each measured on every push and reproducible.
 ---
 
-Telixon measures three properties on every push: conformance with Google libphonenumber,
-performance, and payload size. Each section names the method and the command that reproduces it.
+import size from '../../generated/size.json';
+
+Telixon measures conformance with Google libphonenumber, performance, and payload size on every
+push. Each section names the method and the command that reproduces it.
 
 ## Conformance
 
-Every query method is compared with Google libphonenumber. The oracle is version-matched: it runs
-Google's own JavaScript source at the exact commit the engine's metadata was built from, so a
-mismatch is a real difference and never version drift.
+Twelve of the thirteen [`PhoneNumber`](/core/reference/phone-number/) methods have a Google
+libphonenumber counterpart; every one of them is compared against it. The oracle is version-matched, running Google's own JavaScript source at
+the exact commit the engine's metadata was built from. Every mismatch it reports is a real
+behavioral difference.
 
-Three gates cover it: the full corpus, one number from every distinct case the library can
-produce, and a one-million-input sample. The current run stands at 315,988 comparisons with
-zero divergences: twelve methods, each matching on 11,232 of 11,232 corpus inputs, across all 245
-regions. `isValidForRegion` is set-compared per case, 692,672 region checks. The allowlist of
-accepted divergences is empty.
+The gate runs two sweeps. The full corpus compares the twelve methods on 11,232 inputs each, across
+all 245 regions, while case coverage compares one number from every distinct case the library can
+produce. Together they stand at 315,988 comparisons with zero divergences. `isValidForRegion` is
+set-compared per case, with 692,672 region checks in the case-coverage sweep alone. The allowlist
+of accepted divergences is empty.
 
-Weekly, the airtight proof enumerates the complete geographic input domain: 1,838,775,900 inputs,
-split across ten shards.
+On top of the gate, every push runs a one-million-input parity sample. Weekly, the airtight proof
+enumerates the complete geographic input domain of 1,838,775,900 inputs, split across ten shards.
 
 ```sh
 pnpm conformance
@@ -30,8 +33,8 @@ The [parity dashboard](https://proof.telixon.dev/parity.html) publishes every ru
 ## Performance
 
 The benchmark measures parsing and query throughput, cold and warm, plus per-keystroke controller
-latency. The comparison baseline is the google-libphonenumber npm package, a third-party wrapper
-of Google's port. Wall-time numbers depend on hardware, so this page quotes none.
+latency. The reference baseline is the google-libphonenumber npm package, a third-party wrapper
+of Google's port. Since wall-time numbers depend on hardware, this page quotes none.
 CodSpeed tracks instrumented regressions.
 
 ```sh
@@ -42,14 +45,16 @@ The [benchmark dashboard](https://proof.telixon.dev/benchmark.html) publishes ea
 
 ## Size
 
-`size-limit` gates the entry sizes. The engine tables ship outside the entries. The
-async builds load them on demand; the sync entry embeds them.
+`size-limit` gates the entry sizes. The engine tables ship outside them, loaded on demand by the
+async builds and embedded by the sync entry. Their figure below is the gzip payload inside the
+embedded modules.
 
-| Artifact                        | Measured        | Budget |
-| ------------------------------- | --------------- | ------ |
-| `@telixon/core` Node entry      | 18.79 kB brotli | 22 kB  |
-| `@telixon/core` browser entry   | 21.34 kB brotli | 22 kB  |
-| Engine tables, loaded on demand | 123 kB gzip     | none   |
+| Artifact                        | Measured                     | Budget                     |
+| ------------------------------- | ---------------------------- | -------------------------- |
+| `@telixon/core` Node entry      | {size.nodeEntry.measured}    | {size.nodeEntry.budget}    |
+| `@telixon/core` browser entry   | {size.browserEntry.measured} | {size.browserEntry.budget} |
+| `@telixon/web-sdk`              | {size.webSdk.measured}       | {size.webSdk.budget}       |
+| Engine tables, loaded on demand | {size.engineTables} gzip     | none                       |
 
 ```sh
 pnpm size

--- a/apps/docs/src/generated/size.json
+++ b/apps/docs/src/generated/size.json
@@ -1,0 +1,18 @@
+{
+  "nodeEntry": {
+    "artifact": "@telixon/core (Node entry)",
+    "measured": "20.83 kB brotli",
+    "budget": "22 kB"
+  },
+  "browserEntry": {
+    "artifact": "@telixon/core (browser entry)",
+    "measured": "23.45 kB brotli",
+    "budget": "25 kB"
+  },
+  "webSdk": {
+    "artifact": "@telixon/web-sdk",
+    "measured": "3.78 kB brotli",
+    "budget": "5 kB"
+  },
+  "engineTables": "122 kB"
+}

--- a/apps/docs/src/package-registry.ts
+++ b/apps/docs/src/package-registry.ts
@@ -34,7 +34,7 @@ export const PACKAGES: readonly DocsPackage[] = [
       {
         label: 'Guides',
         items: [
-          'core/guides/validate-user-input',
+          'core/guides/validate-a-phone-number',
           'core/guides/build-a-phone-input',
           'core/guides/build-a-region-selector',
         ],

--- a/scripts/generate-size.mjs
+++ b/scripts/generate-size.mjs
@@ -1,0 +1,56 @@
+// Regenerates the measured sizes the Verified page renders, so the table can never go stale.
+// Entry sizes come from size-limit; the engine figure is the gzip payload inside the embedded modules.
+import { execSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const outputPath = join(repoRoot, 'apps/docs/src/generated/size.json');
+
+// size-limit prints kilobytes as bytes over 1000; the page mirrors its convention.
+const kilobytes = (bytes) => (bytes / 1000).toFixed(2);
+
+function embeddedGzipBytes() {
+  const dir = join(repoRoot, 'packages/core/dist/engine/embedded');
+  let total = 0;
+  for (const file of readdirSync(dir)) {
+    const source = readFileSync(join(dir, file), 'utf8');
+    for (const match of source.matchAll(/"([A-Za-z0-9+/=]{100,})"/g)) {
+      total += Buffer.from(match[1], 'base64').length;
+    }
+  }
+  return total;
+}
+
+try {
+  const measured = JSON.parse(
+    execSync('pnpm exec size-limit --json', { cwd: repoRoot, stdio: ['ignore', 'pipe', 'ignore'] }).toString(),
+  );
+  const budgets = JSON.parse(readFileSync(join(repoRoot, '.size-limit.json'), 'utf8'));
+  const budgetByName = Object.fromEntries(budgets.map((entry) => [entry.name, entry.limit]));
+
+  const entries = measured.map((entry) => ({
+    artifact: entry.name,
+    measured: `${kilobytes(entry.size)} kB brotli`,
+    budget: budgetByName[entry.name],
+  }));
+
+  const size = {
+    nodeEntry: entries.find((entry) => entry.artifact.includes('Node entry')),
+    browserEntry: entries.find((entry) => entry.artifact.includes('browser entry')),
+    webSdk: entries.find((entry) => entry.artifact === '@telixon/web-sdk'),
+    engineTables: `${Math.round(embeddedGzipBytes() / 1000)} kB`,
+  };
+
+  writeFileSync(outputPath, JSON.stringify(size, null, 2) + '\n');
+  console.log(
+    `size.json regenerated: ${size.nodeEntry.measured}, ${size.browserEntry.measured}, ${size.webSdk.measured}, engine ${size.engineTables}`,
+  );
+} catch (error) {
+  if (existsSync(outputPath)) {
+    console.warn(`size.json regeneration failed, keeping the committed figures: ${error.message}`);
+  } else {
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

Tighten the eleven `@telixon/core` documentation pages: the three top-level pages, the three guides, and the five reference pages. Every documented value was re-verified by running it, and the wording was corrected for accuracy and cut for duplication. The "Validate user input" guide is renamed to "Validate a phone number" (file, slug, and both inbound links). No source code changes.

## Motivation

A read-through against the running library surfaced claims that no longer held. `getNumberType` was documented as returning `UNKNOWN` for an ambiguous type, but a scan of all 245 regions shows it returns `UNKNOWN` only for invalid numbers. `parsePhoneNumber` was said to "never throw", though it throws `EngineNotReadyError` before the engine loads, so it now reads "bad input never throws". The old guide title claimed the input-controller's territory while the guide only uses `parsePhoneNumber`. Several reference paragraphs also carried duplicated claims or bundled unrelated facts, and controller examples named their variable `field`.

## Conformance impact

None. No engine or query-method code is touched; the changes are documentation prose, one file rename, and one sidebar slug.

## Checklist

- [x] Tests added or updated (or a rationale for why none) — documentation-only, no behavior to cover
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention
