### PR TITLE
perf(core): fold extension-suspect detection into the resolution walk

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -109,14 +109,14 @@ accessors shaped `(engine, state, ...)`, which makes the engine a Moore machine,
 output is a function of the state it reaches. One linear-time walk per resolution is what keeps
 per-keystroke work cheap. The automaton is global and unified, matching one
 number against every region at once, with no per-region data to load. The per-keystroke controller
-path runs no regular expression at all. Five survive elsewhere, each compiled once and anchored.
-Two are prefix transforms built from the metadata: the per-territory national-prefix rewrite (a
-bounded capture-group transform) and the IDD strip that removes a dialed international prefix
-before the digits are resolved. Three belong to `parsePhoneNumber` and port libphonenumber's
-extension handling at the pinned commit: the end-anchored extension-suffix capture, the
-viable-number guard that protects it, and the single-class gate that keeps both off inputs made of
-digits and plain punctuation. The engine ships as four embedded modules carrying nine binary
-layers:
+path and the ordinary parse run no regular expression at all; extension-suspect detection rides
+the resolution walk itself, on the branch digits never take. Four survive, each compiled once and
+anchored. Two are prefix transforms built from the metadata: the per-territory national-prefix
+rewrite (a bounded capture-group transform) and the IDD strip that removes a dialed international
+prefix before the digits are resolved. Two port libphonenumber's extension handling at the pinned
+commit and run only when an input's raw string carries a character plain phone input never
+contains: the end-anchored extension-suffix capture and the viable-number guard that protects it.
+The engine ships as four embedded modules carrying nine binary layers:
 
 ```
 walk.bin.js      recognition DFA state graph, calling-code dispatch, region disambiguation

--- a/packages/core/src/modules/number-resolver/resolve-number.ts
+++ b/packages/core/src/modules/number-resolver/resolve-number.ts
@@ -45,6 +45,43 @@ function collectDigits(input: string): string {
   return digits;
 }
 
+interface CollectedDigits {
+  readonly digits: string;
+  readonly extensionSuspect: boolean;
+}
+
+// collectDigits with suspect detection fused into the same pass: a character beyond digits, '+',
+// common format punctuation, and whitespace controls means parsePhoneNumber must run the ported
+// extension machinery. The digit branch pays nothing; walkInputDetectingExtensionSuspect inlines the same checks.
+function collectDigitsDetectingExtensionSuspect(input: string): CollectedDigits {
+  let digits = '';
+  let extensionSuspect = false;
+  for (let index = 0; index < input.length; index++) {
+    const charCode: number = input.charCodeAt(index);
+    if (charCode >= 0x30 && charCode <= 0x39) {
+      digits += input[index];
+      continue;
+    }
+    if (extensionSuspect) continue;
+    if (
+      charCode === 0x20 ||
+      charCode === 0x2b ||
+      charCode === 0x2d ||
+      charCode === 0x28 ||
+      charCode === 0x29 ||
+      charCode === 0x2e ||
+      charCode === 0x2f ||
+      charCode === 0x2a ||
+      charCode === 0x3a ||
+      (charCode >= 0x09 && charCode <= 0x0d)
+    ) {
+      continue;
+    }
+    extensionSuspect = true;
+  }
+  return { digits, extensionSuspect };
+}
+
 // libphonenumber maybeStripInternationalPrefixAndNormalize: strip a leading IDD prefix and re-parse the
 // remainder. Not an IDD when the next digit is '0', the national trunk digit.
 function stripIddPrefix(digits: string, matcher: RegExp): string | null {
@@ -62,6 +99,37 @@ function walkInput(resolver: NumberResolver, input: string): void {
   }
 }
 
+// walkInput with suspect detection fused into the same pass; the digit branch pays nothing and
+// the checks stay inline so the advance call keeps its inlining.
+// Only parsePhoneNumber's first raw read takes this variant.
+function walkInputDetectingExtensionSuspect(resolver: NumberResolver, input: string): boolean {
+  let extensionSuspect = false;
+  for (let index = 0; index < input.length; index++) {
+    const charCode: number = input.charCodeAt(index);
+    if (charCode >= 0x30 && charCode <= 0x39) {
+      resolver.advance(charCode - 48);
+      continue;
+    }
+    if (extensionSuspect) continue;
+    if (
+      charCode === 0x20 ||
+      charCode === 0x2b ||
+      charCode === 0x2d ||
+      charCode === 0x28 ||
+      charCode === 0x29 ||
+      charCode === 0x2e ||
+      charCode === 0x2f ||
+      charCode === 0x2a ||
+      charCode === 0x3a ||
+      (charCode >= 0x09 && charCode <= 0x0d)
+    ) {
+      continue;
+    }
+    extensionSuspect = true;
+  }
+  return extensionSuspect;
+}
+
 export interface ResolveNumberInput {
   // Raw string; whitespace, '+', and formatting characters are ignored.
   readonly input: string;
@@ -73,6 +141,8 @@ export interface ResolveNumberInput {
   readonly regionFilter: BinaryFilter | null;
   readonly numberTypeFilter: BinaryFilter | null;
   readonly strict: boolean;
+  // parsePhoneNumber only: detect extension-suspect characters during the first raw read.
+  readonly detectExtensionSuspect?: boolean;
 }
 
 export interface ResolvedNumberState {
@@ -82,16 +152,31 @@ export interface ResolvedNumberState {
   readonly readAsNational: boolean;
   // The seeded literal read above; the national-prefix-present check applies only then.
   readonly callingCodeSeeded: boolean;
+  // Set only under `detectExtensionSuspect`: the raw input carries a character the extension machinery must inspect.
+  readonly extensionSuspect: boolean;
 }
 
 export function resolveNumber(params: ResolveNumberInput): ResolvedNumberState {
-  const { input, hasLeadingPlus, seedCallingCode, defaultRegionIndex, regionFilter, numberTypeFilter, strict } = params;
+  const {
+    input,
+    hasLeadingPlus,
+    seedCallingCode,
+    defaultRegionIndex,
+    regionFilter,
+    numberTypeFilter,
+    strict,
+    detectExtensionSuspect = false,
+  } = params;
   const resourceProvider = getResourceProvider();
 
   const resolver: NumberResolver = cachedResolver ?? (cachedResolver = new NumberResolver());
   resolver.setRegionFilter(regionFilter);
   resolver.setNumberTypeFilter(numberTypeFilter);
   resolver.setStrict(strict);
+
+  // Suspect detection rides the first read over the raw string; every later walk is over digits.
+  let extensionSuspect = false;
+  let rawReadDone = false;
 
   if (seedCallingCode !== null) {
     resolver.setCallingCode(seedCallingCode);
@@ -101,15 +186,27 @@ export function resolveNumber(params: ResolveNumberInput): ResolvedNumberState {
       nationalPrefixPresent: false,
       readAsNational: false,
       callingCodeSeeded: true,
+      extensionSuspect: false,
     };
   }
 
   // National-mode digits beginning with the region's IDD prefix are internationally dialed: strip the
   // prefix and parse the remainder as international (libphonenumber FROM_NUMBER_WITH_IDD).
   let iddRemainder: string | null = null;
+  let rawDigits: string | null = null;
   if (!hasLeadingPlus && defaultRegionIndex !== -1) {
     const matcher: RegExp | null = getIddMatcher(defaultRegionIndex);
-    if (matcher !== null) iddRemainder = stripIddPrefix(collectDigits(input), matcher);
+    if (matcher !== null) {
+      if (detectExtensionSuspect) {
+        const collected: CollectedDigits = collectDigitsDetectingExtensionSuspect(input);
+        extensionSuspect = collected.extensionSuspect;
+        rawReadDone = true;
+        rawDigits = collected.digits;
+      } else {
+        rawDigits = collectDigits(input);
+      }
+      iddRemainder = stripIddPrefix(rawDigits, matcher);
+    }
   }
 
   const readAsNational: boolean = !hasLeadingPlus && defaultRegionIndex !== -1 && iddRemainder === null;
@@ -120,7 +217,12 @@ export function resolveNumber(params: ResolveNumberInput): ResolvedNumberState {
   if (readAsNational) {
     const callingCode: string = String(getMetadataRegionCallingCode(resourceProvider.engine, defaultRegionIndex));
     resolver.setCallingCode(callingCode);
-    walkInput(resolver, input);
+    if (detectExtensionSuspect && !rawReadDone) {
+      extensionSuspect = walkInputDetectingExtensionSuspect(resolver, input);
+    } else {
+      // The digits collected for the IDD check walk directly; the raw string is never rescanned.
+      walkInput(resolver, rawDigits ?? input);
+    }
 
     // National digits that redundantly begin with the region's own calling code: drop it and re-walk.
     // The national-prefix strip still runs below, matching libphonenumber's second pass in parseHelper.
@@ -137,7 +239,12 @@ export function resolveNumber(params: ResolveNumberInput): ResolvedNumberState {
     }
   } else {
     resolver.reset();
-    walkInput(resolver, iddRemainder !== null ? iddRemainder : input);
+    const walkTarget: string = iddRemainder !== null ? iddRemainder : input;
+    if (detectExtensionSuspect && !rawReadDone) {
+      extensionSuspect = walkInputDetectingExtensionSuspect(resolver, walkTarget);
+    } else {
+      walkInput(resolver, walkTarget);
+    }
   }
 
   // Strip the national prefix against the default region - but once a leading calling code is extracted
@@ -164,5 +271,11 @@ export function resolveNumber(params: ResolveNumberInput): ResolvedNumberState {
     walkInput(resolver, stripped);
   }
 
-  return { snapshot: resolver.snapshot, nationalPrefixPresent, readAsNational, callingCodeSeeded: false };
+  return {
+    snapshot: resolver.snapshot,
+    nationalPrefixPresent,
+    readAsNational,
+    callingCodeSeeded: false,
+    extensionSuspect,
+  };
 }

--- a/packages/core/src/modules/parse-phone-number/parse-phone-number.ts
+++ b/packages/core/src/modules/parse-phone-number/parse-phone-number.ts
@@ -6,41 +6,14 @@ import { ParsePhoneNumberOptions } from './models';
 import { extractPossibleNumber } from './utils/extract-possible-number';
 import { stripExtension } from './utils/strip-extension';
 
-// Any character beyond digits, `+`, and plain number punctuation calls for the full
-// extract-and-strip treatment; a single native class test keeps the gate off the JS per-character
-// path. The slow path resolves identically and may only do extra trimming work.
-const NON_PLAIN_INPUT_PATTERN = /[^0-9+\-(). /*:\t-\r]/;
-
-// The index of the first plus or digit, or -1. ASCII checks suffice; the gate above routes any
-// other character to the slow path.
+// The index of the first plus or digit, or -1. ASCII checks match the resolver, which reads ASCII
+// digits only.
 function firstPlusOrDigitIndex(input: string): number {
   for (let index = 0; index < input.length; index++) {
     const code: number = input.charCodeAt(index);
     if ((code >= 0x30 && code <= 0x39) || code === 0x2b) return index;
   }
   return -1;
-}
-
-interface PreparedInput {
-  readonly base: string;
-  readonly extension: string | null;
-  readonly hasLeadingPlus: boolean;
-}
-
-// Both branches read the leading plus off the first plus or digit, the position libphonenumber's
-// extractPossibleNumber would cut to.
-function prepareInput(input: string): PreparedInput {
-  if (NON_PLAIN_INPUT_PATTERN.test(input)) {
-    const { base, extension } = stripExtension(extractPossibleNumber(input));
-    return { base, extension, hasLeadingPlus: base.charCodeAt(0) === 0x2b };
-  }
-
-  const startIndex: number = firstPlusOrDigitIndex(input);
-  return {
-    base: input,
-    extension: null,
-    hasLeadingPlus: startIndex !== -1 && input.charCodeAt(startIndex) === 0x2b,
-  };
 }
 
 /**
@@ -55,26 +28,50 @@ function prepareInput(input: string): PreparedInput {
  * parsePhoneNumber('+1 (415) 555-0132').formatE164(); // '+14155550132'
  * parsePhoneNumber('(415) 555-0132', { defaultRegion: 'US' }).isValid(); // true
  */
-// Trims to the candidate number, splits off a trailing extension, detects the leading-plus flag,
-// then defers to the shared resolveNumber pipeline (which ignores non-digits).
+// One resolution pass detects extension-suspect characters as it walks; only an input carrying one
+// takes the ported extract-and-strip machinery and a second resolution over the cleaned base.
 export function parsePhoneNumber(input: string, options: ParsePhoneNumberOptions = {}): PhoneNumber {
   requireEngineReady();
 
   const resourceProvider = getResourceProvider();
   const defaultRegionIndex: number =
     options.defaultRegion !== undefined ? (resourceProvider.regionKeyToIndex[options.defaultRegion] ?? -1) : -1;
+  const strict: boolean = options.strict ?? false;
 
-  const { base, extension, hasLeadingPlus } = prepareInput(input);
-
+  const startIndex: number = firstPlusOrDigitIndex(input);
+  const hasLeadingPlus: boolean = startIndex !== -1 && input.charCodeAt(startIndex) === 0x2b;
   const resolved: ResolvedNumberState = resolveNumber({
-    input: base,
+    input,
     hasLeadingPlus,
     seedCallingCode: null,
     defaultRegionIndex,
     regionFilter: null,
     numberTypeFilter: null,
-    strict: options.strict ?? false,
+    strict,
+    detectExtensionSuspect: true,
   });
+  if (!resolved.extensionSuspect) {
+    return createPhoneNumber(toResolvedPhoneNumber(resolved, defaultRegionIndex, null));
+  }
 
-  return createPhoneNumber(toResolvedPhoneNumber(resolved, defaultRegionIndex, extension));
+  const extracted = extractPossibleNumber(input);
+  const { base, extension } = stripExtension(extracted.candidate);
+
+  // The first resolution stands when the trims dropped no digit and the read mode is unchanged:
+  // the walk ignores non-digits, so the cleaned base resolves to the same state.
+  const baseHasLeadingPlus: boolean = base.charCodeAt(0) === 0x2b;
+  if (extension === null && !extracted.secondNumberCut && baseHasLeadingPlus === hasLeadingPlus) {
+    return createPhoneNumber(toResolvedPhoneNumber(resolved, defaultRegionIndex, null));
+  }
+
+  const rebased: ResolvedNumberState = resolveNumber({
+    input: base,
+    hasLeadingPlus: baseHasLeadingPlus,
+    seedCallingCode: null,
+    defaultRegionIndex,
+    regionFilter: null,
+    numberTypeFilter: null,
+    strict,
+  });
+  return createPhoneNumber(toResolvedPhoneNumber(rebased, defaultRegionIndex, extension));
 }

--- a/packages/core/src/modules/parse-phone-number/utils/extract-possible-number.ts
+++ b/packages/core/src/modules/parse-phone-number/utils/extract-possible-number.ts
@@ -42,17 +42,26 @@ function findSecondNumberStart(input: string): number {
 
 /**
  * Trims `input` to the candidate phone number, mirroring libphonenumber's extractPossibleNumber.
- * Returns the empty string when no plus sign or digit starts a candidate.
+ * The candidate is the empty string when no plus sign or digit starts one. `secondNumberCut`
+ * reports the one trim that can drop digits; every other trim removes non-digits only.
  */
-export function extractPossibleNumber(input: string): string {
+export interface ExtractedCandidate {
+  readonly candidate: string;
+  readonly secondNumberCut: boolean;
+}
+
+export function extractPossibleNumber(input: string): ExtractedCandidate {
   let start = 0;
   while (start < input.length && !isPlusOrDigit(input.charCodeAt(start))) start++;
-  if (start === input.length) return '';
+  if (start === input.length) return { candidate: '', secondNumberCut: false };
 
   let end: number = input.length;
   while (end > start && !isWantedEndChar(input.charCodeAt(end - 1))) end--;
 
   const candidate: string = input.slice(start, end);
   const secondNumberStart: number = findSecondNumberStart(candidate);
-  return secondNumberStart >= 0 ? candidate.slice(0, secondNumberStart) : candidate;
+  if (secondNumberStart >= 0) {
+    return { candidate: candidate.slice(0, secondNumberStart), secondNumberCut: true };
+  }
+  return { candidate, secondNumberCut: false };
 }


### PR DESCRIPTION
## Summary

Extension-suspect detection now rides the resolution walk instead of a standalone gate scan: an
ordinary input takes one pass and no regular expression, and redundant re-resolutions on tel: and
national inputs are gone. Controllers are untouched.

## Motivation

The gate scanned every input before resolution; fusing the check removes that cost from the
ordinary path.

## Conformance impact

Parse routing only. The corpus and a 298,848-comparison notation sweep against the version-matched
oracle report zero divergences; `pnpm conformance` passes locally.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention