### PR TITLE
chore(release): web-sdk 1.0.0

### DIFF
--- a/packages/web-sdk/CHANGELOG.md
+++ b/packages/web-sdk/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to `@telixon/web-sdk` are documented in this file. The forma
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-08-21
+
 ### Added
 
 - `createPhoneInput` binding a plain `<input>` to a core input controller. It wires the
@@ -16,4 +18,5 @@ All notable changes to `@telixon/web-sdk` are documented in this file. The forma
 - `regionToFlagEmoji` mapping a region code to its flag emoji.
 - `@telixon/core` as a peer dependency; the engine loads through it directly.
 
-[Unreleased]: https://github.com/martsinlabs/telixon/commits/main
+[Unreleased]: https://github.com/martsinlabs/telixon/compare/web-sdk@v1.0.0...HEAD
+[1.0.0]: https://github.com/martsinlabs/telixon/releases/tag/web-sdk@v1.0.0

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telixon/web-sdk",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "DOM adapter for @telixon/core: two headless widgets, PhoneInput driving a plain <input> and RegionList feeding region pickers.",
   "keywords": [
     "phone-input",


### PR DESCRIPTION
## Summary

The 1.0.0 release cut for @telixon/web-sdk.

## Motivation

First release.

## Conformance impact

None.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention