### PR TITLE
Docs/wording and structure sweep

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,7 +15,7 @@ self-contained.
 Telixon is a phone-number library verified against Google libphonenumber, the reference implementation. Four priorities drive every decision, in order:
 
 1. **Performance.** The input path runs on every keystroke. Allocation and indirection in hot paths
-   are defects, not style choices.
+   count as defects.
 2. **Accuracy.** Behavior is verified against Google's libphonenumber, the reference implementation,
    at a pinned commit. Divergence is a bug.
 3. **Stability.** The public API is a contract. Additions are deliberate; removals are breaking.
@@ -42,12 +42,14 @@ telixon/
     core/          @telixon/core    pure engine, all phone-number logic
     web-sdk/       @telixon/web-sdk headless DOM adapter for <input> elements
   apps/
+    docs/          landing page and documentation site (telixon.dev), never published to npm
     sandbox/       internal dev workbench (Vite + TS), never published
+  examples/        runnable examples, one per topic
   CLAUDE.md        engineering standards and AI-assistant operating notes
   ARCHITECTURE.md  this document
 ```
 
-Planned packages (not yet present): `components`, `angular`, `react`, `vue`.
+Planned packages (not yet present): `web-components`, `angular`, `react`, `vue`.
 The layer model below is designed so they slot in without reshaping existing packages.
 
 ## Layer stack
@@ -62,17 +64,17 @@ Each layer adds one concern and depends only on layers beneath it.
 | 3     | `core/src/resource-*`         | How the engine artifact is loaded and decoded (node / browser / edge) | layer 1    | present |
 | 4     | `@telixon/web-sdk`            | Headless: DOM events to engine ops + `subscribe`                      | core       | present |
 | 5     | `angular` / `react` / `vue`   | `subscribe` to framework-native reactive state                        | web-sdk    | planned |
-| 6     | `components`                  | Optional drop-in `<tel-input>`; the only renderer                     | web-sdk    | planned |
+| 6     | `web-components`              | Optional drop-in `<tel-input>`; the only renderer                     | web-sdk    | planned |
 | 7     | user code                     | All markup, styles, region-selector wiring                            | a binding  | n/a     |
 
 The split keeps the engine free of DOM, reactivity, and framework weight, and lets a caller enter at
 the level matching their need:
 
-- **`@telixon/components`**: drop in a component, one line. (planned)
+- **`@telixon/web-components`**: drop in a component, one line. (planned)
 - **`@telixon/web-sdk`**: bring your own UI, roughly ten lines.
 - **`@telixon/core`**: bypass the SDK.
 
-UI rendering belongs only in the planned `components` layer; `web-sdk` stays UI-free.
+UI rendering belongs only in the planned `web-components` layer; `web-sdk` stays UI-free.
 
 ## Data flow
 
@@ -83,33 +85,32 @@ truth for the resolved value; everything downstream reacts.
 DOM event
   -> web-sdk translates it to a core insert / delete / caret operation
   -> core resolves and returns InputState
-  -> web-sdk applies value and caret to the <input>, then notifies subscribers
+  -> web-sdk applies value and selection to the <input>, then notifies subscribers
   -> framework binding maps the new state to reactive state
   -> user code re-renders
 ```
 
-The engine is imperative and synchronous: a call returns the next `InputState` directly. Reactivity is
-added once, in `web-sdk`, via `subscribe(listener)`; it is not baked into the engine.
+The engine is imperative and synchronous, returning the next `InputState` directly from a call.
+Reactivity is added once, in `web-sdk`, via `subscribe(listener)`; the engine itself carries none.
 
 ## Engine
 
 The engine is the original work and the differentiator.
 
-**It is a generated artifact, not hand-written source.** `core/src/engine` contains no hand-written
-`.ts` source. It is `index.js` + `index.d.ts` (the accessor API) plus binary layers, compiled from
-Google's libphonenumber metadata by a separate tool. Never hand-edit it; changes come from recompiling and
+**It is a generated artifact.** `core/src/engine` holds `index.js` and `index.d.ts` (the accessor
+API) plus binary layers, all compiled from Google's libphonenumber metadata by a separate tool. Never hand-edit it; changes come from recompiling and
 bumping provenance.
 
-**It is a family of deterministic finite-state automata, not per-region data.** Google publishes its
-metadata as regular expressions; the compiler turns them into automata. At the core is a recognition
-DFA: a number's digits drive deterministic state transitions, and the state reached decides validity
-and number type. Region disambiguation and format selection run on dedicated finite-state transducers,
-automata that emit a value (a region, a format index) at the end of the walk instead of a yes/no.
-Resolving a number is therefore a linear-time table walk, deterministic and backtracking-free, which is
-what makes per-keystroke resolution cheap. The recognition automaton is global and unified: one number
-is matched against every region at once, with no per-region data to load. Two regular expressions
+**It is one deterministic finite automaton whose states carry the answers.** Google publishes its
+metadata as regular expressions; the compiler turns them into a single state graph. A number's
+digits drive one walk, deterministic and backtracking-free, and the state the walk ends on is the
+key to every answer. Validity, number type, region, and format index are read off that state through
+accessors shaped `(engine, state, ...)`, which makes the engine a Moore machine, an automaton whose
+output is a function of the state it reaches. One linear-time walk per resolution is what keeps
+per-keystroke work cheap. The automaton is global and unified, matching one
+number against every region at once, with no per-region data to load. Two regular expressions
 survive at runtime, both anchored prefix transforms built from the metadata. The per-territory
-national-prefix rewrite is a bounded capture-group transform; the IDD strip removes a dialled
+national-prefix rewrite is a bounded capture-group transform; the IDD strip removes a dialed
 international prefix before the digits are resolved. Each matches a short leading prefix, never the
 number as a whole. The engine ships as four embedded modules carrying nine binary layers:
 
@@ -145,17 +146,18 @@ statically bundles the modules and decodes them in-process. Each uses the fastes
 
 The pure-JS base64 + gunzip floor runs in any runtime and is byte-equality-tested against zlib in CI.
 
-The bundle-size story is code-and-data separation, not "ship fewer regions":
+Bundle size follows from separating code and data:
 
 - The JS code is tree-shakeable; a caller pays only for the functions they import.
-- The engine artifact is runtime data, out of the initial JS bundle (~119 KB compressed across four
-  content-hashed chunks, ~0.61 MB decompressed). The async entries load it lazily (cached after first
-  load on the web); `@telixon/core/sync-init` carries it in the bundle.
+- The engine artifact is runtime data, out of the initial JS bundle and split across four
+  content-hashed chunks. The async entries load it lazily (cached after first load on the web);
+  `@telixon/core/sync-init` carries it in the bundle instead. Measured figures are published at
+  [proof.telixon.dev/bundle.html](https://proof.telixon.dev/bundle.html).
 
 `index.node.ts`, `index.browser.ts`, and `index.edge.ts` (selected via package export conditions) bind
 `ensureEngineReady()` to the environment's loader and re-export the shared `index.ts`;
 `index.sync-init.ts` and `index.sync-init.node.ts` back the `@telixon/core/sync-init` entry. The
-provider is process-wide, so either entry readies one engine and the rest of the code stays
+provider is process-wide, which lets either entry ready one engine while the rest of the code stays
 environment-agnostic. Initialization is explicit: `await ensureEngineReady()` is the default,
 `ensureEngineReadySync()` from `@telixon/core/sync-init` is the synchronous path, and an API call before
 either throws `EngineNotReadyError`. `isEngineReady()` is a synchronous readiness predicate. Full
@@ -182,17 +184,17 @@ in CI; the rest are enforced in review.
 `packages/core/conformance` runs the public query methods against Google's libphonenumber across every
 supported region, on valid numbers, display spellings, deterministic corruptions, and every digit
 prefix, and fails CI on any divergence outside an explicit allowlist. The oracle loads Google's
-source at **the same commit the engine was compiled from**, so there is no metadata version drift: a
-mismatch is always a real engine difference, never a stale reference. The current baseline is on the
+source at **the same commit the engine was compiled from**, which rules out metadata version drift.
+A mismatch is always a real engine difference, never a stale reference. The current baseline is on the
 [live dashboard](https://proof.telixon.dev/parity.html). See
 [conformance/README.md](packages/core/conformance/README.md).
 
 ### Performance
 
-The per-keystroke path is hot. The standing rule: avoid allocation, regex, and indirection in hot
-paths; prefer charCode parsing and early exits. Outside hot paths, allocation is fine where it improves
-clarity. This is a discipline applied in review and backed by the benchmark suite (`pnpm bench`), with
-continuous performance regression tracking in CI via CodSpeed. It is not a formal zoning map.
+The per-keystroke path is hot. The standing rule avoids allocation, regex, and indirection there,
+preferring charCode parsing and early exits. Outside hot paths, allocation is fine where it improves
+clarity. Review applies the discipline, and the benchmark suite (`pnpm bench`) backs it, with
+continuous performance regression tracking in CI via CodSpeed.
 
 ### Bundle size
 
@@ -206,8 +208,8 @@ These keep modules independent and the dependency graph legible. They are enforc
 - **One primary concept per file**, named for the one thing it exports.
 - **Self-contained modules.** Each owns its `models/`, `utils/`, and `index.ts`.
 - **`index.ts` is a re-export barrel only.** No logic in a barrel.
-- **Never import a module's internals.** Import only from another module's `index.ts`, so internal
-  layout is free to change without rippling outward.
+- **Never import a module's internals.** Import only from another module's `index.ts`, leaving
+  internal layout free to change without rippling outward.
 - **Types live close to usage.** Promote a type to `models/` only once it is shared across modules.
 
 ## Naming

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ packages/
   angular/    # (planned)
   react/      # (planned)
   vue/        # (planned)
-  components/ # (planned)
+  web-components/ # (planned)
 ```
 
 ### Core package

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,12 +19,14 @@ pnpm install --frozen-lockfile
 
 ## Project layout
 
-A pnpm monorepo. See [ARCHITECTURE.md](ARCHITECTURE.md) for the full picture.
+A pnpm monorepo.
 
 ```
 packages/core      @telixon/core    engine and phone-number logic
 packages/web-sdk   @telixon/web-sdk headless DOM adapter
+apps/docs          landing page and documentation site (telixon.dev)
 apps/sandbox       internal dev workbench
+examples/          runnable examples, one per topic
 ```
 
 ## Development
@@ -43,12 +45,14 @@ Run from the repo root:
 | `pnpm bench`                 | benchmarks, console output                                                   |
 | `pnpm bench:report`          | bench + writes `bench.json`, `bench-badge.json`, `benchmark.html`            |
 | `pnpm conformance`           | parity gate vs Google libphonenumber (fetches Google source once per commit) |
+| `pnpm fuzz`                  | randomized differential sweep against the oracle                             |
+| `pnpm size`                  | `size-limit` budgets for the published entries                               |
 | `pnpm build`                 | build all packages                                                           |
 
 ## Submitting changes
 
-`main` is protected: every change lands through a pull request, and merges are squash-only, so the
-pull request title becomes the commit subject on `main`.
+`main` is protected. Every change lands through a pull request, and merges are squash-only, which
+makes the pull request title the commit subject on `main`.
 
 1. Branch off `main`.
 2. Make your change.
@@ -112,7 +116,7 @@ These are the canonical engineering standards for Telixon. They are non-negotiab
 
 - No unnecessary allocations or copies in hot paths.
 - Every dependency must be justified by measurable need.
-- Bundle size is a hard constraint, not a soft preference.
+- Bundle size is a hard constraint.
 
 ### Hard rules
 
@@ -123,7 +127,7 @@ These are the canonical engineering standards for Telixon. They are non-negotiab
   - **I/O adapter.** A runtime boundary is bridged behind an interface (e.g. resource loaders).
   - **Cached interface implementation.** The class exists solely to memoize underlying pure
     functions on a per-instance basis (e.g. `PhoneNumberView` for `PhoneNumber`). Same input must
-    produce the same output across calls; the class adds caching, not behavior.
+    produce the same output across calls; the class adds caching alone.
   - **State machine.** The contract is a sequence of state transitions reached through an
     imperative API (e.g. `NumberResolver.advance(...)`, `.reset()`, `.snapshot`). The class wraps
     a mutation sequence that has no equivalent pure form.

--- a/README.md
+++ b/README.md
@@ -35,18 +35,29 @@ number.getRegion(); // 'US'
 number.formatE164(); // '+14155550132'
 ```
 
-The same engine drives a phone field, formatting on every keystroke and holding the caret:
+[`@telixon/web-sdk`](packages/web-sdk/README.md) turns a plain `<input>` into a phone field,
+handling the events, the caret, and the history:
 
 ```ts
-import { createNationalInputController } from '@telixon/core';
+import { ensureEngineReady } from '@telixon/core';
+import { createPhoneInput } from '@telixon/web-sdk';
 
-const controller = createNationalInputController({ defaultRegion: 'US' });
+await ensureEngineReady();
 
-controller.insert('', '415', 0, 0);
-// { value: '(415) ', region: 'US', selectionStart: 6, selectionEnd: 6 }
+const input = document.querySelector('input')!;
 
-controller.insert('(415) ', '5550132', 6, 6);
-// { value: '(415) 555-0132', region: 'US', selectionStart: 14, selectionEnd: 14 }
+const phone = createPhoneInput({
+  mode: 'national',
+  defaultRegion: 'US',
+  input,
+});
+
+phone.subscribe((state) => {
+  // After typing 4155550132:
+  // state.value            '(415) 555-0132'
+  // state.region           'US'
+  // state.validationError  null
+});
 ```
 
 Full documentation is at [telixon.dev](https://telixon.dev), with live demos for the
@@ -58,12 +69,12 @@ Full documentation is at [telixon.dev](https://telixon.dev), with live demos for
 
 - **Compiled to one automaton.** Google publishes its metadata as regular expressions; Telixon
   compiles them ahead of time into a single deterministic finite automaton. Resolving a number is
-  one linear-time walk, and the state it ends on carries validity, type, region, and format.
+  one linear-time walk; the state it ends on carries validity, type, region, and format.
+- **A real input controller.** Formatting on every keystroke, with caret tracking, undo and redo,
+  and the full query surface mid-typing.
 - **No third-party dependencies.** `@telixon/core` installs nothing beyond itself.
 - **Every JavaScript runtime.** Node.js, browsers, Deno, Bun, and edge, selected through package
   export conditions.
-- **A real input controller.** Formatting on every keystroke, with caret tracking, undo and redo,
-  and the full query surface mid-typing.
 - **TypeScript-first.** Region codes and number types are closed unions; a typo fails to compile.
 
 ## Conformance
@@ -84,15 +95,10 @@ a divergence the gate misses?
 | ------------------------------------------------ | ------- | ------------------------------------- |
 | [`@telixon/core`](packages/core/README.md)       | shipped | parsing, formatting, validation       |
 | [`@telixon/web-sdk`](packages/web-sdk/README.md) | shipped | headless DOM input controller         |
-| `@telixon/components`                            | planned | drop-in Web Component (`<tel-input>`) |
+| `@telixon/web-components`                        | planned | drop-in Web Component (`<tel-input>`) |
 | `@telixon/angular`                               | planned | Angular binding                       |
 | `@telixon/react`                                 | planned | React binding (hook + component)      |
 | `@telixon/vue`                                   | planned | Vue binding                           |
-
-## Status
-
-`@telixon/core` and `@telixon/web-sdk` are stable at 1.0. Their public APIs follow semantic
-versioning; a breaking change requires a major release.
 
 ## Support
 
@@ -103,7 +109,7 @@ follow [SECURITY.md](SECURITY.md).
 ## Contributing
 
 Setup, workflow, and the engineering standards are in [CONTRIBUTING.md](CONTRIBUTING.md). The system
-design is in [ARCHITECTURE.md](ARCHITECTURE.md), and benchmark methodology is in
+design is in [ARCHITECTURE.md](ARCHITECTURE.md); benchmark methodology is in
 [bench/README.md](packages/core/bench/README.md).
 
 ## License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,8 +30,11 @@ Do not file a public issue. Do not post details on social media or blogs before 
 
 ## Supported versions
 
-Pre-1.0. Security fixes target the latest published version only. A formal LTS policy will be defined
-at 1.0.
+| Version | Supported |
+| ------- | --------- |
+| 1.x     | Yes       |
+
+Security fixes land in the latest `1.x` release.
 
 ## Response timeline
 

--- a/apps/docs/src/components/demos/complete-field.js
+++ b/apps/docs/src/components/demos/complete-field.js
@@ -40,13 +40,15 @@ function renderTrigger() {
   code.textContent = '+' + selected.callingCode;
 }
 
+// Shown when the search matches nothing.
+const emptyRow = document.createElement('li');
+emptyRow.className = 'phone-field-empty';
+emptyRow.textContent = 'No matches';
+
 // Full rebuild when the search changes the option set.
 function renderList(state) {
   if (state.options.length === 0) {
-    const empty = document.createElement('li');
-    empty.className = 'phone-field-empty';
-    empty.textContent = 'No matches';
-    list.replaceChildren(empty);
+    list.replaceChildren(emptyRow);
     return;
   }
 
@@ -136,7 +138,7 @@ function applySelection(region) {
   markSelected(region);
 }
 
-// Under a shared calling code the digits decide the region, so follow it.
+// Under a shared calling code the digits decide the region; follow it.
 function followResolvedRegion(region) {
   if (region === null || region === selected.region) return;
   applySelection(region);
@@ -200,7 +202,7 @@ root.addEventListener('keydown', (event) => {
     trigger.focus();
   }
 });
-// Dismiss on the press itself, so releasing a text-selection drag outside never closes the popup.
+// Dismiss on the press itself. Releasing a text-selection drag outside then leaves the popup open.
 // In a framework component, remove this document listener on unmount, next to each machine's destroy.
 function dismissOnOutsidePress(event) {
   if (!popup.hidden && !root.contains(event.target)) closePopup();
@@ -211,7 +213,7 @@ root.addEventListener('focusout', (event) => {
   if (!popup.hidden && event.relatedTarget && !root.contains(event.relatedTarget)) closePopup();
 });
 
-// A new option set moves the cursor to the first row, so Enter picks the top match.
+// A new option set moves the cursor to the first row, which lets Enter pick the top match.
 regions.subscribe((state) => {
   renderList(state);
   setActive(state.options.length > 0 ? state.options[0].region : null);
@@ -221,7 +223,7 @@ phone.subscribe((state) => {
   renderStatus(state);
 });
 
-// The subscriptions fire only on later changes, so render the initial state manually.
+// The subscriptions fire only on later changes; render the initial state manually.
 renderTrigger();
 renderList(regions.getState());
 renderStatus(phone.getState());

--- a/apps/docs/src/components/demos/region-picker.js
+++ b/apps/docs/src/components/demos/region-picker.js
@@ -14,13 +14,15 @@ const regions = createRegionList({
 
 let selected = 'US';
 
+// Shown when the search matches nothing.
+const emptyRow = document.createElement('li');
+emptyRow.className = 'region-picker-empty';
+emptyRow.textContent = 'No matches';
+
 // Full rebuild when the search changes the option set.
 function renderList(state) {
   if (state.options.length === 0) {
-    const empty = document.createElement('li');
-    empty.className = 'region-picker-empty';
-    empty.textContent = 'No matches';
-    list.replaceChildren(empty);
+    list.replaceChildren(emptyRow);
     return;
   }
 
@@ -109,12 +111,12 @@ list.addEventListener('click', (event) => {
   if (row) select(row.dataset.region);
 });
 
-// A new option set moves the cursor to the first row, so Enter picks the top match.
+// A new option set moves the cursor to the first row, which lets Enter pick the top match.
 regions.subscribe((state) => {
   renderList(state);
   setActive(state.options.length > 0 ? state.options[0].region : null);
 });
 
-// The subscription fires only on later changes, so render the initial state manually.
+// The subscription fires only on later changes; render the initial state manually.
 renderList(regions.getState());
 status.textContent = 'Selected: United States (+1)';

--- a/apps/docs/src/content/docs/core/guides/build-a-phone-input.mdx
+++ b/apps/docs/src/content/docs/core/guides/build-a-phone-input.mdx
@@ -1,9 +1,9 @@
 ---
 title: Build a phone input
-description: Wire a text field to a controller that formats live, moves the caret, and keeps history.
+description: Wire a phone field to a controller that formats live, moves the caret, and keeps history.
 ---
 
-A phone input pairs a plain text field with an
+A phone input pairs a plain `<input>` with an
 [`InputController`](/core/reference/input-controller/). The field emits edits; the controller
 returns the next state to write back.
 
@@ -85,8 +85,8 @@ controller.getPhoneNumber().isValid(); // true
 controller.getPhoneNumber().formatE164(); // '+14155550132'
 ```
 
-While the value is unfinished, prefer the tolerant checks; see
-[Validate a phone number](/core/guides/validate-a-phone-number/).
+The full query surface is available on that number, including the possibility check and the typed
+validation error; see [Validate a phone number](/core/guides/validate-a-phone-number/).
 
 ## The international field
 

--- a/apps/docs/src/content/docs/core/guides/validate-a-phone-number.mdx
+++ b/apps/docs/src/content/docs/core/guides/validate-a-phone-number.mdx
@@ -1,46 +1,38 @@
 ---
 title: Validate a phone number
-description: Tolerant feedback while the user types and an exact message on submit.
+description: The possibility check, the typed validation error, and the canonical form.
 ---
 
-The possibility checks stay tolerant while the user types. `getValidationError` names the exact
-fault on submit.
+`isValid` is the verdict. `isPossibleWithReason` weighs the calling code and the length while
+leaving the digits alone, which lets an incomplete number pass. `getValidationError` names the exact
+fault behind a failed `isValid`, carrying the numbers that describe it.
 
-## While the user types
+## Possibility
 
-Flag only the failures that more typing cannot fix. A calling code that does not exist and a number
-that is already too long qualify; a short number is still on its way.
+An unfinished number comes back `TOO_SHORT`. A number whose digits belong to no assigned range
+still comes back `IS_POSSIBLE`, because the check never reads them.
 
 ```ts
 import { parsePhoneNumber } from '@telixon/core';
 
-function feedbackWhileTyping(input: string): string | null {
-  const number = parsePhoneNumber(input, { defaultRegion: 'US' });
-  if (number.isValid()) return null;
-
-  switch (number.isPossibleWithReason()) {
-    case 'INVALID_CALLING_CODE':
-      return 'That country code does not exist.';
-    case 'TOO_LONG':
-      return 'This number has too many digits.';
-    default:
-      return null;
-  }
+function reason(input: string) {
+  return parsePhoneNumber(input, { defaultRegion: 'US' }).isPossibleWithReason();
 }
 
-feedbackWhileTyping('+1 415'); // null, still typing
-feedbackWhileTyping('+999 123'); // 'That country code does not exist.'
-feedbackWhileTyping('+1 21255512345678'); // 'This number has too many digits.'
+reason('+1 415'); // 'TOO_SHORT'
+reason('+999 123'); // 'INVALID_CALLING_CODE'
+reason('+1 21255512345678'); // 'TOO_LONG'
+reason('+1 999 555 0132'); // 'IS_POSSIBLE', while isValid() is false
 ```
 
 The six reason codes are under
 [`PossibilityResult`](/core/reference/phone-number/#possibilityresult).
 
-## On submit
+## Validation error
 
-Require [`isValid`](/core/reference/phone-number/#isvalid), then turn the failure into a message.
-The [carried payloads](/core/reference/validation-error/) let each message name the
-fix:
+[`getValidationError`](/core/reference/phone-number/#getvalidationerror) returns `null` for a valid
+number. Otherwise it returns one of nine kinds, each
+[carrying the numbers](/core/reference/validation-error/) behind the fault:
 
 ```ts
 import { parsePhoneNumber, type ValidationError } from '@telixon/core';
@@ -50,36 +42,39 @@ function describe(error: ValidationError): string {
     case 'EMPTY':
       return 'Enter a phone number.';
     case 'INVALID_CALLING_CODE':
-      return 'That country code does not exist.';
+      return 'No country uses this calling code.';
     case 'TOO_SHORT':
-      return `Too short. This number needs ${error.minLength} digits.`;
+      return `Too short. Use at least ${error.minLength} digits.`;
     case 'TOO_LONG':
-      return `Too long. This number takes at most ${error.maxLength} digits.`;
+      return `Too long. Use at most ${error.maxLength} digits.`;
     case 'INVALID_LENGTH':
       return `Wrong length. Valid lengths are ${error.possibleLengths.join(', ')}.`;
     case 'POSSIBLE_LOCAL_ONLY':
-      return 'That number only works when dialled locally.';
+      return 'Add the area code.';
     case 'PATTERN_MISMATCH':
-      return 'The length is right, but no number with these digits exists in this region.';
+      return 'This number does not exist in this region.';
     case 'NATIONAL_PREFIX_MISSING':
       return `Start the number with ${error.expectedPrefix}.`;
     case 'NATIONAL_PREFIX_PRESENT':
-      return `Drop the leading ${error.prefix}.`;
+      return `Remove the leading ${error.prefix}.`;
   }
 }
 
 const number = parsePhoneNumber('+1 415');
 if (!number.isValid()) {
-  describe(number.getValidationError()!); // 'Too short. This number needs 10 digits.'
+  describe(number.getValidationError()!); // 'Too short. Use at least 10 digits.'
 }
 ```
 
-To restrict validity to the form's own region at parse time, use
+The error answers for the value as it stands, which means a half-typed number reports `TOO_SHORT`
+the same way a finished wrong one does.
+
+To restrict validity to a single region at parse time, use
 [`strict`](/core/reference/parse-phone-number/#strict).
 
-## Store the number
+## Canonical form
 
-Store the canonical E.164 string. It parses back with no options:
+`formatE164` produces the canonical string. It parses back with no options:
 
 ```ts
 parsePhoneNumber('(415) 555-0132', { defaultRegion: 'US' }).formatE164(); // '+14155550132'

--- a/apps/docs/src/content/docs/core/index.mdx
+++ b/apps/docs/src/content/docs/core/index.mdx
@@ -100,9 +100,8 @@ lengths that exist.
 
 ## Drive an input
 
-An input controller is the
-[same engine](/core/how-it-works/#parser-and-controller-consistency) called once per keystroke. It
-takes the field's value and caret, then returns the next ones. The field formats from the first digit:
+An input controller takes the field's value and selection, then returns the formatted value and the
+caret to write back. Formatting starts at the first digit:
 
 ```ts
 import { createNationalInputController } from '@telixon/core';

--- a/apps/docs/src/content/docs/core/load-the-engine.mdx
+++ b/apps/docs/src/content/docs/core/load-the-engine.mdx
@@ -1,12 +1,10 @@
 ---
 title: Load the engine
-description: Load the engine with ensureEngineReady, or synchronously with ensureEngineReadySync.
+description: Explicit initialization with ensureEngineReady, or synchronously with ensureEngineReadySync.
 ---
 
-import size from '../../../generated/size.json';
-
-The engine is the compiled automaton that every query and controller reads. Importing the package
-does not load it.
+Every query and every controller runs on the engine. It ships in separate modules, outside the
+initial bundle. You load it wherever it fits your app's flow.
 
 ## ensureEngineReady
 
@@ -53,7 +51,7 @@ try {
 function isEngineReady(): boolean;
 ```
 
-Whether the engine is loaded. Branch on it to avoid an `EngineNotReadyError`.
+Whether the engine is loaded. It returns `false` where a query would throw `EngineNotReadyError`.
 
 ```ts
 import { isEngineReady } from '@telixon/core';
@@ -67,9 +65,9 @@ isEngineReady(); // false before ensureEngineReady() resolves
 function ensureEngineReadySync(): void;
 ```
 
-Initializes the engine synchronously, from tables embedded in the bundle. Those tables add about
-[{size.engineTables} gzipped](/verified/#size), a weight that lands only where this entry is
-imported.
+Initializes the engine synchronously, from tables embedded in the bundle. That weight lands only
+where this entry is imported; the [bundle report](https://proof.telixon.dev/bundle.html) measures
+it chunk by chunk.
 
 ```ts
 import { ensureEngineReadySync } from '@telixon/core/sync-init';
@@ -80,12 +78,12 @@ ensureEngineReadySync();
 parsePhoneNumber('+1 (415) 555-0132').isValid(); // true
 ```
 
-Reach for this only where you cannot await, such as a synchronous constructor, a module-level
-default, or a migration script.
+It covers the places that cannot await, such as a synchronous constructor, a module-level default,
+or a migration script.
 
 ## Runtime builds
 
-The package name is the same everywhere. The runtime picks the build behind `@telixon/core`.
+The runtime picks the build behind `@telixon/core`.
 
 | Runtime                  | Build resolved     |
 | ------------------------ | ------------------ |

--- a/apps/docs/src/content/docs/core/reference/input-controller.mdx
+++ b/apps/docs/src/content/docs/core/reference/input-controller.mdx
@@ -79,7 +79,7 @@ interface InputState {
 }
 ```
 
-The next value and caret to apply to the field. `value` is the formatted string; the selection
+The next value and selection to apply to the field. `value` is the formatted string; the selection
 indices point into it.
 
 `region` is the region the value resolves to, or `null` when none does. Within a shared calling
@@ -234,7 +234,7 @@ typed national (trunk) prefix there reports
 readonly currentState: InputState;
 ```
 
-The value and caret as they stand.
+The value and selection as they stand.
 
 ## Conformance
 

--- a/apps/docs/src/content/docs/core/reference/phone-number.mdx
+++ b/apps/docs/src/content/docs/core/reference/phone-number.mdx
@@ -70,14 +70,14 @@ parsePhoneNumber('+1 415').getValidationError(); // { kind: 'TOO_SHORT', minLeng
 The six reason codes `isPossibleWithReason` returns. Mirrors Google libphonenumber's
 `ValidationResult`.
 
-| Value                    | Meaning                                                        |
-| ------------------------ | -------------------------------------------------------------- |
-| `IS_POSSIBLE`            | The calling code resolves and the length is dialled nationally |
-| `IS_POSSIBLE_LOCAL_ONLY` | The length is dialled only inside its own area                 |
-| `INVALID_CALLING_CODE`   | The digits begin with no known calling code                    |
-| `TOO_SHORT`              | Fewer digits than the region's shortest number                 |
-| `TOO_LONG`               | More digits than the region's longest number                   |
-| `INVALID_LENGTH`         | The length falls in a gap between valid lengths                |
+| Value                    | Meaning                                                       |
+| ------------------------ | ------------------------------------------------------------- |
+| `IS_POSSIBLE`            | The calling code resolves and the length is dialed nationally |
+| `IS_POSSIBLE_LOCAL_ONLY` | The length is dialed only inside its own area                 |
+| `INVALID_CALLING_CODE`   | The digits begin with no known calling code                   |
+| `TOO_SHORT`              | Fewer digits than the region's shortest number                |
+| `TOO_LONG`               | More digits than the region's longest number                  |
+| `INVALID_LENGTH`         | The length falls in a gap between valid lengths               |
 
 ## Identity
 

--- a/apps/docs/src/content/docs/core/reference/validation-error.mdx
+++ b/apps/docs/src/content/docs/core/reference/validation-error.mdx
@@ -34,7 +34,7 @@ Every row is a real input and its real result.
 | `'+1 21'`                                                     | `{ kind: 'TOO_SHORT', minLength: 10 }`                     | Fewer digits than the region's shortest number                |
 | `'+1 21255512345678'`                                         | `{ kind: 'TOO_LONG', maxLength: 10 }`                      | More digits than the region's longest number                  |
 | `'+57 321 123 456'`                                           | `{ kind: 'INVALID_LENGTH', possibleLengths: [8, 10, 11] }` | The length falls in a gap between valid lengths               |
-| `'5550132'` with `defaultRegion: 'US'`                        | `{ kind: 'POSSIBLE_LOCAL_ONLY' }`                          | Valid only when dialled inside its own area                   |
+| `'5550132'` with `defaultRegion: 'US'`                        | `{ kind: 'POSSIBLE_LOCAL_ONLY' }`                          | Valid only when dialed inside its own area                    |
 | `'+1 1234567890'`                                             | `{ kind: 'PATTERN_MISMATCH' }`                             | The length is valid and the digits match no number            |
 | `'501234567'` with `defaultRegion: 'AE'`                      | `{ kind: 'NATIONAL_PREFIX_MISSING', expectedPrefix: '0' }` | A required national (trunk) prefix was missing                |
 | `'0501234567'` in an `AE` field with the calling code outside | `{ kind: 'NATIONAL_PREFIX_PRESENT', prefix: '0' }`         | The trunk prefix was typed where international input omits it |

--- a/apps/docs/src/content/docs/verified.mdx
+++ b/apps/docs/src/content/docs/verified.mdx
@@ -21,8 +21,9 @@ produce. Together they stand at 315,988 comparisons with zero divergences. `isVa
 set-compared per case, with 692,672 region checks in the case-coverage sweep alone. The allowlist
 of accepted divergences is empty.
 
-On top of the gate, every push runs a one-million-input parity sample. Weekly, the airtight proof
-enumerates the complete geographic input domain of 1,838,775,900 inputs, split across ten shards.
+On top of the gate, every push runs a one-million-input parity sample. Weekly, the
+[airtight proof](https://github.com/martsinlabs/telixon/actions/workflows/fuzz.yml) enumerates the
+complete geographic input domain of 1,838,775,900 inputs, split across ten shards.
 
 ```sh
 pnpm conformance
@@ -34,8 +35,8 @@ The [parity dashboard](https://proof.telixon.dev/parity.html) publishes every ru
 
 The benchmark measures parsing and query throughput, cold and warm, plus per-keystroke controller
 latency. The reference baseline is the google-libphonenumber npm package, a third-party wrapper
-of Google's port. Since wall-time numbers depend on hardware, this page quotes none.
-CodSpeed tracks instrumented regressions.
+of Google's port. Wall-time numbers depend on hardware. CodSpeed tracks the instrumented
+regressions.
 
 ```sh
 pnpm bench
@@ -45,17 +46,18 @@ The [benchmark dashboard](https://proof.telixon.dev/benchmark.html) publishes ea
 
 ## Size
 
-`size-limit` gates the entry sizes. The engine tables ship outside them, loaded on demand by the
-async builds and embedded by the sync entry. Their figure below is the gzip payload inside the
-embedded modules.
+`size-limit` gates the entry sizes.
 
-| Artifact                        | Measured                     | Budget                     |
-| ------------------------------- | ---------------------------- | -------------------------- |
-| `@telixon/core` Node entry      | {size.nodeEntry.measured}    | {size.nodeEntry.budget}    |
-| `@telixon/core` browser entry   | {size.browserEntry.measured} | {size.browserEntry.budget} |
-| `@telixon/web-sdk`              | {size.webSdk.measured}       | {size.webSdk.budget}       |
-| Engine tables, loaded on demand | {size.engineTables} gzip     | none                       |
+| Artifact                      | Measured                     | Budget                     |
+| ----------------------------- | ---------------------------- | -------------------------- |
+| `@telixon/core` Node entry    | {size.nodeEntry.measured}    | {size.nodeEntry.budget}    |
+| `@telixon/core` browser entry | {size.browserEntry.measured} | {size.browserEntry.budget} |
+| `@telixon/web-sdk`            | {size.webSdk.measured}       | {size.webSdk.budget}       |
 
 ```sh
 pnpm size
 ```
+
+The engine tables ship outside these entries, loaded on demand by the async builds and embedded by
+the sync entry. The [bundle report](https://proof.telixon.dev/bundle.html) measures them from a real
+production build, chunk by chunk.

--- a/apps/docs/src/content/docs/web-sdk/guides/complete-field.mdx
+++ b/apps/docs/src/content/docs/web-sdk/guides/complete-field.mdx
@@ -20,6 +20,10 @@ empty field's placeholder now a Canadian example. Type `6045550132` and the fiel
 `604-555-0132` with the status `Valid: +16045550132`. Reopen the picker and choose United States.
 `604` still belongs to Canada, which flips the flag straight back.
 
+Undo reaches the picker as well. Cmd/Ctrl+Z steps back through the digits, then through the region
+change itself, carrying the flag and the calling code with it. Cmd/Ctrl+Shift+Z replays the whole
+sequence.
+
 The keyboard works throughout. Search `united k` and press Enter, or walk the rows with the arrow
 keys. Select the United Kingdom and type `07400123456`. The leading zero is a trunk prefix with no
 place after `+44`. The status reads `NATIONAL_PREFIX_PRESENT`.

--- a/apps/docs/src/content/docs/web-sdk/phone-input.mdx
+++ b/apps/docs/src/content/docs/web-sdk/phone-input.mdx
@@ -4,7 +4,7 @@ description: The phone-number controller attached to a DOM input.
 ---
 
 A core [`InputController`](/core/reference/input-controller/) attached to a DOM `<input>`. It wires
-the field's events, writes each new value and caret back, and emits a
+the field's events, writes each new value and selection back, and emits a
 [`PhoneInputState`](#phoneinputstate) snapshot to subscribers. No emit fires at construction. The
 initial state goes straight to the DOM; read it with [`getState`](#getstate).
 

--- a/apps/docs/src/package-registry.ts
+++ b/apps/docs/src/package-registry.ts
@@ -68,8 +68,6 @@ export const PACKAGES: readonly DocsPackage[] = [
       },
     ],
   },
-  { name: '@telixon/web-anatomy', label: 'Web Anatomy' },
-  { name: '@telixon/web-theme', label: 'Web Theme' },
   { name: '@telixon/web-components', label: 'Web Components', logo: 'stencil' },
   { name: '@telixon/angular', label: 'Angular', logo: 'angular' },
   { name: '@telixon/react', label: 'React', logo: 'react' },

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -1762,18 +1762,6 @@ const closedTypesCode = `controller.setRegion('USA')
             <span class="desc">The DOM layer for the input controller. You bring your own markup.</span>
           </a>
           <div class="slab">
-            <span class="name">@telixon/web-anatomy</span>
-            <span class="chip chip-planned">Planned</span>
-            <span class="desc">
-              The styling contract for the web packages: stable class names, semantic tokens, and state attributes.
-            </span>
-          </div>
-          <div class="slab">
-            <span class="name">@telixon/web-theme</span>
-            <span class="chip chip-planned">Planned</span>
-            <span class="desc">A ready-made stylesheet implementing the web-anatomy contract.</span>
-          </div>
-          <div class="slab">
             <span class="name">@telixon/web-components</span>
             <span class="chip chip-planned">Planned</span>
             <span class="desc">A drop-in phone input as a standard web component.</span>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -20,39 +20,51 @@ import { ensureEngineReady, parsePhoneNumber } from '@telixon/core';
 await ensureEngineReady(); // load the engine once; the API is synchronous afterward
 
 const number = parsePhoneNumber('+12015550123');
+
 number.isValid(); // true
-number.getRegion(); // "US"
-number.formatE164(); // "+12015550123"
-number.formatInternational(); // "+1 201-555-0123"
+number.getRegion(); // 'US'
+number.formatE164(); // '+12015550123'
+number.formatInternational(); // '+1 201-555-0123'
 ```
 
-## Initialization
+Input controllers take the field's value and selection, then return the formatted value and the caret to write back:
 
-Initialization is explicit and asynchronous by default; an API call before it throws `EngineNotReadyError`. `await ensureEngineReady()` from `@telixon/core` loads the engine on demand (a dynamic import, code-split into ~119 KB of lazy chunks in the browser) and decodes it off the main thread. For synchronous initialization, `ensureEngineReadySync()` from `@telixon/core/sync-init` bundles the engine and decodes it in-process (native `node:zlib` in Node, pure-JS elsewhere); in global scope on edge it readies the engine once per isolate, outside per-request CPU accounting. Both entries share one process-wide engine, which decompresses to ~0.61 MB of binary tables.
+```ts
+import { createNationalInputController } from '@telixon/core';
 
-Full rationale and numbers: [Load the engine](https://telixon.dev/core/load-the-engine/). Measured bundle breakdown: [proof.telixon.dev/bundle.html](https://proof.telixon.dev/bundle.html).
+const controller = createNationalInputController({ defaultRegion: 'US' });
+
+controller.insert('', '4155550132', 0, 0);
+// { value: '(415) 555-0132', region: 'US', selectionStart: 14, selectionEnd: 14 }
+
+// Deleting the selected '5) 55' drops its digits and reflows what remains.
+controller.deleteBackward('(415) 555-0132', 3, 8);
+// { value: '(415) 013-2', region: 'US', selectionStart: 3, selectionEnd: 3 }
+```
+
+Full documentation is at [telixon.dev/core](https://telixon.dev/core/).
 
 ## Highlights
 
-- **Conformance-verified.** Every public query method matches Google libphonenumber at the pinned commit recorded in [PROVENANCE.json](https://github.com/martsinlabs/telixon/blob/main/packages/core/src/engine/PROVENANCE.json). The gate runs in CI on every push.
-- **Synchronous hot path.** Once the engine is ready, every public API call returns directly, with no Promise allocation. The input path runs on every keystroke.
-- **Deterministic finite-state engine.** Validation, number typing, region resolution, and format selection are linear-time walks over automata compiled from the metadata, not regex passes: backtracking-free.
-- **Engine out of the bundle, on your terms.** The metadata is compressed runtime data, never live JS objects in your bundle, and stays out of your initial bundle by default. You choose when to pay the one-time load cost (at startup, on entering a route with a phone field, or behind `requestIdleCallback`), so it never blocks a route transition or animation.
+- **Conformance-verified.** Every query method with a Google libphonenumber counterpart is compared
+  against it in CI, on every push.
+- **One deterministic finite automaton.** Google publishes its metadata as regular expressions;
+  Telixon compiles them ahead of time into one automaton. A single linear-time walk yields validity,
+  number type, region, and format.
+- **No third-party dependencies.** The package installs nothing beyond itself.
+- **Every JavaScript runtime.** Node.js, browsers, Deno, Bun, and edge, selected through package
+  export conditions.
 
-## What's in this package
+## Support
 
-- `parsePhoneNumber` and the `PhoneNumber` query view (`isValid`, `isPossible`, `getNumberType`, `getRegion`, `formatE164`, `formatNational`, `formatInternational`, `formatRfc3966`, and more).
-- `createInternationalInputController` and `createNationalInputController`: full per-keystroke input controllers (insert and delete at any position, caret tracking, undo/redo, and the complete query surface). The DOM-binding wrapper `createPhoneInput` lives in [`@telixon/web-sdk`](https://www.npmjs.com/package/@telixon/web-sdk).
-- Region and number-type helpers: `getCallingCodeForRegion`, `regionSupportsNumberTypes`, `getPlaceholders`, `isNationalPrefixOptional`.
-- `ensureEngineReady`, `isEngineReady`, and `ensureEngineReadySync` (from `@telixon/core/sync-init`): engine initialization and readiness.
+Questions belong in [Discussions](https://github.com/martsinlabs/telixon/discussions). Bugs and
+feature requests belong in [Issues](https://github.com/martsinlabs/telixon/issues). Vulnerabilities
+follow [SECURITY.md](https://github.com/martsinlabs/telixon/blob/main/SECURITY.md).
 
-## Project
+## Contributing
 
-Architecture, conformance methodology, benchmarks, and the project roadmap live at the [project README](https://github.com/martsinlabs/telixon).
-
-## Status
-
-Pre-release. APIs may change before 1.0.
+Setup, workflow, and the engineering standards are in
+[CONTRIBUTING.md](https://github.com/martsinlabs/telixon/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/packages/core/bench/README.md
+++ b/packages/core/bench/README.md
@@ -19,7 +19,7 @@ versions are resolved at runtime from `node_modules`, pinned in `package.json`.
 
 Built at startup from the [oracle](../oracle/) (Google libphonenumber source at the engine's pinned
 commit), filtered to the engine's supported regions, one example number per region per type. No
-on-disk snapshot, so the bench cannot drift from conformance.
+on-disk snapshot, which keeps the bench from drifting away from conformance.
 
 ## Scenarios
 

--- a/packages/core/conformance/README.md
+++ b/packages/core/conformance/README.md
@@ -16,14 +16,14 @@ Full report with sample mismatches:
 npx vitest run --config vitest.conformance.config.ts --disableConsoleIntercept
 ```
 
-Excluded from `pnpm test`, so the unit suite stays fast and offline.
+Excluded from `pnpm test`, which keeps the unit suite fast and offline.
 
 ## Version-matched oracle
 
 Google publishes no npm package. Its JS port lives as Closure-coupled source in the repo. The oracle
 fetches that source at the **same commit the engine was built from** (`src/engine/PROVENANCE.json`)
-and runs it on `google-closure-library`. Sources are cached under `.cache/<commit>/`, so only the
-first run needs network.
+and runs it on `google-closure-library`. Sources are cached under `.cache/<commit>/`, leaving only
+the first run in need of network.
 
 Because the oracle and the engine share one commit, there is **no metadata version drift**: any
 mismatch is a real engine difference, never a stale reference.
@@ -67,9 +67,8 @@ oracle and engine pinned to google/libphonenumber@<commit> · no metadata drift
 
 The header shows the shared commit, coverage, and the corpus composition by case kind (`skipped` =
 example or display-variant inputs the oracle could not parse; must be zero). One line per method:
-match rate and `(matched / total)`. Any mismatch prints an indented line: `expected` is Google,
-`actual` is Telixon. The prefix sweep prints its own block after the table. Live numbers are on the
-[dashboard](https://proof.telixon.dev/parity.html).
+match rate and `(matched / total)`. Any mismatch prints an indented line, where `expected` is
+Google and `actual` is Telixon. The prefix sweep prints its own block after the table.
 
 ## Gate
 
@@ -97,8 +96,8 @@ Two sweeps run in the gate:
 
 - **corpus**: every corpus case over its region cluster;
 - **case coverage**: one number per distinct engine case (lengths 1-15). `isValidForRegion` is a
-  pure function of the end state, the national length, and the region, so this sweep covers the
-  method's entire reachable domain.
+  pure function of the end state, the national length, and the region, which makes this sweep cover
+  the method's entire reachable domain.
 
 Inputs Google rejects at parse follow the rejection contract: Telixon must judge them valid for no
 candidate. Mismatches feed the same allowlist audit as every other axis.
@@ -108,8 +107,8 @@ candidate. Mismatches feed the same allowlist audit as every other axis.
 `measureAsYouType` (in `as-you-type.ts`) replays each corpus number one character at a time through
 both input controllers, international and national, and compares the live value at every keystroke
 against Google's `AsYouTypeFormatter`. The controllers and `formatInternational` / `formatNational`
-share one format selector, so a complete number renders identically; while typing, grouping is applied
-progressively. This is a measurement printed in the run, not a gate.
+share one format selector, which renders a complete number identically; while typing, grouping is
+applied progressively. The run prints this as a measurement; the gate ignores it.
 
 ## Baseline
 
@@ -128,10 +127,10 @@ parsed under identical conditions on both sides.
 | `display-variant` | international display, national display (parsed with the region), RFC3966 URI, padding                | both sides parse; all methods compared                                            |
 | `mutation`        | truncated (1-3 digits), extended (1-2 digits), first national digit shifted, unassigned calling codes | all methods compared; if Google rejects at parse, Telixon must judge not possible |
 
-The comparison is differential: a mutation that happens to stay valid is still a case, because both
-sides must agree on whatever the verdict is.
+The comparison is differential, which keeps a mutation that happens to stay valid as a case, because
+both sides must agree on whatever the verdict is.
 
-The prefix sweep is a fourth axis: every digit prefix of every example is parsed by both sides and
+The prefix sweep is a fourth axis, where every digit prefix of every example is parsed by both sides and
 `isPossibleWithReason` must match verbatim, prefix by prefix. This is the verdict surface the input
 controllers expose per keystroke.
 

--- a/packages/core/src/modules/input-controller/models/index.ts
+++ b/packages/core/src/modules/input-controller/models/index.ts
@@ -2,7 +2,7 @@ import { NumberType, RegionCode } from '@telixon/core/engine';
 import { NumberResolverSnapshot, NumberTypeProfileRef } from '../../number-resolver/models';
 import { PhoneNumber } from '../../phone-number/models';
 
-/** The next value and caret to apply to the field. Returned by every mutating {@link InputController} method. */
+/** The next value and selection to apply to the field. Returned by every mutating {@link InputController} method. */
 export interface InputState {
   /** The formatted string to place in the field. */
   readonly value: string;
@@ -61,6 +61,6 @@ export interface InputController {
   readonly canUndo: boolean;
   /** Whether there is history to {@link InputController.redo}. */
   readonly canRedo: boolean;
-  /** The value and caret as they stand, without mutating. */
+  /** The value and selection as they stand, without mutating. */
   readonly currentState: InputState;
 }

--- a/packages/core/src/modules/number-resolver/resolve-number.ts
+++ b/packages/core/src/modules/number-resolver/resolve-number.ts
@@ -104,7 +104,7 @@ export function resolveNumber(params: ResolveNumberInput): ResolvedNumberState {
     };
   }
 
-  // National-mode digits beginning with the region's IDD prefix are internationally dialled: strip the
+  // National-mode digits beginning with the region's IDD prefix are internationally dialed: strip the
   // prefix and parse the remainder as international (libphonenumber FROM_NUMBER_WITH_IDD).
   let iddRemainder: string | null = null;
   if (!hasLeadingPlus && defaultRegionIndex !== -1) {
@@ -114,7 +114,7 @@ export function resolveNumber(params: ResolveNumberInput): ResolvedNumberState {
 
   const readAsNational: boolean = !hasLeadingPlus && defaultRegionIndex !== -1 && iddRemainder === null;
 
-  // True once a redundant leading calling code is dropped: from then on the number behaves as if dialled
+  // True once a redundant leading calling code is dropped: from then on the number behaves as if dialed
   // through that calling code, so the strip below prefers its main region over the default region.
   let leadingCallingCodeStripped = false;
   if (readAsNational) {

--- a/packages/core/src/modules/parse-phone-number/__tests__/idd-prefix.test.ts
+++ b/packages/core/src/modules/parse-phone-number/__tests__/idd-prefix.test.ts
@@ -6,7 +6,7 @@ const GB_FIXED = getExampleNumber('GB', 'FIXED_LINE');
 
 describe('parsePhoneNumber: IDD prefix stripping (libphonenumber FROM_NUMBER_WITH_IDD)', () => {
   it('strips the region IDD prefix and parses the remainder as international', () => {
-    // Dialled from Germany (IDD "00") to a UK number: "00" + "44" + national.
+    // Dialed from Germany (IDD "00") to a UK number: "00" + "44" + national.
     const number = parsePhoneNumber('0044' + GB_FIXED, { defaultRegion: 'DE' });
 
     expect(number.getCallingCode()).toBe('44');

--- a/packages/core/src/modules/parse-phone-number/__tests__/leading-calling-code.test.ts
+++ b/packages/core/src/modules/parse-phone-number/__tests__/leading-calling-code.test.ts
@@ -3,7 +3,7 @@ import { parsePhoneNumber } from '..';
 
 describe('parsePhoneNumber: leading calling code (libphonenumber maybeExtractCountryCode FROM_NUMBER)', () => {
   it('drops a redundant leading calling code when the full number is too long', () => {
-    // RU national input dialled with its own calling code: "7" + "8001234567".
+    // RU national input dialed with its own calling code: "7" + "8001234567".
     const number = parsePhoneNumber('78001234567', { defaultRegion: 'RU' });
 
     expect(number.getRegion()).toBe('RU');

--- a/packages/core/src/modules/phone-number/models/index.ts
+++ b/packages/core/src/modules/phone-number/models/index.ts
@@ -29,7 +29,7 @@ export type ValidationError =
   | { readonly kind: 'TOO_LONG'; readonly maxLength: number }
   /** The length falls in a gap between valid lengths. `possibleLengths` lists the lengths that exist. */
   | { readonly kind: 'INVALID_LENGTH'; readonly possibleLengths: readonly number[] }
-  /** Valid only when dialled inside its own area. */
+  /** Valid only when dialed inside its own area. */
   | { readonly kind: 'POSSIBLE_LOCAL_ONLY' }
   /** The length is valid but the digits match no number that exists in the region. */
   | { readonly kind: 'PATTERN_MISMATCH' }
@@ -70,7 +70,7 @@ export interface PhoneNumber {
   isPossibleWithReason(): PossibilityResult;
   /** The fault to correct, or `null` when none applies. One of nine typed variants. */
   getValidationError(): ValidationError | null;
-  /** The line type, such as `MOBILE` or `FIXED_LINE`. `UNKNOWN` when the number is not valid or the type is ambiguous. */
+  /** The line type, such as `MOBILE` or `FIXED_LINE`. `UNKNOWN` means the number is not valid. */
   getNumberType(): NumberType;
   /** The national significant number: digits only, with the national prefix stripped. */
   getNationalNumber(): string;

--- a/packages/web-sdk/README.md
+++ b/packages/web-sdk/README.md
@@ -1,6 +1,6 @@
 # @telixon/web-sdk
 
-Headless DOM adapter for [`@telixon/core`](https://www.npmjs.com/package/@telixon/core): `PhoneInput` and `RegionList` state machines for the web.
+Headless DOM adapter for [`@telixon/core`](https://www.npmjs.com/package/@telixon/core), shipping the `PhoneInput` and `RegionList` state machines for the web.
 
 [![conformance](https://img.shields.io/endpoint?url=https://proof.telixon.dev/parity-badge.json)](https://proof.telixon.dev/parity.html)
 
@@ -12,45 +12,64 @@ npm install @telixon/core @telixon/web-sdk
 
 ## Quick start
 
+`createPhoneInput` turns a plain `<input>` into a phone field, handling the events, the caret, and the history:
+
 ```ts
 import { ensureEngineReady } from '@telixon/core';
 import { createPhoneInput } from '@telixon/web-sdk';
 
-// Load the engine before creating an input: createPhoneInput reads metadata and needs it ready.
-await ensureEngineReady();
+await ensureEngineReady(); // once per process; createPhoneInput throws until it resolves
 
 const phone = createPhoneInput({
-  input: document.querySelector<HTMLInputElement>('#phone')!,
   mode: 'international',
+  input: document.querySelector<HTMLInputElement>('#phone')!,
 });
 
 phone.subscribe((state) => {
-  // state.value, state.region, state.selectionStart, state.selectionEnd, state.validationError, state.placeholder
+  // After typing +442071838750:
+  // state.value            '44 20 7183 8750'
+  // state.region           'GB'
+  // state.validationError  null
 });
 ```
 
+`createRegionList` feeds a region picker, with search, sorting, and pinned rows already applied:
+
+```ts
+import { createRegionList, regionToFlagEmoji } from '@telixon/web-sdk';
+
+const regions = createRegionList({
+  prioritize: ['US', 'CA', 'GB'],
+  dataFactory: ({ region }) => regionToFlagEmoji(region),
+});
+
+regions.getState().options[0];
+// { region: 'US', callingCode: '1', displayName: 'United States', data: '🇺🇸' }
+
+regions.search('united');
+regions.getState().options.map((option) => option.region); // ['US', 'GB', 'AE']
+```
+
+Full documentation is at [telixon.dev/web-sdk](https://telixon.dev/web-sdk/).
+
 ## Highlights
 
-- **Full input controller.** Live formatting on every keystroke with a stable caret, including mid-string edits, deletions, and paste, not just appended digits.
-- **Controlled history.** Undo and redo restore the exact prior value and caret position.
-- **Headless.** No styles, no rendering. Bind to any framework or to a plain `<input>`.
-- **Framework-agnostic.** Works in React, Vue, Angular, Svelte, or vanilla JS.
+- **Full input controller.** Live formatting on every keystroke with a stable caret, across
+  mid-string edits, deletions, and paste.
+- **Controlled history.** Undo and redo restore the exact prior value and selection.
+- **Headless.** No styles, no rendering. Binds a plain `<input>` in React, Vue, Angular, Svelte, or
+  vanilla JS.
 
-## What's in this package
+## Support
 
-- `createPhoneInput`: DOM-bound phone input controller (live formatting with a stable caret, history, validation surface).
-- `createRegionList`: headless region list state machine (search, filtering, localization).
-- `regionToFlagEmoji`: region code to its flag emoji (the pair of Unicode regional indicator symbols).
+Questions belong in [Discussions](https://github.com/martsinlabs/telixon/discussions). Bugs and
+feature requests belong in [Issues](https://github.com/martsinlabs/telixon/issues). Vulnerabilities
+follow [SECURITY.md](https://github.com/martsinlabs/telixon/blob/main/SECURITY.md).
 
-Engine, parser, and formatter live in [`@telixon/core`](https://www.npmjs.com/package/@telixon/core).
+## Contributing
 
-## Project
-
-Architecture, conformance methodology, benchmarks, and the project roadmap live at the [project README](https://github.com/martsinlabs/telixon).
-
-## Status
-
-Pre-release. APIs may change before 1.0.
+Setup, workflow, and the engineering standards are in
+[CONTRIBUTING.md](https://github.com/martsinlabs/telixon/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/packages/web-sdk/src/modules/phone-input/phone-input.ts
+++ b/packages/web-sdk/src/modules/phone-input/phone-input.ts
@@ -28,7 +28,7 @@ function assertInputIsAvailable(input: HTMLInputElement): void {
  * Attach a headless phone input controller to a DOM `<input>` element.
  *
  * Wires DOM events (`beforeinput`, `compositionend`, undo/redo keyboard shortcuts) to a Telixon
- * input controller and synchronizes the input value, caret, and resolved phone metadata.
+ * input controller and synchronizes the input value, selection, and resolved phone metadata.
  *
  * Throws if the element is not `type="text"` or `type="tel"`, if another PhoneInput is already
  * attached to the same element, or if the engine is not ready (`EngineNotReadyError`). Call

--- a/packages/web-sdk/src/modules/region-list/models/index.ts
+++ b/packages/web-sdk/src/modules/region-list/models/index.ts
@@ -7,7 +7,7 @@ import type { NumberType, RegionCode } from '@telixon/core';
  * - `callingCode`: numeric calling code as string (e.g. `'1'`).
  * - `displayName`: region name from `Intl.DisplayNames` for the active locale; falls back to the
  *   ISO region code when the runtime can't produce a localized name. The exact string depends on the
- *   runtime's ICU data, so it is not byte-stable across environments (Node/browser/ICU versions).
+ *   runtime's ICU data, which leaves it byte-unstable across environments (Node/browser/ICU versions).
  * - `data`: caller-defined payload produced by {@link RegionDataFactory}; `undefined` when no factory.
  */
 export type RegionOption<T = undefined> = {
@@ -37,14 +37,14 @@ export type RegionDataFactory<T = undefined> = (input: RegionDataFactoryInput) =
 /**
  * Custom search predicate. Returns `true` to include `option` in the filtered result.
  *
- * The library short-circuits empty and whitespace-only queries and does not invoke this function.
- * The function receives the raw `query`; perform any normalization needed internally.
+ * Empty and whitespace-only queries short-circuit without calling this function. The `query` arrives
+ * raw; normalize it inside the predicate when needed.
  */
 export type RegionSearchFn<T = undefined> = (query: string, option: RegionOption<T>) => boolean;
 
 /**
  * Sort selector. Built-in comparators collate `displayName` in the list's `locale` and break ties by
- * region code, so they are total orders (stable run to run). Because `displayName` comes from
+ * region code, which makes them total orders (stable run to run). Because `displayName` comes from
  * `Intl.DisplayNames` and collation uses the runtime's ICU, the resulting order is locale/ICU dependent
  * and not guaranteed identical across environments.
  *
@@ -97,9 +97,9 @@ export type RegionListListener<T = undefined> = (state: RegionListState<T>) => v
  * Headless region list controller. Produces a reactive, filtered, sorted, searched, localized list
  * of region options for pickers, dropdowns, and selector UIs.
  *
- * The naming distinction is intentional: action verbs (`search`, `localize`) name user-driven
- * interactions; `set*` names declarative config mutations. No initial emit is fired on
- * construction. Call `getState()` after `subscribe` to read the bootstrap value.
+ * Action verbs (`search`, `localize`) name user-driven interactions; `set*` names declarative config
+ * mutations. No initial emit is fired on construction. Call `getState()` after `subscribe` to read
+ * the bootstrap value.
  */
 export type RegionList<T = undefined> = {
   /** Subscribe to state changes. Returns an unsubscribe function. */

--- a/packages/web-sdk/src/modules/region-list/utils/region-to-flag-emoji.ts
+++ b/packages/web-sdk/src/modules/region-list/utils/region-to-flag-emoji.ts
@@ -4,14 +4,15 @@ const REGIONAL_INDICATOR_BASE: number = 0x1f1e6; // U+1F1E6 REGIONAL INDICATOR S
 const LETTER_A: number = 65; // 'A'.charCodeAt(0)
 
 /**
- * Convert an ISO region code to its flag emoji: the two Unicode regional indicator symbols for its
- * letters. `regionToFlagEmoji('US')` returns the United States flag (U+1F1FA U+1F1F8).
+ * Convert an ISO region code to its flag emoji, built from the two Unicode regional indicator
+ * symbols for its letters. `regionToFlagEmoji('US')` returns the United States flag
+ * (U+1F1FA U+1F1F8).
  *
- * Rendering is the platform's choice: systems with flag-emoji support (iOS, macOS, Android, most
+ * Rendering belongs to the platform. Systems with flag-emoji support (iOS, macOS, Android, most
  * Linux) show a flag; systems without it (notably Windows) show the two letters. For a flag on every
- * platform, render an SVG set keyed by the region code instead.
+ * platform, render an SVG set keyed by the region code.
  *
- * Every {@link RegionCode} is two ASCII letters, so the result is always a valid regional indicator
+ * Every {@link RegionCode} is two ASCII letters, which keeps the result a valid regional indicator
  * pair.
  */
 export function regionToFlagEmoji(region: RegionCode): string {


### PR DESCRIPTION
## Summary

A wording and structure sweep across the docs site, the three readmes, the top-level docs, and the JSDoc in both packages. The web-anatomy and web-theme listings leave the landing page and the package registry; SECURITY.md states the 1.x support policy. Runtime behavior is untouched; in the two touched test files only descriptions are reworded, assertions stay as they are.

## Motivation

Docs state only verified behavior. The sweep settles one controller contract everywhere (takes the field's value and selection, returns the formatted value and the caret to write back), rebuilds the validation guide around the possibility check, the typed error, and the canonical form, corrects the getNumberType UNKNOWN wording, unifies American spelling, and links the weekly fuzz run from the Verified page.

## Conformance impact

None. Prose, JSDoc, and comments only; no engine or query-method behavior is touched.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention