### PR TITLE
fix(bench): measure the built package and make the memo caches proces…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # Benchmarks import the built package (#dist); build outside the instrumented step.
+      - run: pnpm build
+
       # Walltime-stable benchmark measurement: CodSpeed runs vitest bench under instrumentation
       # and posts per-PR regression deltas. Threshold and base reference are managed in the CodSpeed
       # GitHub App settings. BENCH_TELIXON_ONLY drops the competitor adapters so only telixon
@@ -138,6 +141,9 @@ jobs:
         with:
           path: packages/core/oracle/.cache
           key: lpn-source-${{ hashFiles('packages/core/src/engine/PROVENANCE.json') }}
+
+      # Benchmarks import the built package (#dist).
+      - run: pnpm build
 
       - run: pnpm bench:report
 

--- a/packages/core/bench/README.md
+++ b/packages/core/bench/README.md
@@ -8,12 +8,23 @@ this directory.
 ## Run
 
 ```bash
+pnpm build         # benchmarks measure the built package
 pnpm bench         # console only
 pnpm bench:report  # also writes dist/{bench.json, bench-badge.json, benchmark.html}
 ```
 
 Vitest bench (Tinybench) reports `ops/sec`, mean, p99, and ±rme per library per operation. Competitor
 versions are resolved at runtime from `node_modules`, pinned in `package.json`.
+
+## Methodology
+
+Every library runs its built artifact. Telixon is imported through the `#dist` specifier, which
+resolves to `dist/index.node.js`, the same file npm consumers install; the competitors run their
+published `node_modules` builds. A guard fails the suite when `dist` is missing or older than
+`src`. The parse scenario runs with a lengthened warmup and sample window so every library reaches
+steady JIT state before sampling; the same options apply to all three adapters. The strict-cold
+scenario clears Telixon's process-wide memo caches every iteration while leaving the competitors
+untouched, which biases that scenario against Telixon by design.
 
 ## Corpus
 

--- a/packages/core/bench/benchmark.template.html
+++ b/packages/core/bench/benchmark.template.html
@@ -57,6 +57,7 @@
         >.<br />
         Corpus: {{corpusSize}} phone numbers, one Google example per region per type (the example set the conformance
         corpus is derived from).<br />
+        Every library runs its built package, the same code a consumer installs.<br />
         Compared against the npm packages
         <a href="https://www.npmjs.com/package/libphonenumber-js/v/{{libphonenumberJsVersion}}"
           >libphonenumber-js@{{libphonenumberJsVersion}}</a

--- a/packages/core/bench/competitors.ts
+++ b/packages/core/bench/competitors.ts
@@ -1,8 +1,4 @@
-import {
-  ensureEngineReady,
-  parsePhoneNumber as telixonParse,
-  type PhoneNumber as TelixonPhoneNumber,
-} from '@telixon/core';
+import { ensureEngineReady, parsePhoneNumber as telixonParse, type PhoneNumber as TelixonPhoneNumber } from '#dist';
 import { type RegionCode } from '@telixon/core/engine';
 import googleLibphonenumber from 'google-libphonenumber';
 import libphonenumberJsParse, {
@@ -10,6 +6,7 @@ import libphonenumberJsParse, {
   type CountryCode,
   type PhoneNumber as LibphonenumberJsPhoneNumber,
 } from 'libphonenumber-js';
+import './require-fresh-dist';
 
 export interface PhoneLibraryAdapter {
   readonly name: string;

--- a/packages/core/bench/hotpath.bench.ts
+++ b/packages/core/bench/hotpath.bench.ts
@@ -33,11 +33,19 @@ function clearTelixonGlobalCachesIfTelixon(adapter: PhoneLibraryAdapter): void {
 
 // ── Parse ────────────────────────────────────────────────
 
+// The tightest loop in the suite needs a long warmup to reach steady JIT state; default-length
+// runs publish under-optimized samples with inflated variance. Applied to every adapter alike.
+const PARSE_BENCH_OPTIONS = { warmupTime: 1000, time: 3000 } as const;
+
 describe('parsePhoneNumber (corpus pass)', () => {
   for (const adapter of ADAPTERS) {
-    bench(adapter.name, () => {
-      for (const entry of CORPUS) consume(adapter.parse(entry.e164, entry.region));
-    });
+    bench(
+      adapter.name,
+      () => {
+        for (const entry of CORPUS) consume(adapter.parse(entry.e164, entry.region));
+      },
+      PARSE_BENCH_OPTIONS,
+    );
   }
 });
 

--- a/packages/core/bench/input-controller.bench.ts
+++ b/packages/core/bench/input-controller.bench.ts
@@ -1,7 +1,8 @@
-import { createInternationalInputController, ensureEngineReady, type InputController } from '@telixon/core';
+import { createInternationalInputController, ensureEngineReady, type InputController } from '#dist';
 import { afterAll, bench, describe } from 'vitest';
 import { consume, flushSink } from './consume';
 import { CORPUS } from './corpus';
+import './require-fresh-dist';
 
 await ensureEngineReady();
 

--- a/packages/core/bench/measure-keystroke-latency.ts
+++ b/packages/core/bench/measure-keystroke-latency.ts
@@ -1,9 +1,10 @@
-import { createInternationalInputController, ensureEngineReady, type InputController } from '@telixon/core';
+import { createInternationalInputController, ensureEngineReady, type InputController } from '#dist';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { consume, flushSink } from './consume';
 import { CORPUS } from './corpus';
+import './require-fresh-dist';
 
 await ensureEngineReady();
 

--- a/packages/core/bench/require-fresh-dist.ts
+++ b/packages/core/bench/require-fresh-dist.ts
@@ -1,0 +1,29 @@
+import { readdirSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Benchmarks measure the built package through the #dist specifier. A dist older than src would
+// silently describe outdated code; fail loudly and ask for a build instead.
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function newestMtime(directory: string): number {
+  let newest = 0;
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue;
+    const entryPath = join(directory, entry.name);
+    const mtime: number = entry.isDirectory() ? newestMtime(entryPath) : statSync(entryPath).mtimeMs;
+    if (mtime > newest) newest = mtime;
+  }
+  return newest;
+}
+
+let builtEntryMtime: number;
+try {
+  builtEntryMtime = statSync(join(packageRoot, 'dist/index.node.js')).mtimeMs;
+} catch {
+  throw new Error('Benchmarks measure the built package; run `pnpm build` first.');
+}
+
+if (newestMtime(join(packageRoot, 'src')) > builtEntryMtime) {
+  throw new Error('dist is older than src; run `pnpm build` before benchmarking.');
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,12 @@
   "author": "Myroslav Martsin <myroslav@martsinlabs.com>",
   "sideEffects": false,
   "type": "module",
+  "imports": {
+    "#dist": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.node.js"
+    }
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/core/src/modules/number-resolver/__tests__/process-scoped-caches.test.ts
+++ b/packages/core/src/modules/number-resolver/__tests__/process-scoped-caches.test.ts
@@ -1,0 +1,33 @@
+import { parsePhoneNumber } from '@telixon/core';
+import { describe, expect, it, vi } from 'vitest';
+import { version } from '../../../../package.json';
+
+type CacheSlot = { readonly size?: number; readonly length?: number };
+
+const slot = (name: string): CacheSlot | undefined =>
+  (globalThis as unknown as Record<symbol, CacheSlot | undefined>)[
+    Symbol.for(`telixon.core.memoCache.${version}.${name}`)
+  ];
+
+const entryCount = (name: string): number => slot(name)?.size ?? slot(name)?.length ?? 0;
+
+// The strict-cold bench scenario relies on this invariant: the harness imports clearGlobalCaches
+// from src while measuring the built entry, which only works while the memo caches stay
+// process-scoped. A cache reverted to a plain module-level Map fails this test.
+describe('process-scoped memo caches', () => {
+  it('lets a fresh module copy of clearGlobalCaches empty the caches the first copy populated', async () => {
+    parsePhoneNumber('(415) 555-0132', { defaultRegion: 'US' }).formatNational();
+
+    expect(entryCount('iddMatchers')).toBeGreaterThan(0);
+    expect(entryCount('exactFormatMasks')).toBeGreaterThan(0);
+
+    vi.resetModules();
+    const { clearGlobalCaches } = await import('../__internal__/clear-global-caches');
+    clearGlobalCaches();
+
+    expect(entryCount('iddMatchers')).toBe(0);
+    expect(entryCount('exactFormatMasks')).toBe(0);
+    expect(entryCount('longestFormatMasks')).toBe(0);
+    expect(entryCount('nationalPrefixRules')).toBe(0);
+  });
+});

--- a/packages/core/src/modules/number-resolver/resolve-number.ts
+++ b/packages/core/src/modules/number-resolver/resolve-number.ts
@@ -5,6 +5,7 @@ import {
 } from '@telixon/core/engine';
 import { BinaryFilter } from '@telixon/core/models';
 import { getResourceProvider } from '@telixon/core/resource-provider';
+import { getProcessScopedCache } from '@telixon/core/utils/get-process-scoped-cache';
 import { applyLeadingCallingCodeStrip } from './apply-leading-calling-code-strip';
 import { applyNationalPrefixStrip } from './apply-national-prefix-strip';
 import { NumberResolverSnapshot } from './models';
@@ -17,8 +18,9 @@ import { resolvePrimaryRegionIndex } from './utils/resolve-primary-region-index'
 
 let cachedResolver: NumberResolver | null = null;
 
-// Compiled IDD matcher per region: the prefix is fixed metadata, so memoize (referentially transparent).
-const iddMatcherCache = new Map<number, RegExp | null>();
+// Compiled IDD matcher per region: the prefix is fixed metadata, so memoize (referentially
+// transparent). Process-scoped, so every bundled copy of this module shares the one memo.
+const iddMatcherCache = getProcessScopedCache('iddMatchers', () => new Map<number, RegExp | null>());
 function getIddMatcher(regionIndex: number): RegExp | null {
   const cached: RegExp | null | undefined = iddMatcherCache.get(regionIndex);
   if (cached !== undefined) return cached;

--- a/packages/core/src/modules/number-resolver/utils/format-masks.ts
+++ b/packages/core/src/modules/number-resolver/utils/format-masks.ts
@@ -1,10 +1,12 @@
 import { forEachFormatMask, getFormatMask } from '@telixon/core/engine';
 import { getResourceProvider } from '@telixon/core/resource-provider';
+import { getProcessScopedCache } from '@telixon/core/utils/get-process-scoped-cache';
 
-// Per-call mask reads decode from the binary; the per-keystroke variant/longest scans are memoized (immutable after load).
+// Per-call mask reads decode from the binary; the per-keystroke variant/longest scans are memoized
+// (immutable after load). Process-scoped, so every bundled copy of this module shares the memos.
 const NO_MASK = '';
-const exactMaskCache = new Map<number, string>();
-const longestMaskCache = new Map<number, string>();
+const exactMaskCache = getProcessScopedCache('exactFormatMasks', () => new Map<number, string>());
+const longestMaskCache = getProcessScopedCache('longestFormatMasks', () => new Map<number, string>());
 
 function exactKey(formatIndex: number, variant: number, totalLength: number): number {
   return formatIndex * 128 + variant * 32 + totalLength;

--- a/packages/core/src/modules/number-resolver/utils/get-national-prefix-rules.ts
+++ b/packages/core/src/modules/number-resolver/utils/get-national-prefix-rules.ts
@@ -5,9 +5,11 @@ import {
   NationalPrefixRules,
 } from '@telixon/core/engine';
 import { getResourceProvider } from '@telixon/core/resource-provider';
+import { getProcessScopedCache } from '@telixon/core/utils/get-process-scoped-cache';
 
-// National-prefix rules per region, decoded lazily and cached (consulted per parse and per keystroke).
-const cache: (NationalPrefixRules | undefined)[] = [];
+// National-prefix rules per region, decoded lazily and cached (consulted per parse and per
+// keystroke). Process-scoped, so every bundled copy of this module shares the memo.
+const cache = getProcessScopedCache('nationalPrefixRules', () => [] as (NationalPrefixRules | undefined)[]);
 
 export function getNationalPrefixRules(regionIndex: number): NationalPrefixRules | undefined {
   if (regionIndex < 0) return undefined;

--- a/packages/core/src/resource-provider/resource-provider.ts
+++ b/packages/core/src/resource-provider/resource-provider.ts
@@ -157,7 +157,8 @@ export function getResourceProvider(): ResourceProvider {
   return cachedProvider;
 }
 
-// @internal Test and bench hook: drop the process-wide provider so the next getResourceProvider() rebuilds it.
+// @internal Test and bench hook: drop the process-wide provider so the next getResourceProvider()
+// rebuilds it. The process-scoped memo caches survive this reset; clear-global-caches covers them.
 export function __resetResourceProvider(): void {
   cachedProvider = undefined;
   (globalThis as unknown as Record<symbol, ResourceProvider | undefined>)[PROVIDER_KEY] = undefined;

--- a/packages/core/src/utils/get-process-scoped-cache.ts
+++ b/packages/core/src/utils/get-process-scoped-cache.ts
@@ -1,0 +1,16 @@
+import { version } from '../../package.json';
+
+// Process-wide memo storage, mirroring the resource-provider singleton: duplicate copies of a
+// caching module (multiple bundles in one process, the bench harness beside the built entry) share
+// one cache instance through globalThis (Symbol.for), and the module-local binding each copy takes
+// at load keeps every cache hit a plain read. The key carries the package version, so copies of
+// different library versions in one process keep separate caches (key encodings may differ).
+export function getProcessScopedCache<T>(slot: string, create: () => T): T {
+  const key = Symbol.for(`telixon.core.memoCache.${version}.${slot}`);
+  const store = globalThis as unknown as Record<symbol, T | undefined>;
+  const existing: T | undefined = store[key];
+  if (existing !== undefined) return existing;
+  const created: T = create();
+  store[key] = created;
+  return created;
+}

--- a/scripts/safe-publish.mjs
+++ b/scripts/safe-publish.mjs
@@ -12,6 +12,7 @@
 //       scripts           (build/copy/typecheck/prepublishOnly; consumers do not run)
 //       packageManager    (corepack hint for monorepo development)
 //       publishConfig     (publish-time directives; flags passed on CLI instead)
+//       imports           (the #dist specifier the bench harness measures the build through)
 //
 // Usage (in CI):
 //   node ../../scripts/safe-publish.mjs --access public --provenance --no-git-checks
@@ -21,7 +22,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const STRIP_FIELDS = ['devDependencies', 'scripts', 'packageManager', 'publishConfig'];
+const STRIP_FIELDS = ['devDependencies', 'scripts', 'packageManager', 'publishConfig', 'imports'];
 
 // The size-limit entry whose measurement ships as the manifest's `bundleSize`. Core publishes the
 // browser entry, the figure the initial-bundle badge is about.


### PR DESCRIPTION
## Summary

Benchmarks measure the built package. Bench entries import `#dist` (the `dist/index.node.js` npm
serves), a guard fails the suite on a stale or missing `dist`, and CI builds before the codspeed
and bench jobs. The memo caches become process-scoped, which keeps strict-cold clearing effective
on the measured copy; a test enforces the invariant. The parse bench gets a longer warmup and
sample window, identical for all adapters. The published artifact is unchanged.

## Motivation

Closes #68.

## Conformance impact

None. `pnpm conformance` passes locally.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention