### PR TITLE
Build/publish and size pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 examples/core/bundle-size/report
 packages/core/oracle/.cache
 .DS_Store
+.claude/settings.local.json

--- a/apps/docs/src/generated/size.json
+++ b/apps/docs/src/generated/size.json
@@ -1,18 +1,17 @@
 {
   "nodeEntry": {
     "artifact": "@telixon/core (Node entry)",
-    "measured": "20.80 kB brotli",
+    "measured": "20.78 kB brotli",
     "budget": "22 kB"
   },
   "browserEntry": {
     "artifact": "@telixon/core (browser entry)",
-    "measured": "23.39 kB brotli",
+    "measured": "23.37 kB brotli",
     "budget": "25 kB"
   },
   "webSdk": {
     "artifact": "@telixon/web-sdk",
     "measured": "3.77 kB brotli",
     "budget": "5 kB"
-  },
-  "engineTables": "122 kB"
+  }
 }

--- a/examples/core/bundle-size/README.md
+++ b/examples/core/bundle-size/README.md
@@ -2,21 +2,20 @@
 
 A Vite app that uses the entire public API of `@telixon/core` and builds it the way a real consumer's bundler does. It
 exists to show exactly what the package adds to an application's initial download, and why bundle analyzers report a
-larger number. The app exercises every export, including the input controller, so the initial figure is the ceiling, not
-a tree-shaken minimum.
+larger number. The app exercises every export, including the input controller, which makes the initial figure a
+ceiling for any real application.
 
 ## What it shows
 
 `@telixon/core` ships its engine (the compiled libphonenumber metadata) as four base64-of-gzip modules loaded through
-dynamic `import()`. A production bundler keeps those in separate lazy chunks instead of inlining them, so the build
-splits into:
+dynamic `import()`. A production bundler keeps those in separate lazy chunks, splitting the build into:
 
-- an **initial chunk** (~18 KB gzip): the entire public API plus the loader, no metadata;
-- **four engine chunks** (~119 KB gzip total): fetched by `ensureEngineReady()` after first paint, off the critical
-  path.
+- an **initial chunk**: the entire public API plus the loader, no metadata;
+- **four engine chunks**: fetched by `ensureEngineReady()` after first paint, off the critical path.
 
-Bundlephobia and the Import Cost editor extension cannot model code-splitting, so they inline every `import()` and report
-the sum (~138 KB). The number a user downloads on first paint is the initial chunk.
+Bundlephobia and the Import Cost editor extension inline every `import()` and report the combined total, since
+neither models code-splitting. The number a user downloads on first paint is the initial chunk. Running this example
+prints the measured split, published at [proof.telixon.dev/bundle.html](https://proof.telixon.dev/bundle.html).
 
 `size-limit` is the regression gate (it fails CI if the published entry grows past its budget); this example is the
 human-readable proof of where the bytes go.
@@ -29,7 +28,7 @@ pnpm --filter @telixon/example-core-bundle-size build
 ```
 
 Vite prints the chunk sizes. `pnpm --filter @telixon/example-core-bundle-size report` additionally writes
-`report/bundle.html` (the published [proof.telixon.dev/bundle.html](https://proof.telixon.dev/bundle.html) page).
+`report/bundle.html`, the page published on the dashboard.
 
 ## How the numbers are measured
 

--- a/examples/core/bundle-size/bundle.template.html
+++ b/examples/core/bundle-size/bundle.template.html
@@ -173,9 +173,9 @@
   <body>
     <h1>@telixon/core bundle size</h1>
     <div class="meta">
-      What @telixon/core actually adds to a consumer's initial download, measured from a real Vite production build. The
-      app exercises the entire public API, including the input controller, so the initial figure is the ceiling;
-      tree-shaking trims a typical app below it.<br />
+      What @telixon/core adds to a consumer's initial download, measured from a real Vite production build. The app
+      imports the entire public API, including the input controller, which makes the initial figure a ceiling for any
+      real application.<br />
       Engine compiled from Google's libphonenumber source at
       <a href="https://github.com/google/libphonenumber/commit/{{commit}}"
         >github.com/google/libphonenumber@{{shortCommit}}</a
@@ -187,20 +187,18 @@
       <div class="stat-card">
         <div class="stat-value">{{initialGzip}}</div>
         <div class="stat-label">initial bundle</div>
-        <div class="stat-sub">the entry chunk, gzipped: the entire public API plus the loader, no metadata</div>
+        <div class="stat-sub">the entry chunk gzipped, holding the public API and the loader with no metadata</div>
       </div>
       <div class="stat-card">
         <div class="stat-value muted">{{engineGzip}}</div>
         <div class="stat-label">engine, {{engineChunkCount}} lazy chunks</div>
-        <div class="stat-sub">
-          fetched by <code>ensureEngineReady()</code> after first paint, not in the initial bundle
-        </div>
+        <div class="stat-sub">fetched by <code>ensureEngineReady()</code> after first paint</div>
       </div>
       <div class="stat-card">
         <div class="stat-value muted">{{inlinedGzip}}</div>
         <div class="stat-label">what an analyzer reports</div>
         <div class="stat-sub">
-          bundlephobia and Import Cost inline the lazy chunks, so they show initial plus engine as one number
+          bundlephobia and Import Cost inline the lazy chunks, reporting initial plus engine as one number
         </div>
       </div>
     </div>
@@ -218,8 +216,8 @@
     <h2 id="chunks">Chunks</h2>
     <div class="section-note">
       Every JavaScript file the build emitted, gzipped at level 9 and brotli-compressed at quality 11. The engine's four
-      base64-of-gzip modules are referenced through dynamic <code>import()</code>, so the bundler splits each into its
-      own lazy chunk instead of inlining it into the entry.
+      base64-of-gzip modules are referenced through dynamic <code>import()</code>, which makes the bundler split each
+      into its own lazy chunk.
     </div>
     <table>
       <thead>
@@ -236,17 +234,16 @@
       </tbody>
     </table>
 
-    <h2 id="why">Why the analyzer number is higher</h2>
+    <h2 id="why">How analyzers count this</h2>
     <div class="section-note">
       <p>
-        Tools like bundlephobia and the Import Cost editor extension estimate size by inlining every
-        <code>import()</code> back into the entry, because they cannot model how a real bundler code-splits an
-        application. For a library that ships its data through lazy chunks, that collapses the initial bundle and the
-        on-demand engine into a single figure ({{inlinedGzip}}).
+        bundlephobia and the Import Cost editor extension estimate size by inlining every <code>import()</code> back
+        into the entry, since neither models code-splitting. For a library that ships its data through lazy chunks, that
+        collapses the initial bundle and the on-demand engine into one figure ({{inlinedGzip}}).
       </p>
       <p>
         A production bundler keeps the split. The engine layers download in parallel, off the critical path, when
-        <code>ensureEngineReady()</code> runs. The number that reaches a user on first paint is the entry chunk:
+        <code>ensureEngineReady()</code> runs. The entry chunk is what reaches a user on first paint, at
         <strong>{{initialGzip}} gzipped</strong>.
       </p>
     </div>
@@ -257,8 +254,8 @@ cd telixon &amp;&amp; pnpm install
 pnpm --filter @telixon/core build
 pnpm --filter @telixon/example-core-bundle-size build</code></pre>
     <div class="section-note">
-      The build prints the same chunk sizes you see above. No bundler configuration hides anything: the engine is split
-      because it is loaded through dynamic <code>import()</code>, which is how a real consumer's bundler treats it.
+      The build prints the same chunk sizes as the table above. The engine splits because it loads through dynamic
+      <code>import()</code>, exactly as it does in a consumer's build.
     </div>
 
     <footer>

--- a/examples/core/bundle-size/report.ts
+++ b/examples/core/bundle-size/report.ts
@@ -92,7 +92,7 @@ function measureChunk(file: string): Chunk {
     file,
     role: ENGINE_CHUNK_PATTERN.test(file) ? 'engine' : 'initial',
     raw: bytes.byteLength,
-    // Maximum compression on both, so the figures are the smallest a server could transfer.
+    // Maximum compression on both; the figures are the smallest a server could transfer.
     gzip: gzipSync(bytes, { level: 9 }).byteLength,
     brotli: brotliCompressSync(bytes, { params: { [zlibConstants.BROTLI_PARAM_QUALITY]: 11 } }).byteLength,
   };

--- a/scripts/generate-size.mjs
+++ b/scripts/generate-size.mjs
@@ -1,7 +1,8 @@
-// Regenerates the measured sizes the Verified page renders, so the table can never go stale.
-// Entry sizes come from size-limit; the engine figure is the gzip payload inside the embedded modules.
+// Regenerates the measured entry sizes the Verified page renders, so the table can never go stale.
+// The engine figure is not duplicated here; the bundle-size example measures it from a real build
+// and publishes it at proof.telixon.dev/bundle.html.
 import { execSync } from 'node:child_process';
-import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -10,18 +11,6 @@ const outputPath = join(repoRoot, 'apps/docs/src/generated/size.json');
 
 // size-limit prints kilobytes as bytes over 1000; the page mirrors its convention.
 const kilobytes = (bytes) => (bytes / 1000).toFixed(2);
-
-function embeddedGzipBytes() {
-  const dir = join(repoRoot, 'packages/core/dist/engine/embedded');
-  let total = 0;
-  for (const file of readdirSync(dir)) {
-    const source = readFileSync(join(dir, file), 'utf8');
-    for (const match of source.matchAll(/"([A-Za-z0-9+/=]{100,})"/g)) {
-      total += Buffer.from(match[1], 'base64').length;
-    }
-  }
-  return total;
-}
 
 try {
   const measured = JSON.parse(
@@ -40,12 +29,11 @@ try {
     nodeEntry: entries.find((entry) => entry.artifact.includes('Node entry')),
     browserEntry: entries.find((entry) => entry.artifact.includes('browser entry')),
     webSdk: entries.find((entry) => entry.artifact === '@telixon/web-sdk'),
-    engineTables: `${Math.round(embeddedGzipBytes() / 1000)} kB`,
   };
 
   writeFileSync(outputPath, JSON.stringify(size, null, 2) + '\n');
   console.log(
-    `size.json regenerated: ${size.nodeEntry.measured}, ${size.browserEntry.measured}, ${size.webSdk.measured}, engine ${size.engineTables}`,
+    `size.json regenerated: ${size.nodeEntry.measured}, ${size.browserEntry.measured}, ${size.webSdk.measured}`,
   );
 } catch (error) {
   if (existsSync(outputPath)) {

--- a/scripts/safe-publish.mjs
+++ b/scripts/safe-publish.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-// Atomically removes dev-only fields from the current package.json, runs
-// `pnpm publish` with all passed-through args, then restores the source file
-// regardless of outcome. Run from the package directory you want to ship.
+// Removes dev-only fields from the current package.json, runs `pnpm publish` with all passed-through
+// args, then restores the source file on success, on failure, and on interrupt. Run from the package
+// directory you want to ship.
 //
 // Stripped fields (none are consumer-facing):
 //   - devDependencies   (tests, conformance, benchmarks; consumers do not install)
@@ -12,7 +12,7 @@
 // Usage (in CI):
 //   node ../../scripts/safe-publish.mjs --access public --provenance --no-git-checks
 
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
@@ -31,18 +31,34 @@ writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
 
 console.log(`safe-publish: stripped ${stripped.length ? stripped.join(', ') : '(no fields)'}`);
 
-let exitCode = 1;
-try {
-  const result = spawnSync('pnpm', ['publish', ...process.argv.slice(2)], {
-    stdio: 'inherit',
-    shell: false,
-  });
-  exitCode = result.status ?? 1;
-} catch (error) {
-  console.error('safe-publish: pnpm publish crashed:', error);
-} finally {
+// Writes back the original bytes, keeping formatting and key order. Safe to call more than once.
+let restored = false;
+function restoreSource() {
+  if (restored) return;
+  restored = true;
   writeFileSync(pkgPath, original);
   console.log('safe-publish: source package.json restored');
 }
 
-process.exit(exitCode);
+// Async spawn keeps the event loop free; a blocking one would defer these handlers until the child
+// exits, which is exactly when an interrupt needs them.
+const child = spawn('pnpm', ['publish', ...process.argv.slice(2)], { stdio: 'inherit', shell: false });
+
+for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+  process.on(signal, () => {
+    child.kill(signal);
+    restoreSource();
+    process.exit(1);
+  });
+}
+
+child.on('error', (error) => {
+  console.error('safe-publish: pnpm publish failed to start:', error);
+  restoreSource();
+  process.exit(1);
+});
+
+child.on('close', (code) => {
+  restoreSource();
+  process.exit(code ?? 1);
+});


### PR DESCRIPTION
## Summary

`safe-publish.mjs` runs `pnpm publish` through async `spawn`; `SIGINT`, `SIGTERM`, and `SIGHUP` are forwarded to the child and restore `package.json` before exit. `generate-size.mjs` stops emitting the engine-tables figure, leaving the bundle report as its single owner; the bundle-size example template follows the docs style. Package sources are untouched.

## Motivation

Closes #54. The publish step ran through `spawnSync`, which blocks the event loop; an interrupt during publish left the stripped manifest on disk. The engine-tables figure also existed in two places that could drift apart.

## Conformance impact

None. No engine or query-method behavior is touched; the changes are release tooling and the size pipeline.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention
