### PR TITLE
chore(release): core 1.0.1

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to `@telixon/core` are documented in this file. The format f
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-08-23
+
 ### Changed
 
 - `PhoneNumber` and the input controllers hold their state in native private fields; a runtime
@@ -41,5 +43,6 @@ All notable changes to `@telixon/core` are documented in this file. The format f
 - A conformance gate in CI comparing every query method with a Google libphonenumber counterpart
   against Google's source at the pinned metadata commit.
 
-[Unreleased]: https://github.com/martsinlabs/telixon/compare/core@v1.0.0...HEAD
+[Unreleased]: https://github.com/martsinlabs/telixon/compare/core@v1.0.1...HEAD
+[1.0.1]: https://github.com/martsinlabs/telixon/compare/core@v1.0.0...core@v1.0.1
 [1.0.0]: https://github.com/martsinlabs/telixon/releases/tag/core@v1.0.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telixon/core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Phone-number parser, formatter, and validator built on Google libphonenumber metadata.",
   "keywords": [
     "phone",


### PR DESCRIPTION
## Summary

Core moves to 1.0.1; the changelog cuts the 1.0.1 section.

## Motivation

Ship the engine metadata refresh and the sealed runtime surface.

## Conformance impact

None.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention