### PR TITLE
docs(web-sdk): restore the stranded RegionListOptions table rows

### DIFF
--- a/apps/docs/src/content/docs/web-sdk/region-list.mdx
+++ b/apps/docs/src/content/docs/web-sdk/region-list.mdx
@@ -29,6 +29,9 @@ regions.getState().options[0];
 | Field              | Type                            | Meaning                                                                                                                |
 | ------------------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `dataFactory`      | `RegionDataFactory<T>`          | Produces the `data` slot from the option's `region`, `callingCode`, and `displayName`; its return type flows into `T`. |
+| `locale`           | `string`                        | Locale for display names; `'en'` by default.                                                                           |
+| `sort`             | `RegionListSort`                | `'alphabetical'` (default), `'callingCode'`, or a comparator.                                                          |
+| `prioritize`       | `readonly RegionCode[]`         | Regions pinned to the top, in the given order.                                                                         |
 | `regionFilter`     | `readonly RegionCode[] \| null` | Restricts the list to these regions.                                                                                   |
 | `numberTypeFilter` | `readonly NumberType[] \| null` | Keeps regions that assign at least one of these types.                                                                 |
 | `searchQuery`      | `string`                        | Initial search query.                                                                                                  |
@@ -37,9 +40,6 @@ regions.getState().options[0];
 `RegionDataFactory<T>` is `(input: RegionDataFactoryInput) => T`, where `RegionDataFactoryInput`
 carries the option's `region`, `callingCode`, and `displayName`. `RegionSearchFn<T>` is
 `(query: string, option: RegionOption<T>) => boolean`.
-| `locale` | `string` | Locale for display names; `'en'` by default. |
-| `sort` | `RegionListSort` | `'alphabetical'` (default), `'callingCode'`, or a comparator. |
-| `prioritize` | `readonly RegionCode[]` | Regions pinned to the top, in the given order. |
 
 For both filters, `null` lifts the restriction; `[]` matches nothing.
 

--- a/apps/docs/src/generated/size.json
+++ b/apps/docs/src/generated/size.json
@@ -1,7 +1,7 @@
 {
   "nodeEntry": {
     "artifact": "@telixon/core (Node entry)",
-    "measured": "23.52 kB brotli",
+    "measured": "23.56 kB brotli",
     "budget": "25 kB"
   },
   "browserEntry": {


### PR DESCRIPTION
## Summary

Three `RegionListOptions` rows (`locale`, `sort`, `prioritize`) sat outside the options table and rendered as raw pipe text;

## Motivation

The reference page must render every option.

## Conformance impact

None.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention
