### PR TITLE
feat: stamp the bundle size into published manifests and refresh the …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,36 @@ makes the pull request title the commit subject on `main`.
 
 Telixon has a single maintainer who reviews and merges.
 
+## Releasing
+
+Packages release independently. A release is a changelog cut, a version bump, a tag, and an
+automated publish from CI. `main` is protected; everything except the tag lands through a pull
+request.
+
+1. Open a release pull request for the package.
+   - Move the `Unreleased` section of `packages/<package>/CHANGELOG.md` under the new version with
+     the release date; retarget the comparison links.
+   - The changelog decides the bump. Entries under `Removed`, or breaking entries under `Changed`,
+     make it major; `Added` makes it minor; `Fixed` alone makes it patch.
+   - Set `version` in `packages/<package>/package.json` and refresh the lockfile with
+     `pnpm install`.
+2. Merge the pull request, then pull `main`.
+3. Tag the merge commit as `<package>@v<version>` and push the tag:
+
+   ```sh
+   git tag core@v1.0.0 && git push origin core@v1.0.0
+   ```
+
+4. The tag triggers `.github/workflows/release-<package>.yml`. It runs typecheck, tests, build, and
+   the published-types check (the core workflow also runs the conformance gate), then publishes to
+   npm with provenance through `scripts/safe-publish.mjs`. The publish step stamps the package's
+   measured bundle size into the published manifest as `bundleSize`; the README size badge reads it
+   from the registry.
+5. Create the GitHub release from the tag, with the changelog section as the body.
+
+`@telixon/web-sdk` declares `@telixon/core` as a peer dependency; release core first. The web-sdk
+workflow stops before publishing when the core version it needs is not on npm.
+
 ## Engineering standards
 
 These are the canonical engineering standards for Telixon. They are non-negotiable.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@
   <a href="https://codspeed.io/martsinlabs/telixon"><img src="https://img.shields.io/endpoint?url=https://codspeed.io/badge.json" alt="CodSpeed" /></a>
 </p>
 
+<p align="center">
+  <a href="https://telixon.dev"><b>Documentation</b></a>
+  &middot;
+  <a href="https://telixon.dev/web-sdk/guides/complete-field/"><b>Live demo</b></a>
+  &middot;
+  <a href="https://telixon.dev/core/how-it-works/"><b>How it works</b></a>
+</p>
+
 ## Quick start
 
 ```bash
@@ -59,11 +67,6 @@ phone.subscribe((state) => {
   // state.validationError  null
 });
 ```
-
-Full documentation is at [telixon.dev](https://telixon.dev), with live demos for the
-[phone field](https://telixon.dev/web-sdk/guides/phone-field/),
-[region picker](https://telixon.dev/web-sdk/guides/region-picker/), and
-[complete field](https://telixon.dev/web-sdk/guides/complete-field/).
 
 ## Highlights
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,7 +4,9 @@ Phone-number parser, formatter, and validator built on Google libphonenumber met
 
 [![conformance](https://img.shields.io/endpoint?url=https://proof.telixon.dev/parity-badge.json)](https://proof.telixon.dev/parity.html)
 [![benchmarks](https://img.shields.io/endpoint?url=https://proof.telixon.dev/bench-badge.json)](https://proof.telixon.dev/benchmark.html)
-[![initial bundle](https://img.shields.io/endpoint?url=https://proof.telixon.dev/bundle-badge.json)](https://proof.telixon.dev/bundle.html)
+[![initial bundle](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fregistry.npmjs.org%2F%40telixon%2Fcore%2Flatest&query=%24.bundleSize&label=initial%20bundle&color=26997b)](https://www.npmjs.com/package/@telixon/core)
+
+**[Documentation](https://telixon.dev/core/)** &middot; **[Live demo](https://telixon.dev/web-sdk/guides/complete-field/)**
 
 ## Install
 
@@ -27,7 +29,7 @@ number.formatE164(); // '+12015550123'
 number.formatInternational(); // '+1 201-555-0123'
 ```
 
-Input controllers take the field's value and selection, then return the formatted value and the caret to write back:
+Input controllers take the field's value and selection, and return the formatted value and the caret to write back:
 
 ```ts
 import { createNationalInputController } from '@telixon/core';
@@ -41,8 +43,6 @@ controller.insert('', '4155550132', 0, 0);
 controller.deleteBackward('(415) 555-0132', 3, 8);
 // { value: '(415) 013-2', region: 'US', selectionStart: 3, selectionEnd: 3 }
 ```
-
-Full documentation is at [telixon.dev/core](https://telixon.dev/core/).
 
 ## Highlights
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@telixon/core",
   "version": "0.1.0",
-  "description": "Phone number parser, formatter, and validator built on Google libphonenumber metadata.",
+  "description": "Phone-number parser, formatter, and validator built on Google libphonenumber metadata.",
   "keywords": [
     "phone",
     "phone-number",

--- a/packages/web-sdk/README.md
+++ b/packages/web-sdk/README.md
@@ -3,6 +3,10 @@
 The DOM adapter for [`@telixon/core`](https://www.npmjs.com/package/@telixon/core), shipping two headless widgets: `PhoneInput` drives a plain `<input>`, `RegionList` feeds the region picker.
 
 [![conformance](https://img.shields.io/endpoint?url=https://proof.telixon.dev/parity-badge.json)](https://proof.telixon.dev/parity.html)
+[![benchmarks](https://img.shields.io/endpoint?url=https://proof.telixon.dev/bench-badge.json)](https://proof.telixon.dev/benchmark.html)
+[![initial bundle](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fregistry.npmjs.org%2F%40telixon%2Fweb-sdk%2Flatest&query=%24.bundleSize&label=initial%20bundle&color=26997b)](https://www.npmjs.com/package/@telixon/web-sdk)
+
+**[Documentation](https://telixon.dev/web-sdk/)** &middot; **[Live demo](https://telixon.dev/web-sdk/guides/complete-field/)**
 
 ## Install
 
@@ -49,8 +53,6 @@ regions.getState().options[0];
 regions.search('united');
 regions.getState().options.map((option) => option.region); // ['US', 'GB', 'AE']
 ```
-
-Full documentation is at [telixon.dev/web-sdk](https://telixon.dev/web-sdk/).
 
 ## Highlights
 

--- a/scripts/safe-publish.mjs
+++ b/scripts/safe-publish.mjs
@@ -1,26 +1,63 @@
 #!/usr/bin/env node
-// Removes dev-only fields from the current package.json, runs `pnpm publish` with all passed-through
-// args, then restores the source file on success, on failure, and on interrupt. Run from the package
-// directory you want to ship.
+// Prepares the current package.json for publishing, runs `pnpm publish` with all passed-through
+// args, then restores the source file on success, on failure, and on interrupt. Run from the
+// package directory you want to ship.
 //
-// Stripped fields (none are consumer-facing):
-//   - devDependencies   (tests, conformance, benchmarks; consumers do not install)
-//   - scripts           (build/copy/typecheck/prepublishOnly; consumers do not run)
-//   - packageManager    (corepack hint for monorepo development)
-//   - publishConfig     (publish-time directives; flags passed on CLI instead)
+// Preparation:
+//   - Stamps `bundleSize` with the package's measured size-limit figure. The README size badge
+//     reads the field from the npm registry, so the published manifest carries the number for the
+//     exact version a consumer installs. A measurement failure aborts the publish.
+//   - Strips dev-only fields (none are consumer-facing):
+//       devDependencies   (tests, conformance, benchmarks; consumers do not install)
+//       scripts           (build/copy/typecheck/prepublishOnly; consumers do not run)
+//       packageManager    (corepack hint for monorepo development)
+//       publishConfig     (publish-time directives; flags passed on CLI instead)
 //
 // Usage (in CI):
 //   node ../../scripts/safe-publish.mjs --access public --provenance --no-git-checks
 
-import { spawn } from 'node:child_process';
+import { execSync, spawn } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const STRIP_FIELDS = ['devDependencies', 'scripts', 'packageManager', 'publishConfig'];
+
+// The size-limit entry whose measurement ships as the manifest's `bundleSize`. Core publishes the
+// browser entry, the figure the initial-bundle badge is about.
+const BUNDLE_ENTRY_BY_PACKAGE = {
+  '@telixon/core': '@telixon/core (browser entry)',
+  '@telixon/web-sdk': '@telixon/web-sdk',
+};
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function measureBundleSize(entryName) {
+  const measured = JSON.parse(
+    execSync('pnpm exec size-limit --json', {
+      cwd: repoRoot,
+      stdio: ['ignore', 'pipe', 'inherit'],
+    }).toString(),
+  );
+  const entry = measured.find((candidate) => candidate.name === entryName);
+  if (!entry) {
+    throw new Error(`size-limit reported no entry named "${entryName}"`);
+  }
+  // size-limit prints kilobytes as bytes over 1000; the stamped figure mirrors its convention.
+  return `${(entry.size / 1000).toFixed(2)} kB brotli`;
+}
 
 const pkgPath = resolve('package.json');
 const original = readFileSync(pkgPath, 'utf8');
 const pkg = JSON.parse(original);
+
+const bundleEntry = BUNDLE_ENTRY_BY_PACKAGE[pkg.name];
+if (bundleEntry) {
+  pkg.bundleSize = measureBundleSize(bundleEntry);
+  console.log(`safe-publish: stamped bundleSize ${pkg.bundleSize}`);
+} else {
+  console.log(`safe-publish: no size-limit entry mapped for ${pkg.name}, bundleSize not stamped`);
+}
 
 const stripped = STRIP_FIELDS.filter((field) => field in pkg);
 for (const field of stripped) {


### PR DESCRIPTION
## Summary

`safe-publish` now measures the package's size-limit figure and stamps it into the published
manifest as `bundleSize`. The package README size badges read that field from the npm registry, so
each package shows its own compressed size for the version `latest` points at. The readmes get a
unified top block (badge row plus Documentation, Live demo, How it works links), the duplicate
mid-page documentation pointers are removed, and the core npm description is aligned with the
readme tagline.

## Motivation

A package badge should show the size of the artifact the reader installs. The registry manifest is
the only source that always matches it, and stamping at publish time keeps the figure tied to the
release that ships it.

## Conformance impact

None.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention