### PR TITLE
ci: build before typecheck in the release workflows

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -38,6 +38,9 @@ jobs:
             exit 1
           fi
 
+      # Build first: the bundle-size example typechecks against the built package.
+      - run: pnpm build
+
       - run: pnpm typecheck
 
       - run: pnpm test
@@ -49,8 +52,6 @@ jobs:
           key: lpn-source-${{ hashFiles('packages/core/src/engine/PROVENANCE.json') }}
 
       - run: pnpm conformance
-
-      - run: pnpm build
 
       # Re-validate published type entry points against the actual release commit.
       - run: pnpm dlx @arethetypeswrong/cli@0.18.5 --pack packages/core --ignore-rules cjs-resolves-to-esm no-resolution

--- a/.github/workflows/release-web-sdk.yml
+++ b/.github/workflows/release-web-sdk.yml
@@ -38,11 +38,12 @@ jobs:
             exit 1
           fi
 
+      # Build first: the bundle-size example typechecks against the built package.
+      - run: pnpm build
+
       - run: pnpm typecheck
 
       - run: pnpm test
-
-      - run: pnpm build
 
       # Re-validate published type entry points against the actual release commit.
       - run: pnpm dlx @arethetypeswrong/cli@0.18.5 --pack packages/web-sdk --ignore-rules cjs-resolves-to-esm no-resolution


### PR DESCRIPTION
## Summary

The release workflows build before typechecking, the order the verify job already uses.

## Motivation

The bundle-size example typechecks against the built package; a release run starts on a clean
runner.

## Conformance impact

None.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention