### PR TITLE
docs(web-sdk): tighten the reference and guides

### DIFF
--- a/apps/docs/src/content/docs/web-sdk/guides/complete-field.mdx
+++ b/apps/docs/src/content/docs/web-sdk/guides/complete-field.mdx
@@ -10,16 +10,15 @@ import css from '../../../../components/demos/complete-field.css?raw';
 import code from '../../../../components/demos/complete-field.js?raw';
 
 This guide wires the [phone field](/web-sdk/guides/phone-field/) and the
-[region picker](/web-sdk/guides/region-picker/) into one widget. The phone input runs in selector
-mode, which keeps the calling code in the region button on the left rather than the field. The
-searchable popup opens below the button, and the formatted number fills the field to the right.
+[region picker](/web-sdk/guides/region-picker/) into one widget, where the picker supplies the
+calling code and the input holds the rest.
 
 ## Live demo
 
-Open the picker, search `canada`, and pick it. The button shows the Canadian flag on `+1`, and the
-empty field's placeholder becomes a Canadian example. Type `6045550132` and the field reads `604-555-0132` with
-the status `Valid: +16045550132`. Reopen the picker and choose United States. `604` still belongs
-to Canada, which flips the flag straight back.
+Open the picker, search `canada`, and pick it. The button shows the Canadian flag on `+1`, with the
+empty field's placeholder now a Canadian example. Type `6045550132` and the field shows
+`604-555-0132` with the status `Valid: +16045550132`. Reopen the picker and choose United States.
+`604` still belongs to Canada, which flips the flag straight back.
 
 The keyboard works throughout. Search `united k` and press Enter, or walk the rows with the arrow
 keys. Select the United Kingdom and type `07400123456`. The leading zero is a trunk prefix with no
@@ -29,21 +28,23 @@ place after `+44`. The status reads `NATIONAL_PREFIX_PRESENT`.
 
 ## The code
 
-The demo runs these exact files. One bordered field holds the region button and the phone input.
-The popup carries the search box and the list.
+The demo and the source are the same three files. The markup is the region button, the input, and a
+popup with the search box and the list.
 [`callingCodeInInput: false`](/core/reference/input-controller/#internationalinputcontrollerconfig)
-keeps the calling code out of the input, leaving the selected region to supply it. A click on a row
-calls `select`, which updates the button, hands the region to
-[`setRegion`](/web-sdk/phone-input/#setregion), closes the popup, and returns focus to the input. The search box doubles as the keyboard cursor, where the arrow keys walk the
-rows through `aria-activedescendant` and Enter picks the active one. Escape closes the popup and
-hands focus back to the region button, while an outside press or focus moving out of the widget
-closes it too.
+keeps the calling code out of the input, leaving the selected region to supply it.
 
-The subscriber follows the resolved
+The wiring runs both ways. A click on a row calls `select`, which updates the button, hands the
+region to [`setRegion`](/web-sdk/phone-input/#setregion), closes the popup, and returns focus to
+the input. Coming back, the subscriber follows the resolved
 [`state.region`](/web-sdk/phone-input/#phoneinputstate), moving the flag when the digits land in
-another region on the same calling code. Inside a framework component, call each machine's
-[`destroy`](/web-sdk/phone-input/#destroy) on unmount and remove the document-level press listener
-with them. Package installation and engine loading live in [Getting started](/web-sdk/).
+another region on the same calling code.
+
+The search box doubles as the keyboard cursor, where the arrow keys walk the rows through
+`aria-activedescendant` and Enter picks the active one. Escape closes the popup and hands focus
+back to the region button, while an outside press or focus moving out of the widget closes it too.
+
+Inside a framework component, call each machine's [`destroy`](/web-sdk/phone-input/#destroy) on
+unmount and remove the document-level press listener with them.
 
 <Tabs syncKey="source">
 
@@ -61,6 +62,4 @@ with them. Package installation and engine loading live in [Getting started](/we
 
 </Tabs>
 
-The two machines never learn about each other. All the wiring lives in the demo's own functions,
-where `select` hands the picked region to the phone while the subscriber moves the flag to follow
-the resolved digits.
+The two machines never learn about each other. All the wiring lives in the demo's own functions.

--- a/apps/docs/src/content/docs/web-sdk/guides/phone-field.mdx
+++ b/apps/docs/src/content/docs/web-sdk/guides/phone-field.mdx
@@ -11,7 +11,7 @@ import code from '../../../../components/demos/phone-field.js?raw';
 
 [`createPhoneInput`](/web-sdk/phone-input/#createphoneinput) binds a plain `<input>` to a core
 input controller; this guide runs it as an international field. The `PhoneInput` handles the events,
-the caret, and the history while your `renderStatus` function draws the rest.
+the value, the caret, and the history, while your `renderStatus` function draws the rest.
 
 ## Live demo
 
@@ -28,12 +28,11 @@ a time. Undo and redo use Cmd/Ctrl+Z and Cmd/Ctrl+Shift+Z. A value that falls sh
 
 ## The code
 
-The demo and the source are the same three files. The markup is an input with a static
-placeholder and a status line. The script is one `createPhoneInput` call in international mode,
+The demo and the source are the same three files. The markup is an input and a status line. The
+script is one `createPhoneInput` call in international mode,
 where the [erasable plus](/core/reference/input-controller/#internationalinputcontrollerconfig)
 renders only while the value carries one. `renderStatus` draws the status from each emitted
-[state](/web-sdk/phone-input/#phoneinputstate). The machine writes the value and the caret
-itself.
+[state](/web-sdk/phone-input/#phoneinputstate).
 
 <Tabs syncKey="source">
 
@@ -51,6 +50,6 @@ itself.
 
 </Tabs>
 
-Paste, cut, drop, IME composition, word deletes, and native undo are already wired;
-[Covered events](/web-sdk/phone-input/#covered-events) lists them. The field is one half of the
-classic widget, and [Build a region picker](/web-sdk/guides/region-picker/) is the other.
+[Covered events](/web-sdk/phone-input/#covered-events) lists every input type the machine already
+handles, IME composition and drag-and-drop included. The field is one half of the classic widget.
+[Build a region picker](/web-sdk/guides/region-picker/) is the other half.

--- a/apps/docs/src/content/docs/web-sdk/guides/region-picker.mdx
+++ b/apps/docs/src/content/docs/web-sdk/guides/region-picker.mdx
@@ -10,13 +10,13 @@ import css from '../../../../components/demos/region-picker.css?raw';
 import code from '../../../../components/demos/region-picker.js?raw';
 
 [`createRegionList`](/web-sdk/region-list/#createregionlist) turns the engine's region data into
-picker rows. The `RegionList` filters, searches, sorts, and prioritizes the list. Your `renderList`
-function draws the rows.
+picker rows. The `RegionList` filters, searches, sorts, and prioritizes the list, while your
+`renderList` function draws the rows.
 
 ## Live demo
 
 All 245 regions are in the list, with US, CA, and GB pinned on top. Search `united` and the list
-narrows to three rows. The match runs over names, region codes, and calling codes, so `+44` finds
+narrows to three rows. The match runs over names, region codes, and calling codes; `+44` finds
 the United Kingdom too. Click a row and the status reports the selection, while the arrow keys
 walk the list from the search box and Enter picks the active row.
 
@@ -24,8 +24,9 @@ walk the list from the search box and Enter picks the active row.
 
 ## The code
 
-The demo and the source are the same three files. The markup is a search input, an empty list, and a status line.
-`createRegionList` builds the rows, with [`prioritize`](/web-sdk/region-list/#regionlistoptions)
+The demo and the source are the same three files. The markup is a search input, an empty list, and
+a status line. `createRegionList` builds the rows, with
+[`prioritize`](/web-sdk/region-list/#regionlistoptions)
 pinning US, CA, and GB and a `dataFactory` putting a
 [flag emoji](/web-sdk/region-list/#regiontoflagemoji) in each option's `data` slot. The search box
 feeds [`search`](/web-sdk/region-list/#search). `renderList` rebuilds the rows from each emitted

--- a/apps/docs/src/content/docs/web-sdk/index.mdx
+++ b/apps/docs/src/content/docs/web-sdk/index.mdx
@@ -59,7 +59,8 @@ Your code imports both packages, since the engine loads through `@telixon/core` 
 
 ## Load the engine
 
-Both machines run on the engine. [Load it](/core/load-the-engine/) before you create either one:
+Creating either machine before the engine is [loaded](/core/load-the-engine/) throws
+`EngineNotReadyError`:
 
 ```ts
 import { ensureEngineReady } from '@telixon/core';

--- a/apps/docs/src/content/docs/web-sdk/phone-input.mdx
+++ b/apps/docs/src/content/docs/web-sdk/phone-input.mdx
@@ -6,7 +6,7 @@ description: The phone-number controller attached to a DOM input.
 A core [`InputController`](/core/reference/input-controller/) attached to a DOM `<input>`. It wires
 the field's events, writes each new value and caret back, and emits a
 [`PhoneInputState`](#phoneinputstate) snapshot to subscribers. No emit fires at construction. The
-initial state is applied straight to the DOM. Read it with [`getState`](#getstate).
+initial state goes straight to the DOM; read it with [`getState`](#getstate).
 
 ## createPhoneInput
 
@@ -34,7 +34,7 @@ A discriminated union on `mode`. `'national'` extends
 [`NationalInputControllerConfig`](/core/reference/input-controller/#nationalinputcontrollerconfig);
 `'international'` extends
 [`InternationalInputControllerConfig`](/core/reference/input-controller/#internationalinputcontrollerconfig).
-The adapter adds four fields:
+The adapter adds these fields:
 
 | Field                   | Type                            | Meaning                                                              |
 | ----------------------- | ------------------------------- | -------------------------------------------------------------------- |
@@ -65,9 +65,11 @@ restrictions.
 `placeholder` is the example number for the resolved region, in the field's own display shape.
 While the value resolves no region, it falls back to the configured `defaultRegion`. It is `null`
 without a region to fall back to, or when the region's metadata carries no example for the
-configured type. It lives in the state only. The DOM `placeholder` attribute stays untouched, and
-you render it yourself. A national US field gets `'(201) 555-0123'`. An international field with the
+configured type. A national US field gets `'(201) 555-0123'`. An international field with the
 calling code inside gets `'1 201-555-0123'`.
+
+It lives in the state only. The DOM `placeholder` attribute stays untouched; you render it
+yourself.
 
 `validationError` is
 [`getValidationError`](/core/reference/phone-number/#getvalidationerror) for the current value. An

--- a/apps/docs/src/content/docs/web-sdk/region-list.mdx
+++ b/apps/docs/src/content/docs/web-sdk/region-list.mdx
@@ -66,8 +66,7 @@ type RegionListState<T = undefined> = {
 };
 ```
 
-`options` is the list as currently rendered, with the filters, search, sort, and prioritization
-already applied.
+`options` is the list as currently rendered, with the pipeline already applied.
 
 ## Search matching
 
@@ -108,9 +107,9 @@ The built-in comparators collate display names in the list's locale and break ti
 function regionToFlagEmoji(region: RegionCode): string;
 ```
 
-The region's flag emoji, built from the two Unicode regional indicator symbols for its letters. Platforms
-without flag emoji, notably Windows, render the two letters; for a flag on every platform, ship an
-SVG set keyed by the region code.
+The region's flag emoji, built from the two Unicode regional indicator symbols for its letters.
+Platforms without flag emoji, notably Windows, render the two letters; for a flag on every
+platform, ship an SVG set keyed by the region code.
 
 ```ts
 regionToFlagEmoji('US'); // '🇺🇸'
@@ -160,8 +159,8 @@ locale is a no-op.
 refresh(): void;
 ```
 
-Recomputes the base set and emits, always. Use it when external state read by `dataFactory` has
-changed.
+Recomputes the base set and emits unconditionally. Use it when external state read by `dataFactory`
+has changed.
 
 ### setRegionFilter
 


### PR DESCRIPTION
## Summary

Tighten the six `@telixon/web-sdk` documentation pages: the two reference pages (`PhoneInput`, `RegionList`), the Getting-started page, and the three guides. Every documented value was re-verified by running it through happy-dom. Nothing else changes; no source code is touched.

## Motivation

A read-through against the running SDK surfaced wording that misstated behavior or repeated itself. The complete-field guide claimed a "selector mode" that keeps the calling code "in the region button", but the mode only keeps it out of the input; the button is the demo's own choice, and "selector mode" is not a documented term. The same guide said "the field reads `604-555-0132`", ambiguous for an input, now "shows". The split of work between the machine and the caller was stated twice, and once incompletely, in the phone-field guide. Overloaded paragraphs in the reference were split one topic each, and a few sentences that repeated a heading or a sibling page were cut.

## Conformance impact

None. No engine or query-method code is touched; the changes are documentation prose.

## Checklist

- [x] Tests added or updated (or a rationale for why none) — documentation-only, no behavior to cover
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention