### PR TITLE
docs: point the metadata link at the libphonenumber master

### DIFF
--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -1532,7 +1532,7 @@ const closedTypesCode = `controller.setRegion('USA')
             <p>
               Telixon compiles Google libphonenumber's <a
                 class="link-green"
-                href="https://github.com/google/libphonenumber/blob/2b407afb2e005e5c2b3056881ecca3830e2dc585/resources/PhoneNumberMetadata.xml"
+                href="https://github.com/google/libphonenumber/blob/master/resources/PhoneNumberMetadata.xml"
                 target="_blank"
                 rel="noreferrer">metadata and rules</a
               > into a deterministic finite automaton (DFA), stored as compact binary tables. Most libraries interpret those


### PR DESCRIPTION
## Summary

The landing page link to Google's metadata file points at the libphonenumber master branch instead of a frozen commit.

## Motivation

The pinned-commit link went stale on every metadata refresh; the exact pin already lives in PROVENANCE.json.

## Conformance impact

None.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention