### PR TITLE
docs: refresh the performance claims to the measured benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ phone.subscribe((state) => {
 - **Compiled to one automaton.** Google publishes its metadata as regular expressions; Telixon
   compiles them ahead of time into a single deterministic finite automaton. Resolving a number is
   one linear-time walk; the state it ends on carries validity, type, region, and format.
+- **An order of magnitude faster.** That one walk parses millions of numbers a second, while the
+  established libraries interpret regex metadata on every call. The
+  [live benchmark](https://proof.telixon.dev/benchmark.html) proves the gap on every push.
 - **A real input controller.** Formatting on every keystroke, with caret tracking, undo and redo,
   and the full query surface mid-typing.
 - **No third-party dependencies.** `@telixon/core` installs nothing beyond itself.

--- a/apps/docs/src/content/docs/verified.mdx
+++ b/apps/docs/src/content/docs/verified.mdx
@@ -35,9 +35,11 @@ The [parity dashboard](https://proof.telixon.dev/parity.html) publishes every ru
 ## Performance
 
 The benchmark measures parsing and query throughput, cold and warm, plus per-keystroke controller
-latency. The reference baseline is the google-libphonenumber npm package, a third-party wrapper
-of Google's port. Wall-time numbers depend on hardware. CodSpeed tracks the instrumented
-regressions.
+latency. Every library runs its built package, the same code a consumer installs. The reference
+baseline is the google-libphonenumber npm package, a third-party wrapper of Google's port.
+Wall-time numbers depend on hardware, while the medians across the query surface land around an
+order of magnitude in Telixon's favor; the dashboard publishes the per-method ratios. CodSpeed
+tracks the instrumented regressions.
 
 ```sh
 pnpm bench

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -1396,7 +1396,7 @@ const closedTypesCode = `controller.setRegion('USA')
               >100% geographic parity, verified against Google libphonenumber</a
             >
             <a class="link-green" href="https://proof.telixon.dev/benchmark.html" target="_blank" rel="noreferrer"
-              >About 4x faster parsing, measured in CI</a
+              >Order-of-magnitude faster parsing, measured in CI</a
             >
           </p>
           <div class="cta-row">

--- a/examples/core/bundle-size/report.ts
+++ b/examples/core/bundle-size/report.ts
@@ -1,4 +1,4 @@
-// Measures the chunks from `vite build` and writes the bundle-size proof published at telixon.dev/bundle.html.
+// Measures the chunks from `vite build` and writes the bundle-size proof published at proof.telixon.dev/bundle.html.
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -51,6 +51,9 @@ controller.deleteBackward('(415) 555-0132', 3, 8);
 - **One deterministic finite automaton.** Google publishes its metadata as regular expressions;
   Telixon compiles them ahead of time into one automaton. A single linear-time walk yields validity,
   number type, region, and format.
+- **An order of magnitude faster.** A single linear walk parses millions of numbers a second,
+  while the established libraries interpret regex metadata on every call. The
+  [live benchmark](https://proof.telixon.dev/benchmark.html) proves the gap on every push.
 - **No third-party dependencies.** The package installs nothing beyond itself.
 - **Every JavaScript runtime.** Node.js, browsers, Deno, Bun, and edge, selected through package
   export conditions.

--- a/packages/core/bench/README.md
+++ b/packages/core/bench/README.md
@@ -1,7 +1,7 @@
 # Benchmarks
 
 Compares Telixon against [libphonenumber-js][libphonenumber-js] and
-[google-libphonenumber][google-libphonenumber] (an npm wrapper around Google's libphonenumber JS
+[google-libphonenumber][google-libphonenumber] (a community wrapper around Google's libphonenumber JS
 source) across the public query surface. Same corpus, same runner, same code path, all sources in
 this directory.
 

--- a/packages/core/bench/benchmark.template.html
+++ b/packages/core/bench/benchmark.template.html
@@ -128,7 +128,8 @@
       <p class="note">
         Pre-parsed value, method called repeatedly. Where libphonenumber-js stores the value as a direct property after
         parse (<code>nationalNumber</code>, <code>countryCallingCode</code>, <code>number</code>, <code>country</code>),
-        a property read is 1-4% faster than Telixon's cached method call.
+        the warm comparison is a property read against Telixon's cached method call; the table below shows the measured
+        numbers.
       </p>
       <table>
         <thead>

--- a/packages/core/src/resource-loader/decode-layer-native.ts
+++ b/packages/core/src/resource-loader/decode-layer-native.ts
@@ -10,7 +10,7 @@ function toArrayBuffer(decompressed: Buffer): ArrayBuffer {
   return buffer;
 }
 
-// Node sync decode: native zlib (JIT-free, ~10x the pure-JS path cold).
+// Node sync decode: native zlib, far cheaper cold than the pure-JS path because it needs no JIT warmup.
 export function decodeLayerNative(base64: string): ArrayBuffer {
   return toArrayBuffer(zlib.gunzipSync(Buffer.from(base64, 'base64')));
 }


### PR DESCRIPTION
## Summary

The readmes, the landing hero, and the Verified page state the measured speed advantage, an order
of magnitude over the established libraries, with the exact ratios on the live benchmark. The stale
"About 4x" landing claim, a hardcoded warm-comparison range in the report template, an outdated
dashboard URL in the bundle-size example, and one unverifiable comment figure are corrected.

## Motivation

The benchmark measures built packages and publishes the real ratios.

## Conformance impact

None.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention