### PR TITLE
chore: make @telixon/core a web-sdk peer dependency and polish the docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -107,9 +107,11 @@ and number type. Region disambiguation and format selection run on dedicated fin
 automata that emit a value (a region, a format index) at the end of the walk instead of a yes/no.
 Resolving a number is therefore a linear-time table walk, deterministic and backtracking-free, which is
 what makes per-keystroke resolution cheap. The recognition automaton is global and unified: one number
-is matched against every region at once, with no per-region data to load. The only regular expression
-left at runtime is the per-territory national-prefix rewrite, a bounded capture-group transform applied
-once per parse. The engine ships as four embedded modules carrying nine binary layers:
+is matched against every region at once, with no per-region data to load. Two regular expressions
+survive at runtime, both anchored prefix transforms built from the metadata. The per-territory
+national-prefix rewrite is a bounded capture-group transform; the IDD strip removes a dialled
+international prefix before the digits are resolved. Each matches a short leading prefix, never the
+number as a whole. The engine ships as four embedded modules carrying nine binary layers:
 
 ```
 walk.bin.js      recognition DFA state graph, calling-code dispatch, region disambiguation

--- a/apps/docs/ec.config.mjs
+++ b/apps/docs/ec.config.mjs
@@ -15,6 +15,12 @@ const telixonDark = new ExpressiveCodeTheme({
     { scope: ['keyword.control', 'storage.type', 'storage.modifier'], settings: { foreground: '#79c0ff' } },
     { scope: ['storage.type.function.arrow'], settings: { foreground: '#e8eaec' } },
     { scope: ['entity.name.function', 'support.function'], settings: { foreground: '#d2a8ff' } },
+    { scope: ['constant.numeric', 'keyword.other.unit', 'constant.other.color'], settings: { foreground: '#1fd8a4' } },
+    { scope: ['entity.name.tag'], settings: { foreground: '#79c0ff' } },
+    { scope: ['entity.other.attribute-name'], settings: { foreground: '#d2a8ff' } },
+    { scope: ['support.type.property-name.css'], settings: { foreground: '#79c0ff' } },
+    { scope: ['variable.css'], settings: { foreground: '#d2a8ff' } },
+    { scope: ['punctuation.definition.tag'], settings: { foreground: '#7f858c' } },
   ],
 });
 
@@ -31,6 +37,12 @@ const telixonLight = new ExpressiveCodeTheme({
     { scope: ['keyword.control', 'storage.type', 'storage.modifier'], settings: { foreground: '#0969da' } },
     { scope: ['storage.type.function.arrow'], settings: { foreground: '#17191b' } },
     { scope: ['entity.name.function', 'support.function'], settings: { foreground: '#8250df' } },
+    { scope: ['constant.numeric', 'keyword.other.unit', 'constant.other.color'], settings: { foreground: '#208368' } },
+    { scope: ['entity.name.tag'], settings: { foreground: '#0969da' } },
+    { scope: ['entity.other.attribute-name'], settings: { foreground: '#8250df' } },
+    { scope: ['support.type.property-name.css'], settings: { foreground: '#0969da' } },
+    { scope: ['variable.css'], settings: { foreground: '#8250df' } },
+    { scope: ['punctuation.definition.tag'], settings: { foreground: '#6b7177' } },
   ],
 });
 

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -1325,6 +1325,10 @@ const closedTypesCode = `controller.setRegion('USA')
         .demo-rows .v {
           text-align: left;
         }
+        /* The error value is a flex row, which text-align cannot move. */
+        .demo-rows .v.has-error {
+          justify-content: flex-start;
+        }
         .dfa-grid {
           grid-template-columns: repeat(12, minmax(0, 1fr));
         }

--- a/apps/docs/src/styles/theme.css
+++ b/apps/docs/src/styles/theme.css
@@ -8,6 +8,15 @@
   accent-color: var(--sl-color-accent);
 }
 
+/* Code renders every glyph as typed: JetBrains Mono's calt ligatures would fuse !== and =>. */
+code,
+pre,
+kbd,
+samp {
+  font-variant-ligatures: none;
+  font-feature-settings: 'calt' 0;
+}
+
 /* Type scale: calmer than the Starlight defaults, tuned for reference reading. */
 :root {
   --sl-text-h1: 2.125rem;

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -41,8 +41,11 @@
     "prepublishOnly": "pnpm run build",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
+  "devDependencies": {
     "@telixon/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "@telixon/core": "workspace:^"
   },
   "packageManager": "pnpm@10.16.1",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,7 +131,7 @@ importers:
         version: 1.13.3
 
   packages/web-sdk:
-    dependencies:
+    devDependencies:
       '@telixon/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Summary

Move `@telixon/core` to a `peerDependencies` (`workspace:^`) plus `devDependencies` in `@telixon/web-sdk`, matching the documented "install both" story. Correct `ARCHITECTURE.md` to state the two runtime regexes, not one. Three docs cosmetics: code-block syntax colors, ligatures off in code, and a mobile fix for the landing error row.

## Motivation

A regular dependency let a consumer's core drift from the one they install; a peer ties them. `ARCHITECTURE.md` claimed one runtime regex; there are two (national-prefix rewrite, IDD strip), both verified against the code.

## Conformance impact

None. Packaging metadata and documentation only.

## Checklist

- [x] Tests added or updated (or a rationale for why none) — packaging and docs only
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention