### PR TITLE
feat(core): add graded phone number matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ examples/core/bundle-size/report
 packages/core/oracle/.cache
 .DS_Store
 .claude/settings.local.json
+.idea

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -2,12 +2,12 @@
   {
     "name": "@telixon/core (Node entry)",
     "path": "packages/core/dist/index.node.js",
-    "limit": "23 kB"
+    "limit": "24 kB"
   },
   {
     "name": "@telixon/core (browser entry)",
     "path": "packages/core/dist/index.browser.js",
-    "limit": "26 kB"
+    "limit": "27 kB"
   },
   {
     "name": "@telixon/web-sdk",

--- a/apps/docs/src/content/docs/core/reference/match-phone-numbers.mdx
+++ b/apps/docs/src/content/docs/core/reference/match-phone-numbers.mdx
@@ -1,0 +1,56 @@
+---
+title: matchPhoneNumbers
+description: Grades whether two inputs denote the same phone number.
+---
+
+```ts
+function matchPhoneNumbers(first: string | PhoneNumber, second: string | PhoneNumber): PhoneNumberMatch;
+```
+
+Grades whether two inputs denote the same phone number. It accepts raw strings and parsed
+[`PhoneNumber`](/core/reference/phone-number/) values in any combination; a string parses on the
+spot. Mirrors Google libphonenumber's `isNumberMatch`.
+
+```ts
+matchPhoneNumbers('+14155550132', '+1 (415) 555-0132'); // 'EXACT_MATCH'
+matchPhoneNumbers('415 555 0132', '+1 415 555 0132'); // 'NSN_MATCH'
+```
+
+## PhoneNumberMatch
+
+```ts
+type PhoneNumberMatch = 'EXACT_MATCH' | 'NSN_MATCH' | 'SHORT_NSN_MATCH' | 'NO_MATCH' | 'NOT_A_NUMBER';
+```
+
+| Value             | Meaning                                                                  |
+| ----------------- | ------------------------------------------------------------------------ |
+| `EXACT_MATCH`     | The calling code, the national number, and the extension all agree       |
+| `NSN_MATCH`       | The national numbers agree while at least one side names no calling code |
+| `SHORT_NSN_MATCH` | One national number is a shorter variant of the other                    |
+| `NO_MATCH`        | Both sides read as numbers and they differ                               |
+| `NOT_A_NUMBER`    | No number could be read from one of the inputs                           |
+
+A difference only in a leading zero or in one side carrying an extension also grades as
+`SHORT_NSN_MATCH`; two different explicit extensions never match.
+
+```ts
+matchPhoneNumbers('555 0132', '+1 415 555 0132'); // 'SHORT_NSN_MATCH'
+matchPhoneNumbers('+1 415 555 0132 ext. 22', '+1 415 555 0132'); // 'SHORT_NSN_MATCH'
+matchPhoneNumbers('+1 415 555 0132 ext. 22', '+1 415 555 0132 ext. 23'); // 'NO_MATCH'
+matchPhoneNumbers('abc', '+14155550132'); // 'NOT_A_NUMBER'
+```
+
+## Reading strings
+
+A string with an explicit `+` reads as international. Without one it reads as national digits;
+when the other side carries a calling code, that code's main region parses the digits, and the
+grade caps at `NSN_MATCH`, since the string never named the calling code itself.
+
+```ts
+matchPhoneNumbers('020 7183 8750', '+44 20 7183 8750'); // 'NSN_MATCH'
+```
+
+## Conformance
+
+Every grade is compared with Google libphonenumber's `isNumberMatch` over deterministic pairs
+derived from its example numbers, as part of [the gate](/verified/#conformance).

--- a/apps/docs/src/content/docs/verified.mdx
+++ b/apps/docs/src/content/docs/verified.mdx
@@ -19,7 +19,8 @@ The gate runs two sweeps. The full corpus compares the thirteen methods on 14,35
 across all 245 regions, extension spellings included, while case coverage compares one number from
 every distinct case the library can produce. Together they stand at 367,766 comparisons with zero
 divergences. `isValidForRegion` is set-compared per case, with 692,513 region checks in the
-case-coverage sweep alone. The allowlist of accepted divergences is empty.
+case-coverage sweep alone. A 9,050-pair sweep grades [`matchPhoneNumbers`](/core/reference/match-phone-numbers/) against
+Google's isNumberMatch alongside them. The allowlist of accepted divergences is empty.
 
 On top of the gate, every push runs a one-million-input parity sample. Weekly, the
 [airtight proof](https://github.com/martsinlabs/telixon/actions/workflows/fuzz.yml) enumerates the

--- a/apps/docs/src/generated/size.json
+++ b/apps/docs/src/generated/size.json
@@ -1,13 +1,13 @@
 {
   "nodeEntry": {
     "artifact": "@telixon/core (Node entry)",
-    "measured": "22.34 kB brotli",
-    "budget": "23 kB"
+    "measured": "23.41 kB brotli",
+    "budget": "24 kB"
   },
   "browserEntry": {
     "artifact": "@telixon/core (browser entry)",
-    "measured": "24.91 kB brotli",
-    "budget": "26 kB"
+    "measured": "26.03 kB brotli",
+    "budget": "27 kB"
   },
   "webSdk": {
     "artifact": "@telixon/web-sdk",

--- a/apps/docs/src/package-registry.ts
+++ b/apps/docs/src/package-registry.ts
@@ -44,6 +44,7 @@ export const PACKAGES: readonly DocsPackage[] = [
         items: [
           'core/reference/parse-phone-number',
           'core/reference/phone-number',
+          'core/reference/match-phone-numbers',
           'core/reference/validation-error',
           'core/reference/input-controller',
           'core/reference/region-data',

--- a/packages/core/conformance/conformance.test.ts
+++ b/packages/core/conformance/conformance.test.ts
@@ -8,6 +8,7 @@ import { buildConformanceReport } from './compare';
 import { buildConformanceCorpus, CorpusCaseKind } from './corpus';
 import { geographicDomain } from './enumeration-domain';
 import { auditMismatches } from './known-divergences';
+import { sweepNumberMatch } from './number-match';
 import { sweepPossibilityPrefixes } from './prefix-sweep';
 import { formatConformanceReport, formatPrefixSweepReport, formatValidForRegionReport } from './report';
 import { evaluateWithTelixon } from './subject';
@@ -38,6 +39,7 @@ const audit = auditMismatches([
   ...validForRegion.mismatches,
   ...validForRegionCases.mismatches,
 ]);
+const numberMatch = sweepNumberMatch(oracle, examples);
 const aytInternational = measureAsYouType(oracle, examples, internationalProbe);
 const aytNational = measureAsYouType(oracle, examples, nationalProbe);
 
@@ -77,6 +79,11 @@ describe('conformance vs Google libphonenumber', () => {
   it('exercises every corpus case kind', () => {
     const populatedKinds = report.composition.filter(({ cases }) => cases > 0).map(({ kind }) => kind);
     expect([...populatedKinds].sort()).toEqual([...EXPECTED_KINDS].sort());
+  });
+
+  it('grades number pairs the way the oracle does', () => {
+    expect(numberMatch.compared).toBeGreaterThan(5000);
+    expect(numberMatch.mismatches).toEqual([]);
   });
 
   it('compares real extension values on both sides, never undefined', () => {

--- a/packages/core/conformance/number-match.ts
+++ b/packages/core/conformance/number-match.ts
@@ -1,0 +1,44 @@
+import { matchPhoneNumbers } from '@telixon/core';
+import { CorpusEntry, Oracle } from '../oracle';
+
+export interface NumberMatchSweep {
+  readonly compared: number;
+  readonly mismatches: readonly string[];
+}
+
+// Grades deterministic pairs over every Google example against the oracle's isNumberMatch:
+// identity across notations, national against international, suffixes, extension presence and
+// conflict, cross-example pairs, and length-bounds junk.
+export function sweepNumberMatch(oracle: Oracle, examples: readonly CorpusEntry[]): NumberMatchSweep {
+  let compared = 0;
+  const mismatches: string[] = [];
+
+  const check = (first: string, second: string): void => {
+    const expected: string = oracle.matchNumbers(first, second);
+    const actual: string = matchPhoneNumbers(first, second);
+    compared += 1;
+    if (actual !== expected && mismatches.length < 25) {
+      mismatches.push(`${JSON.stringify(first)} vs ${JSON.stringify(second)} telixon=${actual} google=${expected}`);
+    }
+  };
+
+  let previousE164: string | null = null;
+  for (const example of examples) {
+    const rendered = oracle.evaluate(example.e164);
+    if (!rendered?.formatInternational || !rendered.formatNational) continue;
+    const { e164 } = example;
+
+    check(e164, rendered.formatInternational);
+    check(rendered.formatNational, e164);
+    check(e164, `${e164} ext. 22`);
+    check(`${e164} ext. 22`, `${rendered.formatInternational} x22`);
+    check(`${e164} ext. 22`, `${e164} ext. 23`);
+    check(rendered.formatNational, rendered.formatInternational);
+    const nationalNumber: string = rendered.getNationalNumber;
+    if (nationalNumber.length > 4) check(nationalNumber.slice(-4), e164);
+    if (previousE164 !== null) check(e164, previousE164);
+    previousE164 = e164;
+  }
+
+  return { compared, mismatches };
+}

--- a/packages/core/oracle/load-oracle.ts
+++ b/packages/core/oracle/load-oracle.ts
@@ -53,6 +53,7 @@ interface OracleUtil {
   getSupportedRegions(): string[];
   getExampleNumberForType(regionCode: string, typeId: number): OracleNumber | null;
   parse(value: string, region: string | undefined): OracleNumber;
+  isNumberMatch(first: string, second: string): number;
   format(number: OracleNumber, format: number): string;
   getNationalSignificantNumber(number: OracleNumber): string;
   getRegionCodeForNumber(number: OracleNumber): string | null | undefined;
@@ -73,6 +74,13 @@ interface PhoneNumbersNamespace {
   PhoneNumberUtil: {
     getInstance(): OracleUtil;
     ValidationResult: Record<string, number>;
+    MatchType: {
+      NOT_A_NUMBER: number;
+      NO_MATCH: number;
+      SHORT_NSN_MATCH: number;
+      NSN_MATCH: number;
+      EXACT_MATCH: number;
+    };
   };
   PhoneNumberType: Record<NumberType | 'UNKNOWN', number>;
   PhoneNumberFormat: Record<'E164' | 'INTERNATIONAL' | 'NATIONAL' | 'RFC3966', number>;
@@ -151,6 +159,13 @@ export async function loadOracle(): Promise<Oracle> {
 
   const numberTypeName = buildNumberTypeNames(ph.PhoneNumberType);
   const validationResultName = buildValidationResultNames(ph.PhoneNumberUtil);
+  const matchTypeName: Record<number, string> = {
+    [ph.PhoneNumberUtil.MatchType.NOT_A_NUMBER]: 'NOT_A_NUMBER',
+    [ph.PhoneNumberUtil.MatchType.NO_MATCH]: 'NO_MATCH',
+    [ph.PhoneNumberUtil.MatchType.SHORT_NSN_MATCH]: 'SHORT_NSN_MATCH',
+    [ph.PhoneNumberUtil.MatchType.NSN_MATCH]: 'NSN_MATCH',
+    [ph.PhoneNumberUtil.MatchType.EXACT_MATCH]: 'EXACT_MATCH',
+  };
   const sampledTypes: readonly SampledType[] = SAMPLED_TYPE_NAMES.map((name) => ({
     name,
     id: ph.PhoneNumberType[name],
@@ -173,6 +188,10 @@ export async function loadOracle(): Promise<Oracle> {
       } catch {
         return null;
       }
+    },
+    matchNumbers: (first, second) => {
+      const matchId: number = util.isNumberMatch(first, second);
+      return matchTypeName[matchId] ?? String(matchId);
     },
     evaluate: (input, regionCode) => {
       let parsed: OracleNumber;

--- a/packages/core/oracle/types.ts
+++ b/packages/core/oracle/types.ts
@@ -38,6 +38,8 @@ export interface Oracle {
   sampleExampleE164(regionCode: string, typeId: number): string | null;
   // The oracle's verdict for every compared method, or null when Google rejects the input; `regionCode` reads national form (no '+'), like Telixon's defaultRegion.
   evaluate(input: string, regionCode?: string): MethodResults | null;
+  // Google isNumberMatch over two raw strings, as the MatchType name.
+  matchNumbers(first: string, second: string): string;
   // Google's country calling code for a region, as a string ('0' for an unknown region).
   countryCallingCode(regionCode: string): string;
   // The subset of `candidates` Google judges the number valid for (isValidNumberForRegion), joined

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,8 @@ export { createNationalInputController } from './modules/input-controller/nation
 export type { NationalInputControllerConfig } from './modules/input-controller/national-input-controller';
 
 export { getCallingCodeForRegion } from './modules/calling-code-for-region';
+export { matchPhoneNumbers } from './modules/match-phone-numbers';
+export type { PhoneNumberMatch } from './modules/match-phone-numbers';
 export { getPlaceholders, isNationalPrefixOptional } from './modules/placeholders';
 export type { Placeholders } from './modules/placeholders';
 export { regionSupportsNumberTypes } from './modules/region-number-types';

--- a/packages/core/src/modules/match-phone-numbers/__tests__/match-phone-numbers.test.ts
+++ b/packages/core/src/modules/match-phone-numbers/__tests__/match-phone-numbers.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { matchPhoneNumbers } from '..';
+import { parsePhoneNumber } from '../../parse-phone-number';
+
+describe('matchPhoneNumbers (libphonenumber isNumberMatch)', () => {
+  it('grades identical numbers in different notations as an exact match', () => {
+    expect(matchPhoneNumbers('+14155550132', '+1 (415) 555-0132')).toBe('EXACT_MATCH');
+    expect(matchPhoneNumbers('tel:+1-415-555-0132;ext=22', '+1 415 555 0132 x22')).toBe('EXACT_MATCH');
+  });
+
+  it('caps the grade at NSN_MATCH when one side names no calling code', () => {
+    expect(matchPhoneNumbers('415 555 0132', '+1 415 555 0132')).toBe('NSN_MATCH');
+    expect(matchPhoneNumbers('+44 20 7183 8750', '020 7183 8750')).toBe('NSN_MATCH');
+    expect(matchPhoneNumbers('415-555-0132', '415.555.0132')).toBe('NSN_MATCH');
+  });
+
+  it('grades a shorter variant of the same number as SHORT_NSN_MATCH', () => {
+    expect(matchPhoneNumbers('555 0132', '+1 415 555 0132')).toBe('SHORT_NSN_MATCH');
+  });
+
+  it('grades a difference only in a leading zero or an extension presence as SHORT_NSN_MATCH', () => {
+    expect(matchPhoneNumbers('+39 06 69812345', '+39 6 69812345')).toBe('SHORT_NSN_MATCH');
+    expect(matchPhoneNumbers('+1 415 555 0132 ext. 22', '+1 415 555 0132')).toBe('SHORT_NSN_MATCH');
+  });
+
+  it('never matches two different explicit extensions', () => {
+    expect(matchPhoneNumbers('+1 415 555 0132 ext. 22', '+1 415 555 0132 ext. 23')).toBe('NO_MATCH');
+  });
+
+  it('grades different numbers as NO_MATCH', () => {
+    expect(matchPhoneNumbers('+14155550132', '+14155550133')).toBe('NO_MATCH');
+  });
+
+  it('reports NOT_A_NUMBER for input no number can be read from', () => {
+    expect(matchPhoneNumbers('abc', '+14155550132')).toBe('NOT_A_NUMBER');
+    expect(matchPhoneNumbers('+1', '+14155550132')).toBe('NOT_A_NUMBER');
+    expect(matchPhoneNumbers('+999 123', '+14155550132')).toBe('NOT_A_NUMBER');
+  });
+
+  it('accepts parsed values on either side', () => {
+    const parsed = parsePhoneNumber('+14155550132');
+
+    expect(matchPhoneNumbers(parsed, '+1 (415) 555-0132')).toBe('EXACT_MATCH');
+    expect(matchPhoneNumbers('415 555 0132', parsed)).toBe('NSN_MATCH');
+    expect(matchPhoneNumbers(parsed, parsePhoneNumber('+14155550133'))).toBe('NO_MATCH');
+  });
+});

--- a/packages/core/src/modules/match-phone-numbers/index.ts
+++ b/packages/core/src/modules/match-phone-numbers/index.ts
@@ -1,0 +1,2 @@
+export { matchPhoneNumbers } from './match-phone-numbers';
+export type { PhoneNumberMatch } from './models';

--- a/packages/core/src/modules/match-phone-numbers/match-phone-numbers.ts
+++ b/packages/core/src/modules/match-phone-numbers/match-phone-numbers.ts
@@ -1,0 +1,206 @@
+import { REGION_CODES, RegionCode } from '@telixon/core/engine';
+import { requireEngineReady } from '@telixon/core/utils/require-engine-ready';
+import { resolveNumber } from '../number-resolver/resolve-number';
+import { resolvePrimaryRegionIndex } from '../number-resolver/utils/resolve-primary-region-index';
+import { parsePhoneNumber } from '../parse-phone-number';
+import { extractPossibleNumber } from '../parse-phone-number/utils/extract-possible-number';
+import { stripExtension } from '../parse-phone-number/utils/strip-extension';
+import { PhoneNumber } from '../phone-number';
+import { PhoneNumberMatch } from './models';
+
+// Port of libphonenumber's isNumberMatch. The compared core fields: the calling code, the
+// national number split into leading zeros and the numeric remainder, and the extension.
+interface ComparableNumber {
+  readonly callingCode: string;
+  readonly numericNationalNumber: string;
+  readonly leadingZeros: number;
+  readonly extension: string;
+}
+
+// libphonenumber MIN_LENGTH_FOR_NSN_ and MAX_LENGTH_FOR_NSN_: parse rejects a national number
+// outside these bounds, and the match ladder reports such input as NOT_A_NUMBER.
+const MIN_NATIONAL_NUMBER_LENGTH = 2;
+const MAX_NATIONAL_NUMBER_LENGTH = 17;
+
+function nationalNumberLengthOutOfBounds(digits: string): boolean {
+  return digits.length < MIN_NATIONAL_NUMBER_LENGTH || digits.length > MAX_NATIONAL_NUMBER_LENGTH;
+}
+
+function collectAsciiDigits(input: string): string {
+  let digits = '';
+  for (let index = 0; index < input.length; index++) {
+    const charCode: number = input.charCodeAt(index);
+    if (charCode >= 0x30 && charCode <= 0x39) digits += input[index];
+  }
+  return digits;
+}
+
+// The national number the way libphonenumber stores it: a leading-zero count, capped so at least
+// one digit remains, and the numeric remainder.
+function splitLeadingZeros(nationalDigits: string): { numeric: string; zeros: number } {
+  let zeros = 0;
+  while (zeros < nationalDigits.length - 1 && nationalDigits.charCodeAt(zeros) === 0x30) zeros++;
+  return { numeric: nationalDigits.slice(zeros), zeros };
+}
+
+function toComparable(number: PhoneNumber): ComparableNumber {
+  const { numeric, zeros } = splitLeadingZeros(number.getNationalNumber());
+  return {
+    callingCode: number.getCallingCode() ?? '',
+    numericNationalNumber: numeric,
+    leadingZeros: zeros,
+    extension: number.getExtension() ?? '',
+  };
+}
+
+// The read libphonenumber's parseHelper does with no region: digits and extension only, with no
+// calling code and no prefix stripping.
+function toComparableWithoutCallingCode(base: string, extension: string | null): ComparableNumber {
+  const { numeric, zeros } = splitLeadingZeros(collectAsciiDigits(base));
+  return { callingCode: '', numericNationalNumber: numeric, leadingZeros: zeros, extension: extension ?? '' };
+}
+
+// The fields shared by both grades: the national number split and the extension.
+function nationalFieldsEqual(first: ComparableNumber, second: ComparableNumber): boolean {
+  return (
+    first.numericNationalNumber === second.numericNationalNumber &&
+    first.leadingZeros === second.leadingZeros &&
+    first.extension === second.extension
+  );
+}
+
+function coreFieldsEqual(first: ComparableNumber, second: ComparableNumber): boolean {
+  return first.callingCode === second.callingCode && nationalFieldsEqual(first, second);
+}
+
+// True when one numeric national number is the suffix of the other, equality included.
+function isNationalNumberSuffixOfTheOther(first: ComparableNumber, second: ComparableNumber): boolean {
+  return (
+    first.numericNationalNumber.endsWith(second.numericNationalNumber) ||
+    second.numericNationalNumber.endsWith(first.numericNationalNumber)
+  );
+}
+
+function compareResolved(first: ComparableNumber, second: ComparableNumber): PhoneNumberMatch {
+  // Two different explicit extensions never match.
+  if (first.extension.length > 0 && second.extension.length > 0 && first.extension !== second.extension) {
+    return 'NO_MATCH';
+  }
+
+  if (first.callingCode !== '' && second.callingCode !== '') {
+    if (coreFieldsEqual(first, second)) return 'EXACT_MATCH';
+    if (first.callingCode === second.callingCode && isNationalNumberSuffixOfTheOther(first, second)) {
+      return 'SHORT_NSN_MATCH';
+    }
+    return 'NO_MATCH';
+  }
+
+  // At least one side carries no calling code; the calling codes drop out of the comparison.
+  if (nationalFieldsEqual(first, second)) return 'NSN_MATCH';
+  if (isNationalNumberSuffixOfTheOther(first, second)) return 'SHORT_NSN_MATCH';
+  return 'NO_MATCH';
+}
+
+interface StringRead {
+  readonly comparable: ComparableNumber | null;
+  // The string carried an explicit plus and its calling code resolved.
+  readonly internationalRead: boolean;
+}
+
+// Reads a string the way libphonenumber's match ladder parses it under the unknown region: an
+// explicit plus reads as international, anything else as national digits with no calling code.
+// `null` means no number could be read.
+function readString(input: string): StringRead {
+  const { base, extension } = stripExtension(extractPossibleNumber(input).candidate);
+
+  const firstCode: number = base.charCodeAt(0);
+  if (firstCode !== 0x2b && firstCode !== 0xff0b) {
+    // Without a calling code the whole read is the national number; the bounds apply to it directly.
+    if (nationalNumberLengthOutOfBounds(collectAsciiDigits(base))) {
+      return { comparable: null, internationalRead: false };
+    }
+    return { comparable: toComparableWithoutCallingCode(base, extension), internationalRead: false };
+  }
+
+  const parsed: PhoneNumber = parsePhoneNumber(input);
+  if (parsed.getCallingCode() === null || parsed.isPossibleWithReason() === 'INVALID_CALLING_CODE') {
+    return { comparable: null, internationalRead: false };
+  }
+  if (nationalNumberLengthOutOfBounds(parsed.getNationalNumber())) {
+    return { comparable: null, internationalRead: false };
+  }
+  return { comparable: toComparable(parsed), internationalRead: true };
+}
+
+// The main region of a calling code (libphonenumber getRegionCodeForCountryCode), or null.
+function mainRegionForCallingCode(callingCode: string): RegionCode | null {
+  if (callingCode === '') return null;
+  const resolved = resolveNumber({
+    input: `+${callingCode}`,
+    hasLeadingPlus: true,
+    seedCallingCode: null,
+    defaultRegionIndex: -1,
+    regionFilter: null,
+    numberTypeFilter: null,
+    strict: false,
+  });
+  const regionIndex: number = resolvePrimaryRegionIndex(resolved.snapshot.callingCodeState, -1);
+  return regionIndex >= 0 ? (REGION_CODES[regionIndex] ?? null) : null;
+}
+
+// A national string against a side with a calling code: the string parses again under that calling
+// code's main region, and an exact agreement demotes to NSN_MATCH, since the string never named
+// the calling code itself.
+function matchNationalStringAgainstResolved(nationalInput: string, resolved: ComparableNumber): PhoneNumberMatch {
+  const region: RegionCode | null = mainRegionForCallingCode(resolved.callingCode);
+  if (region === null) {
+    const { base, extension } = stripExtension(extractPossibleNumber(nationalInput).candidate);
+    return compareResolved(toComparableWithoutCallingCode(base, extension), resolved);
+  }
+
+  const reparsedNumber: PhoneNumber = parsePhoneNumber(nationalInput, { defaultRegion: region });
+  if (nationalNumberLengthOutOfBounds(reparsedNumber.getNationalNumber())) return 'NOT_A_NUMBER';
+  const match: PhoneNumberMatch = compareResolved(toComparable(reparsedNumber), resolved);
+  return match === 'EXACT_MATCH' ? 'NSN_MATCH' : match;
+}
+
+/**
+ * Grades whether two inputs denote the same phone number, mirroring libphonenumber's
+ * isNumberMatch. Accepts raw strings and parsed {@link PhoneNumber} values in any combination. A
+ * string without an explicit `+` reads as national digits; when the other side carries a calling
+ * code, its main region parses them, capping the grade at `NSN_MATCH`.
+ *
+ * @example
+ * matchPhoneNumbers('+1 415 555 0132', '+1 (415) 555-0132'); // 'EXACT_MATCH'
+ * matchPhoneNumbers('415 555 0132', '+1 415 555 0132'); // 'NSN_MATCH'
+ */
+export function matchPhoneNumbers(first: string | PhoneNumber, second: string | PhoneNumber): PhoneNumberMatch {
+  requireEngineReady();
+
+  if (typeof first === 'string' && typeof second === 'string') {
+    const firstRead: StringRead = readString(first);
+    if (firstRead.comparable === null) return 'NOT_A_NUMBER';
+    const secondRead: StringRead = readString(second);
+    if (secondRead.comparable === null) return 'NOT_A_NUMBER';
+
+    if (firstRead.internationalRead && !secondRead.internationalRead) {
+      return matchNationalStringAgainstResolved(second, firstRead.comparable);
+    }
+    if (!firstRead.internationalRead && secondRead.internationalRead) {
+      return matchNationalStringAgainstResolved(first, secondRead.comparable);
+    }
+    return compareResolved(firstRead.comparable, secondRead.comparable);
+  }
+
+  if (typeof second === 'string') return matchPhoneNumbers(second, first);
+
+  if (typeof first === 'string') {
+    const read: StringRead = readString(first);
+    if (read.comparable === null) return 'NOT_A_NUMBER';
+    const secondComparable: ComparableNumber = toComparable(second);
+    if (!read.internationalRead) return matchNationalStringAgainstResolved(first, secondComparable);
+    return compareResolved(read.comparable, secondComparable);
+  }
+
+  return compareResolved(toComparable(first), toComparable(second));
+}

--- a/packages/core/src/modules/match-phone-numbers/models/index.ts
+++ b/packages/core/src/modules/match-phone-numbers/models/index.ts
@@ -1,0 +1,8 @@
+/**
+ * The confidence grade for two inputs denoting the same number. Mirrors libphonenumber's
+ * MatchType: `EXACT_MATCH` needs the calling code, the national number, and the extension to
+ * agree; `NSN_MATCH` lacks a calling code on at least one side; `SHORT_NSN_MATCH` covers one
+ * national number being a shorter variant of the other, or a difference only in a leading zero or
+ * an extension's presence; `NOT_A_NUMBER` reports an input no number could be read from.
+ */
+export type PhoneNumberMatch = 'EXACT_MATCH' | 'NSN_MATCH' | 'SHORT_NSN_MATCH' | 'NO_MATCH' | 'NOT_A_NUMBER';


### PR DESCRIPTION
Closes #63

## Summary

`matchPhoneNumbers` grades whether two inputs denote the same number, with the five
`PhoneNumberMatch` values of Google libphonenumber's isNumberMatch. Strings and parsed
`PhoneNumber` values combine freely.

## Motivation

Deduplication and caller-ID matching need a graded comparison; string equality fails on national
forms and shorter variants.

## Conformance impact

No engine or query-method behavior is touched. A 9,050-pair sweep grades the method against the
oracle's isNumberMatch inside the gate, with zero divergences.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention(Edited)