### PR TITLE
docs: align the prose with the house style across every surface

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
     url: https://github.com/martsinlabs/telixon/security/advisories/new
-    about: Report security issues privately, not via public issues.
+    about: Report security issues privately through the GitHub Security Advisory form.
   - name: Questions and discussion
     url: https://github.com/martsinlabs/telixon/discussions
     about: For questions, ideas, and general discussion.

--- a/.github/ISSUE_TEMPLATE/conformance_divergence.yml
+++ b/.github/ISSUE_TEMPLATE/conformance_divergence.yml
@@ -15,7 +15,7 @@ body:
     id: region
     attributes:
       label: Region
-      description: ISO 3166-1 alpha-2 region code (e.g. `US`, `GB`, `UA`).
+      description: ISO 3166-1 alpha-2 region code (for example `US`, `GB`, `UA`).
       placeholder: US
     validations:
       required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Summary
 
-<!-- One paragraph: what changes, what does not. -->
+<!-- One paragraph describing the change. -->
 
 ## Motivation
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -67,8 +67,8 @@ Each layer adds one concern and depends only on layers beneath it.
 | 6     | `web-components`              | Optional drop-in `<tel-input>`; the only renderer                     | web-sdk    | planned |
 | 7     | user code                     | All markup, styles, region-selector wiring                            | a binding  | n/a     |
 
-The split keeps the engine free of DOM, reactivity, and framework weight, and lets a caller enter at
-the level matching their need:
+The split keeps the engine free of DOM, reactivity, and framework weight, while letting a caller
+enter at the level matching their need:
 
 - **`@telixon/web-components`**: drop in a component, one line. (planned)
 - **`@telixon/web-sdk`**: bring your own UI, roughly ten lines.
@@ -103,8 +103,8 @@ bumping provenance.
 
 **It is one deterministic finite automaton whose states carry the answers.** Google publishes its
 metadata as regular expressions; the compiler turns them into a single state graph. A number's
-digits drive one walk, deterministic and backtracking-free, and the state the walk ends on is the
-key to every answer. Validity, number type, region, and format index are read off that state through
+digits drive one walk, deterministic and backtracking-free. The state the walk ends on is the key
+to every answer. Validity, number type, region, and format index are read off that state through
 accessors shaped `(engine, state, ...)`, which makes the engine a Moore machine, an automaton whose
 output is a function of the state it reaches. One linear-time walk per resolution is what keeps
 per-keystroke work cheap. The automaton is global and unified, matching one
@@ -134,7 +134,7 @@ The engine loads as a **single indivisible artifact**. Because the recognition a
 single region cannot be loaded in isolation; there is no per-region lazy loading by design.
 
 The four modules ship as base64-of-gzip ESM (`engine/embedded/*.bin.js`); the library owns loading and
-decoding. Initialization is explicit and **asynchronous by default**: `await ensureEngineReady()` from
+decoding. Initialization is explicit and **asynchronous by default**. `await ensureEngineReady()` from
 `@telixon/core` loads the engine on demand and decodes it off the main thread. A synchronous path lives
 in a separate thin entry, `@telixon/core/sync-init`, exporting `ensureEngineReadySync()`, which
 statically bundles the modules and decodes them in-process. Each uses the fastest decode the runtime has:
@@ -162,7 +162,7 @@ Bundle size follows from separating code and data:
 `ensureEngineReady()` to the environment's loader and re-export the shared `index.ts`;
 `index.sync-init.ts` and `index.sync-init.node.ts` back the `@telixon/core/sync-init` entry. The
 provider is process-wide, which lets either entry ready one engine while the rest of the code stays
-environment-agnostic. Initialization is explicit: `await ensureEngineReady()` is the default,
+environment-agnostic. Initialization is explicit. `await ensureEngineReady()` is the default,
 `ensureEngineReadySync()` from `@telixon/core/sync-init` is the synchronous path, and an API call before
 either throws `EngineNotReadyError`. `isEngineReady()` is a synchronous readiness predicate. Full
 detail: [Load the engine](https://telixon.dev/core/load-the-engine/).
@@ -187,9 +187,9 @@ in CI; the rest are enforced in review.
 
 `packages/core/conformance` runs the public query methods against Google's libphonenumber across every
 supported region, on valid numbers, display spellings, deterministic corruptions, and every digit
-prefix, and fails CI on any divergence outside an explicit allowlist. The oracle loads Google's
+prefix. Any divergence outside an explicit allowlist fails CI. The oracle loads Google's
 source at **the same commit the engine was compiled from**, which rules out metadata version drift.
-A mismatch is always a real engine difference, never a stale reference. The current baseline is on the
+A mismatch is always a real engine difference. The current baseline is on the
 [live dashboard](https://proof.telixon.dev/parity.html). See
 [conformance/README.md](packages/core/conformance/README.md).
 
@@ -197,7 +197,7 @@ A mismatch is always a real engine difference, never a stale reference. The curr
 
 The per-keystroke path is hot. The standing rule avoids allocation, regex, and indirection there,
 preferring charCode parsing and early exits. Outside hot paths, allocation is fine where it improves
-clarity. Review applies the discipline, and the benchmark suite (`pnpm bench`) backs it, with
+clarity. Review applies the discipline. The benchmark suite (`pnpm bench`) backs it, with
 continuous performance regression tracking in CI via CodSpeed.
 
 ### Bundle size
@@ -220,9 +220,9 @@ These keep modules independent and the dependency graph legible. They are enforc
 
 The engine and the entire public API speak in **regions** (`RegionCode`, `REGION_CODES`, `getRegion`, the
 `defaultRegion` config, the web-sdk `RegionList`), matching libphonenumber and ECMAScript `Intl`, where a
-region is an ISO 3166-1 area that may not be a sovereign country. The term "calling code" names the ITU
-E.164 dial prefix (the `+1` number), never the region; "country code" survives only where we cite Google's
-own functions (e.g. `getCountryCodeForRegion`).
+region is an ISO 3166-1 area that may not be a sovereign country. The term "calling code" always names the
+ITU E.164 dial prefix (the `+1` number); "country code" survives only where Google's own functions are
+cited (for example `getCountryCodeForRegion`).
 
 ## Public API
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ Run from the repo root:
 
 ## Submitting changes
 
-`main` is protected. Every change lands through a pull request, and merges are squash-only, which
-makes the pull request title the commit subject on `main`.
+`main` is protected. Every change lands through a pull request. Merges are squash-only, which makes
+the pull request title the commit subject on `main`.
 
 1. Branch off `main`.
 2. Make your change.
@@ -105,7 +105,7 @@ These are the canonical engineering standards for Telixon. They are non-negotiab
 
 - One responsibility per function. No "and" in what it does.
 - Pure by default; side effects only at explicit I/O boundaries.
-- No boolean flag parameters; no optional params that change fundamental behavior. Use separate
+- No boolean flag parameters; no optional parameters that change fundamental behavior. Use separate
   functions.
 - Never mutate inputs; always return new values.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,7 +46,7 @@ Security fixes land in the latest `1.x` release.
 
 1. You submit a private report through the GitHub Security Advisory form.
 2. The maintainer acknowledges within 5 business days.
-3. We agree on impact assessment and embargo timeline.
+3. You and the maintainer agree on the impact assessment and embargo timeline.
 4. A patch is prepared and released in a new version.
 5. A public advisory is published, with a CVE identifier if appropriate and credit to the reporter.
 
@@ -57,7 +57,7 @@ they prefer to remain anonymous.
 
 ## Safe harbor
 
-We will not pursue legal action or report researchers who:
+Telixon will not pursue legal action against or report researchers who:
 
 - act in good faith,
 - limit testing to their own copy or a controlled environment,

--- a/apps/docs/src/content/docs/core/how-it-works.mdx
+++ b/apps/docs/src/content/docs/core/how-it-works.mdx
@@ -1,6 +1,6 @@
 ---
 title: How Telixon works
-description: Digits walk one automaton. Validity is an accepting state. The parser and the input controllers share the walk.
+description: Digits walk one automaton where validity is an accepting state, a walk the parser and the input controllers share.
 ---
 
 Google libphonenumber's metadata is compiled ahead of time into a single

--- a/apps/docs/src/content/docs/core/index.mdx
+++ b/apps/docs/src/content/docs/core/index.mdx
@@ -100,7 +100,7 @@ lengths that exist.
 
 ## Drive an input
 
-An input controller takes the field's value and selection, then returns the formatted value and the
+An input controller takes the field's value and selection, and returns the formatted value and the
 caret to write back. Formatting starts at the first digit:
 
 ```ts

--- a/apps/docs/src/content/docs/core/reference/input-controller.mdx
+++ b/apps/docs/src/content/docs/core/reference/input-controller.mdx
@@ -50,7 +50,7 @@ controller.setValue('+14155550132');
 ### InternationalInputControllerConfig
 
 `defaultRegion`, `strict`, `initialValue`, and `maxHistorySize` match
-[`NationalInputControllerConfig`](#nationalinputcontrollerconfig), with two differences.
+[`NationalInputControllerConfig`](#nationalinputcontrollerconfig).
 `defaultRegion` is required only when the calling code is kept out of the field. When the calling
 code is in the field, `defaultRegion` pre-fills the field with that region's code.
 

--- a/apps/docs/src/content/docs/core/reference/match-phone-numbers.mdx
+++ b/apps/docs/src/content/docs/core/reference/match-phone-numbers.mdx
@@ -43,8 +43,8 @@ matchPhoneNumbers('abc', '+14155550132'); // 'NOT_A_NUMBER'
 ## Reading strings
 
 A string with an explicit `+` reads as international. Without one it reads as national digits;
-when the other side carries a calling code, that code's main region parses the digits, and the
-grade caps at `NSN_MATCH`, since the string never named the calling code itself.
+when the other side carries a calling code, that code's main region parses the digits. The grade
+caps at `NSN_MATCH`, since the string never named the calling code itself.
 
 ```ts
 matchPhoneNumbers('020 7183 8750', '+44 20 7183 8750'); // 'NSN_MATCH'

--- a/apps/docs/src/content/docs/core/reference/validation-error.mdx
+++ b/apps/docs/src/content/docs/core/reference/validation-error.mdx
@@ -43,8 +43,8 @@ Every row is a real input and its real result.
 (`callingCodeInInput: false`), where the digits are the international significant number. It
 reports when a number that is not valid as typed begins with a national-dialing chunk, the trunk
 prefix or a carrier code, whose removal leaves a valid number. `prefix` is the exact leading chunk
-to drop; a Belarusian number typed as `80 29…` reports `prefix: '80'`. Reproducing it takes a
-controller rather than `parsePhoneNumber`:
+to drop; a Belarusian number typed as `80 29...` reports `prefix: '80'`. Reproducing it takes a
+controller:
 
 ```ts
 const controller = createInternationalInputController({

--- a/apps/docs/src/content/docs/verified.mdx
+++ b/apps/docs/src/content/docs/verified.mdx
@@ -15,7 +15,7 @@ libphonenumber counterpart; every one of them is compared against it. The oracle
 the exact commit the engine's metadata was built from. Every mismatch it reports is a real
 behavioral difference.
 
-The gate runs two sweeps. The full corpus compares the thirteen methods on 14,355 inputs each,
+The gate's full corpus compares the thirteen methods on 14,355 inputs each,
 across all 245 regions, extension spellings included, while case coverage compares one number from
 every distinct case the library can produce. Together they stand at 367,766 comparisons with zero
 divergences. `isValidForRegion` is set-compared per case, with 692,513 region checks in the

--- a/apps/docs/src/content/docs/web-sdk/index.mdx
+++ b/apps/docs/src/content/docs/web-sdk/index.mdx
@@ -6,7 +6,7 @@ description: Install @telixon/web-sdk and bind a phone input and a region list t
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 `@telixon/web-sdk` is the DOM adapter for [`@telixon/core`](/core/). It ships two
-headless widgets: [`PhoneInput`](/web-sdk/phone-input/) drives a real `<input>`, and
+headless widgets. [`PhoneInput`](/web-sdk/phone-input/) drives a real `<input>` while
 [`RegionList`](/web-sdk/region-list/) feeds region pickers.
 
 ## Install
@@ -109,7 +109,7 @@ regions.getState().options[0];
 // { region: 'AF', callingCode: '93', displayName: 'Afghanistan', data: undefined }
 ```
 
-The guides turn these into working fields with live demos:
-[Build a phone field](/web-sdk/guides/phone-field/),
+The guides [Build a phone field](/web-sdk/guides/phone-field/),
 [Build a region picker](/web-sdk/guides/region-picker/), and
-[Build the complete field](/web-sdk/guides/complete-field/).
+[Build the complete field](/web-sdk/guides/complete-field/) turn these into working fields with live
+demos.

--- a/apps/docs/src/generated/size.json
+++ b/apps/docs/src/generated/size.json
@@ -1,12 +1,12 @@
 {
   "nodeEntry": {
     "artifact": "@telixon/core (Node entry)",
-    "measured": "23.41 kB brotli",
+    "measured": "23.52 kB brotli",
     "budget": "24 kB"
   },
   "browserEntry": {
     "artifact": "@telixon/core (browser entry)",
-    "measured": "26.03 kB brotli",
+    "measured": "26.11 kB brotli",
     "budget": "27 kB"
   },
   "webSdk": {

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -552,7 +552,7 @@ const closedTypesCode = `controller.setRegion('USA')
       .demo-rows {
         display: grid;
         grid-template-columns: auto 1fr;
-        grid-template-rows: repeat(4, 26px);
+        grid-template-rows: repeat(4, minmax(26px, auto));
         align-items: center;
         gap: 4px 22px;
         margin-top: 18px;
@@ -591,7 +591,10 @@ const closedTypesCode = `controller.setRegion('USA')
         display: flex;
         justify-content: flex-end;
         align-items: center;
-        gap: 8px;
+        gap: 2px 8px;
+        flex-wrap: wrap;
+        white-space: normal;
+        overflow: visible;
       }
       .err-kind {
         color: var(--error);
@@ -1474,7 +1477,7 @@ const closedTypesCode = `controller.setRegion('USA')
               The conformance suite loads Google libphonenumber's own source at the exact commit the <a
                 class="link-green"
                 href="#compiled-engine">engine</a
-              > was compiled from, so there is no version drift between the library and its reference.
+              > was compiled from, which rules out version drift between the library and its reference.
             </p>
             <p>
               On every push to main and every pull request, <a
@@ -1489,8 +1492,8 @@ const closedTypesCode = `controller.setRegion('USA')
                 target="_blank"
                 rel="noreferrer">exhaustive enumeration</a
               > re-proves the result across every input the engine can distinguish, at every length. The input controllers
-              go through the same gate: every input is typed character by character, and the controller's resolved number
-              must equal the parser's.
+              go through the same gate, where every input is typed character by character and the controller's
+              resolved number must equal the parser's.
             </p>
             <p>
               Explore the results on the <a
@@ -1570,7 +1573,7 @@ const closedTypesCode = `controller.setRegion('USA')
           </div>
           <div class="bench">
             <div class="num">Every PR</div>
-            <div class="label">performance-gated, so a regression cannot merge quietly</div>
+            <div class="label">performance-gated; a regression cannot merge quietly</div>
           </div>
         </div>
         <p class="bench-note">
@@ -1690,11 +1693,11 @@ const closedTypesCode = `controller.setRegion('USA')
           </div>
           <div class="cell">
             <h3><span class="tick" aria-hidden="true">+</span> Bad input never throws</h3>
-            <p>parsePhoneNumber always returns. Invalid input answers with null and a typed reason, not an exception.</p>
+            <p>parsePhoneNumber always returns. Invalid input answers with null and a typed reason.</p>
           </div>
           <div class="cell">
             <h3><span class="tick" aria-hidden="true">+</span> Nothing on import</h3>
-            <p>Importing has no side effects: no fetches, no globals. The engine loads only when you call for it.</p>
+            <p>Importing runs no fetches and sets no globals. The engine loads only when you call for it.</p>
           </div>
           <div class="cell">
             <h3><span class="tick" aria-hidden="true">+</span> One object, every query</h3>
@@ -1722,8 +1725,8 @@ const closedTypesCode = `controller.setRegion('USA')
           <div class="cell wide">
             <h3><span class="tick" aria-hidden="true">+</span> Undo and redo built in</h3>
             <p>
-              Bounded history on every field: the undo and redo shortcuts drive it, and the historyUndo and
-              historyRedo input intents are honored.
+              Bounded history on every field, driven by the undo and redo shortcuts and by the historyUndo and
+              historyRedo input intents.
             </p>
           </div>
           <div class="cell wide">

--- a/examples/core/bundle-size/README.md
+++ b/examples/core/bundle-size/README.md
@@ -33,4 +33,4 @@ Vite prints the chunk sizes. `pnpm --filter @telixon/example-core-bundle-size re
 ## How the numbers are measured
 
 `report.ts` reads the emitted chunks from `dist/assets`, classifies each as initial or engine, and gzip/brotli-compresses
-it with `node:zlib`. Nothing is hard-coded; every figure comes from the build output.
+it with `node:zlib`. Every figure comes from the build output.

--- a/packages/core/conformance/README.md
+++ b/packages/core/conformance/README.md
@@ -25,15 +25,15 @@ fetches that source at the **same commit the engine was built from** (`src/engin
 and runs it on `google-closure-library`. Sources are cached under `.cache/<commit>/`, leaving only
 the first run in need of network.
 
-Because the oracle and the engine share one commit, there is **no metadata version drift**: any
-mismatch is a real engine difference, never a stale reference.
+Because the oracle and the engine share one commit, there is **no metadata version drift**. Any
+mismatch is a real engine difference.
 
 ## How it works
 
 ```
-corpus ──▶ for each number ──▶ oracle  (Google's answer)
-                          └──▶ subject (Telixon's answer)
-                                  └──▶ compare ──▶ report ──▶ gate
+corpus --> for each number --> oracle  (Google's answer)
+                          \--> subject (Telixon's answer)
+                                  \--> compare --> report --> gate
 ```
 
 The oracle and the example corpus live in `../oracle/` (shared with the bench so both consume the
@@ -49,7 +49,7 @@ exact same Google source). The conformance corpus is derived from the examples i
 | `report.ts`            | formats the report                                                          |
 | `known-divergences.ts` | the allowlist of accepted mismatches + audit                                |
 | `conformance.test.ts`  | the gate                                                                    |
-| `models.ts`            | shared types (`Mismatch`, `MethodReport`, `MethodName`, …)                  |
+| `models.ts`            | shared types (`Mismatch`, `MethodReport`, `MethodName`, ...)                |
 | `artifacts.ts`         | writes `parity.json`, `parity-badge.json`, `parity.html`                    |
 | `as-you-type.ts`       | per-keystroke as-you-type measurement vs Google                             |
 | `parity.template.html` | HTML template for the dashboard                                             |
@@ -59,7 +59,7 @@ exact same Google source). The conformance corpus is derived from the examples i
 ```
 oracle and engine pinned to google/libphonenumber@<commit> · no metadata drift
 <N> cases · <compared> compared · <covered>/<total> regions · <skipped> skipped
-  <kind>=<count> · …
+  <kind>=<count> · ...
   google-rejected mutations judged not possible: <agreed>/<total>
 
   <method>  <rate>  (<matched>/<total>)
@@ -112,13 +112,13 @@ applied progressively. The run prints this as a measurement; the gate ignores it
 
 ## Baseline
 
-Latest: [live dashboard](https://proof.telixon.dev/parity.html).
-Reproduce locally: `pnpm conformance`.
+The latest run is published on the [live dashboard](https://proof.telixon.dev/parity.html).
+Reproduce it locally with `pnpm conformance`.
 
 ## Corpus
 
-Every case derives deterministically from Google's example numbers (one per region per type), so
-there is no snapshot to drift and no randomness in the gate. One case is one exact input string
+Every case derives deterministically from Google's example numbers (one per region per type), which
+leaves no snapshot to drift and no randomness in the gate. One case is one exact input string
 parsed under identical conditions on both sides.
 
 | Family            | Kinds                                                                                                 | Contract                                                                          |

--- a/packages/web-sdk/README.md
+++ b/packages/web-sdk/README.md
@@ -1,6 +1,6 @@
 # @telixon/web-sdk
 
-The DOM adapter for [`@telixon/core`](https://www.npmjs.com/package/@telixon/core), shipping two headless widgets: `PhoneInput` drives a plain `<input>`, `RegionList` feeds the region picker.
+The DOM adapter for [`@telixon/core`](https://www.npmjs.com/package/@telixon/core), shipping two headless widgets. `PhoneInput` drives a plain `<input>` while `RegionList` feeds the region picker.
 
 [![conformance](https://img.shields.io/endpoint?url=https://proof.telixon.dev/parity-badge.json)](https://proof.telixon.dev/parity.html)
 [![benchmarks](https://img.shields.io/endpoint?url=https://proof.telixon.dev/bench-badge.json)](https://proof.telixon.dev/benchmark.html)


### PR DESCRIPTION
## Summary

A pre-release sweep aligns the prose across the repo with the house style rules. The demo error
row now wraps, and the measured size figures are refreshed.

## Motivation

One pass before the release.

## Conformance impact

None.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention
