### PR TITLE
build: stop publishing source maps

### DIFF
--- a/apps/docs/src/generated/size.json
+++ b/apps/docs/src/generated/size.json
@@ -1,17 +1,17 @@
 {
   "nodeEntry": {
     "artifact": "@telixon/core (Node entry)",
-    "measured": "20.83 kB brotli",
+    "measured": "20.80 kB brotli",
     "budget": "22 kB"
   },
   "browserEntry": {
     "artifact": "@telixon/core (browser entry)",
-    "measured": "23.45 kB brotli",
+    "measured": "23.39 kB brotli",
     "budget": "25 kB"
   },
   "webSdk": {
     "artifact": "@telixon/web-sdk",
-    "measured": "3.78 kB brotli",
+    "measured": "3.77 kB brotli",
     "budget": "5 kB"
   },
   "engineTables": "122 kB"

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
   },
   clean: true,
   splitting: false,
-  sourcemap: true,
+  sourcemap: false,
   treeshake: true,
   target: 'node18',
   esbuildPlugins: [externalEmbedded],

--- a/packages/web-sdk/tsup.config.ts
+++ b/packages/web-sdk/tsup.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   dts: true,
   clean: true,
   splitting: false,
-  sourcemap: true,
+  sourcemap: false,
   treeshake: true,
   target: 'es2020',
   external: ['@telixon/core'],


### PR DESCRIPTION
## Summary

Set `sourcemap: false` in both packages' tsup config, so the published tarballs no longer carry `.map` files. `@telixon/core` drops from 1829 kB to 635 kB unpacked (20 files to 15), `@telixon/web-sdk` from 89 kB to 44 kB. The regenerated `size.json` reflects a small entry-size drop, since removing the maps also removes the trailing `//# sourceMappingURL` comment from each bundle.

## Motivation

Source maps were 65% of the core tarball, larger than the code and the engine tables combined. They never reach a consumer bundle and give a consumer nothing at runtime, while inflating install size and the unpacked figure shown on npm. For a package that gates its own entry sizes, shipping two thirds dead weight reads as carelessness.

## Conformance impact

None. Build configuration only; no engine or query-method code is touched.

## Checklist

- [x] Tests added or updated (or a rationale for why none) — build config only; the suite runs on `src`, and the built `dist` was smoke-tested (`parsePhoneNumber('+1 (415) 555-0132')` returns valid, US, `+14155550132`)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention
