### PR TITLE
docs(web-sdk): classify PhoneInput and RegionList as headless widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ a divergence the gate misses?
 | Package                                          | Status  | Role                                  |
 | ------------------------------------------------ | ------- | ------------------------------------- |
 | [`@telixon/core`](packages/core/README.md)       | shipped | parsing, formatting, validation       |
-| [`@telixon/web-sdk`](packages/web-sdk/README.md) | shipped | headless DOM input controller         |
+| [`@telixon/web-sdk`](packages/web-sdk/README.md) | shipped | headless phone-field widgets          |
 | `@telixon/web-components`                        | planned | drop-in Web Component (`<tel-input>`) |
 | `@telixon/angular`                               | planned | Angular binding                       |
 | `@telixon/react`                                 | planned | React binding (hook + component)      |

--- a/apps/docs/src/content/docs/web-sdk/guides/complete-field.mdx
+++ b/apps/docs/src/content/docs/web-sdk/guides/complete-field.mdx
@@ -47,7 +47,7 @@ The search box doubles as the keyboard cursor, where the arrow keys walk the row
 `aria-activedescendant` and Enter picks the active one. Escape closes the popup and hands focus
 back to the region button, while an outside press or focus moving out of the widget closes it too.
 
-Inside a framework component, call each machine's [`destroy`](/web-sdk/phone-input/#destroy) on
+Inside a framework component, call each one's [`destroy`](/web-sdk/phone-input/#destroy) on
 unmount and remove the document-level press listener with them.
 
 <Tabs syncKey="source">
@@ -66,4 +66,4 @@ unmount and remove the document-level press listener with them.
 
 </Tabs>
 
-The two machines never learn about each other. All the wiring lives in the demo's own functions.
+`PhoneInput` and `RegionList` never learn about each other. All the wiring lives in the demo's own functions.

--- a/apps/docs/src/content/docs/web-sdk/guides/phone-field.mdx
+++ b/apps/docs/src/content/docs/web-sdk/guides/phone-field.mdx
@@ -50,6 +50,6 @@ renders only while the value carries one. `renderStatus` draws the status from e
 
 </Tabs>
 
-[Covered events](/web-sdk/phone-input/#covered-events) lists every input type the machine already
+[Covered events](/web-sdk/phone-input/#covered-events) lists every input type `PhoneInput` already
 handles, IME composition and drag-and-drop included. The field is one half of the classic widget.
 [Build a region picker](/web-sdk/guides/region-picker/) is the other half.

--- a/apps/docs/src/content/docs/web-sdk/index.mdx
+++ b/apps/docs/src/content/docs/web-sdk/index.mdx
@@ -5,8 +5,8 @@ description: Install @telixon/web-sdk and bind a phone input and a region list t
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-`@telixon/web-sdk` is the DOM adapter for [`@telixon/core`](/core/). It ships two headless state
-machines for the web, where [`PhoneInput`](/web-sdk/phone-input/) drives a real `<input>` and
+`@telixon/web-sdk` is the DOM adapter for [`@telixon/core`](/core/). It ships two
+headless widgets: [`PhoneInput`](/web-sdk/phone-input/) drives a real `<input>`, and
 [`RegionList`](/web-sdk/region-list/) feeds region pickers.
 
 ## Install
@@ -59,7 +59,7 @@ Your code imports both packages, since the engine loads through `@telixon/core` 
 
 ## Load the engine
 
-Creating either machine before the engine is [loaded](/core/load-the-engine/) throws
+Creating `PhoneInput` or `RegionList` before the engine is [loaded](/core/load-the-engine/) throws
 `EngineNotReadyError`:
 
 ```ts

--- a/apps/docs/src/content/docs/web-sdk/phone-input.mdx
+++ b/apps/docs/src/content/docs/web-sdk/phone-input.mdx
@@ -1,6 +1,6 @@
 ---
 title: PhoneInput
-description: The phone-number controller attached to a DOM input.
+description: The headless widget driving a phone input.
 ---
 
 A core [`InputController`](/core/reference/input-controller/) attached to a DOM `<input>`. It wires

--- a/apps/docs/src/content/docs/web-sdk/region-list.mdx
+++ b/apps/docs/src/content/docs/web-sdk/region-list.mdx
@@ -1,9 +1,9 @@
 ---
 title: RegionList
-description: The headless state machine behind region pickers.
+description: The headless widget behind region pickers.
 ---
 
-A headless state machine for region pickers. It produces the option rows a dropdown renders and
+The headless widget behind a region picker. It produces the option rows a dropdown renders and
 emits a [`RegionListState`](#regionliststate) snapshot on every change. Each change recomputes the
 options through one pipeline of region filter, number-type filter, search, sort, and prioritized
 pins. No emit fires at construction; read the bootstrap with [`getState`](#getstate).

--- a/packages/web-sdk/README.md
+++ b/packages/web-sdk/README.md
@@ -1,6 +1,6 @@
 # @telixon/web-sdk
 
-Headless DOM adapter for [`@telixon/core`](https://www.npmjs.com/package/@telixon/core), shipping the `PhoneInput` and `RegionList` state machines for the web.
+The DOM adapter for [`@telixon/core`](https://www.npmjs.com/package/@telixon/core), shipping two headless widgets: `PhoneInput` drives a plain `<input>`, `RegionList` feeds the region picker.
 
 [![conformance](https://img.shields.io/endpoint?url=https://proof.telixon.dev/parity-badge.json)](https://proof.telixon.dev/parity.html)
 

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@telixon/web-sdk",
   "version": "0.1.0",
-  "description": "Headless DOM adapter for @telixon/core: PhoneInput and RegionList state machines for the web.",
+  "description": "DOM adapter for @telixon/core: two headless widgets, PhoneInput driving a plain <input> and RegionList feeding region pickers.",
   "keywords": [
     "phone-input",
     "phone-number",

--- a/packages/web-sdk/src/modules/phone-input/phone-input.ts
+++ b/packages/web-sdk/src/modules/phone-input/phone-input.ts
@@ -25,7 +25,7 @@ function assertInputIsAvailable(input: HTMLInputElement): void {
 }
 
 /**
- * Attach a headless phone input controller to a DOM `<input>` element.
+ * Attach the headless phone-field widget to a DOM `<input>` element.
  *
  * Wires DOM events (`beforeinput`, `compositionend`, undo/redo keyboard shortcuts) to a Telixon
  * input controller and synchronizes the input value, selection, and resolved phone metadata.

--- a/packages/web-sdk/src/modules/region-list/region-list.ts
+++ b/packages/web-sdk/src/modules/region-list/region-list.ts
@@ -18,7 +18,7 @@ import { resolveRegionListComparator } from './utils/sort';
 const DEFAULT_LOCALE: string = 'en';
 
 /**
- * Create a headless region list controller.
+ * Create the headless widget behind a region picker.
  *
  * Pipeline on every state change: base set (cached per locale) -> regionFilter -> numberTypeFilter
  * -> searchFn -> sort -> prioritize -> emit. Mutators that don't change the underlying value skip


### PR DESCRIPTION
## Summary

`PhoneInput` and `RegionList` are classified as headless widgets across the npm description, both
readmes, the web-sdk docs, and the factory JSDoc. The vocabulary ladder stays reserved: automaton
for the engine, controller for the core input surface, Web Component for the planned `<tel-input>`.

## Motivation

The previous label, state machines, belongs to the engine and the resolver; the widgets carry
state and behavior without rendering.

## Conformance impact

None.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention