### PR TITLE
feat(core): delete through formatting characters in one press

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to `@telixon/core` are documented in this file. The format f
 
 ## [Unreleased]
 
+### Changed
+
+- Backspace and forward delete treat formatting characters as transparent and consume the nearest
+  digit on the edit side in one press.
+
 ## [1.0.1] - 2026-08-23
 
 ### Changed

--- a/packages/core/src/modules/input-controller/international-input-controller/__tests__/delete-operations.test.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/__tests__/delete-operations.test.ts
@@ -6,16 +6,16 @@ const US_MOBILE = getExampleNumber('US', 'MOBILE');
 const US_MOBILE_INTL = '1' + US_MOBILE;
 
 describe('InternationalInputController.deleteBackward', () => {
-  it('snaps caret past the trailing space separator when no national digits exist (structural)', () => {
+  it('deletes the calling-code digit through the trailing structural separator', () => {
     const controller = createInternationalInputController({ defaultRegion: 'US' });
-    // '1 ' with caret at end: the separator is structurally re-added on resolve, so backspace snaps the caret after the calling-code digit.
+    // '1 ' with caret at end: the separator is transparent, backspace consumes the calling-code digit.
     const state = controller.deleteBackward('1 ', 2, 2);
 
-    expect(state.value).toBe('1 ');
-    expect(state.selectionStart).toBe(1);
+    expect(state.value).toBe('');
+    expect(state.selectionStart).toBe(0);
   });
 
-  it('strips trailing formatting after a partial national number without losing a digit', () => {
+  it('deletes the last digit through a trailing formatting character', () => {
     const controller = createInternationalInputController({ defaultRegion: 'US' });
     const seeded = controller.setValue('1212');
     const valueWithTrailingFormatter = `${seeded.value}-`;
@@ -23,8 +23,8 @@ describe('InternationalInputController.deleteBackward', () => {
 
     const state = controller.deleteBackward(valueWithTrailingFormatter, caret, caret);
 
-    // All four national digits remain; only the trailing dash is removed.
-    expect(state.value.replace(/\D/g, '')).toBe('1212');
+    // The trailing dash is transparent: backspace consumes the last digit and the value reformats.
+    expect(state.value.replace(/\D/g, '')).toBe('121');
     expect(state.value.endsWith('-')).toBe(false);
     expect(state.selectionStart).toBe(state.value.length);
   });
@@ -81,7 +81,7 @@ describe('InternationalInputController.deleteForward', () => {
     expect(state.value.replace(/\D/g, '')).toBe('1' + US_MOBILE.slice(1));
   });
 
-  it('keeps the "+" under forward delete at position 0 when plusPrefix is \'fixed\'', () => {
+  it('keeps the "+" and deletes the first digit under forward delete at position 0 (fixed plus)', () => {
     const controller = createInternationalInputController({
       defaultRegion: 'US',
       display: { callingCodeInInput: true, plusPrefix: 'fixed' },
@@ -91,7 +91,7 @@ describe('InternationalInputController.deleteForward', () => {
     const state = controller.deleteForward(seeded.value, 0, 0);
 
     expect(state.value.startsWith('+')).toBe(true);
-    expect(state.value.replace(/\D/g, '')).toBe(US_MOBILE_INTL);
+    expect(state.value.replace(/\D/g, '')).toBe(US_MOBILE_INTL.slice(1));
   });
 });
 

--- a/packages/core/src/modules/input-controller/international-input-controller/international-input-controller.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/international-input-controller.ts
@@ -10,13 +10,7 @@ import { createPhoneNumber, PhoneNumber, toResolvedPhoneNumber } from '../../pho
 import { InputStateHistory } from '../input-state-history';
 import { InputChange, InputController, InputControllerState, InputState } from '../models';
 
-import {
-  findNextDigitPosition,
-  findPreviousDigitPosition,
-  isFormattingChar,
-  toInputState,
-  toInputStateWithSelection,
-} from '../utils';
+import { findNextDigitPosition, findPreviousDigitPosition, toInputState, toInputStateWithSelection } from '../utils';
 import { resolveInput } from '../utils/resolve-input';
 import { InternationalInputControllerConfig } from './models';
 import { resolveInternationalControllerState } from './utils';
@@ -159,41 +153,6 @@ class InternationalInputController implements InputController {
       return toInputState(this.#history.current);
     }
 
-    if (selectionStart === selectionEnd && isFormattingChar(value, selectionStart - 1)) {
-      if (findNextDigitPosition(value, selectionStart) !== -1) {
-        const prevDigit: number = findPreviousDigitPosition(value, selectionStart);
-        if (prevDigit === -1) {
-          this.#history.updateCurrentSelection(selectionStart, selectionStart);
-          return toInputStateWithSelection(this.#history.current, selectionStart, selectionStart);
-        }
-        const pos: number = prevDigit + 1;
-        this.#history.updateCurrentSelection(pos, pos);
-        return toInputStateWithSelection(this.#history.current, pos, pos);
-      }
-
-      this.#history.updateCurrentSelection(selectionStart, selectionEnd);
-
-      const trimmedState: InputControllerState = this.#resolveState(
-        value,
-        { insertText: '', selectionStart, selectionEnd },
-        'backward',
-        this.#plusErased,
-      );
-
-      if (trimmedState.value.length < value.length) {
-        this.#history.push(trimmedState);
-        return toInputState(this.#history.current);
-      }
-
-      const prevDigit: number = findPreviousDigitPosition(value, selectionStart);
-      if (prevDigit === -1) {
-        return toInputStateWithSelection(this.#history.current, selectionStart, selectionStart);
-      }
-      const pos: number = prevDigit + 1;
-      this.#history.updateCurrentSelection(pos, pos);
-      return toInputStateWithSelection(this.#history.current, pos, pos);
-    }
-
     let effectiveStart: number = selectionStart;
     let effectiveEnd: number = selectionEnd;
 
@@ -236,13 +195,6 @@ class InternationalInputController implements InputController {
         this.#resolveState(value, { insertText: '', selectionStart: 0, selectionEnd: 0 }, 'forward', true),
       );
       return toInputState(this.#history.current);
-    }
-
-    if (selectionStart === selectionEnd && isFormattingChar(value, selectionStart)) {
-      const nextDigit: number = findNextDigitPosition(value, selectionStart + 1);
-      const pos: number = nextDigit === -1 ? selectionStart : nextDigit;
-      this.#history.updateCurrentSelection(pos, pos);
-      return toInputStateWithSelection(this.#history.current, pos, pos);
     }
 
     this.#history.updateCurrentSelection(selectionStart, selectionEnd);

--- a/packages/core/src/modules/input-controller/national-input-controller/__tests__/delete-operations.test.ts
+++ b/packages/core/src/modules/input-controller/national-input-controller/__tests__/delete-operations.test.ts
@@ -17,15 +17,15 @@ describe('NationalInputController.deleteBackward', () => {
     expect(state.selectionEnd).toBe(0);
   });
 
-  it('snaps caret past a formatting char without deleting a digit (caret just after "011 ")', () => {
+  it('deletes the digit before the caret through a formatting char (caret just after "011 ")', () => {
     const controller = createNationalInputController({ defaultRegion: 'AR' });
     controller.setValue(AR_RAW);
-    // Position 4 is right after "011 ": char at index 3 is the space.
+    // Position 4 is right after "011 ": the separator is transparent, the nearest digit to the left goes.
     const state = controller.deleteBackward(AR_FORMATTED, 4, 4);
 
-    expect(state.value).toBe(AR_FORMATTED);
-    expect(state.selectionStart).toBe(3);
-    expect(state.selectionEnd).toBe(3);
+    expect(state.value.replace(/\D/g, '')).toBe('011534343444');
+    expect(state.selectionStart).toBe(2);
+    expect(state.selectionEnd).toBe(2);
   });
 
   it('removes the last digit and trims trailing formatting (direction backward)', () => {
@@ -51,14 +51,14 @@ describe('NationalInputController.deleteBackward', () => {
 });
 
 describe('NationalInputController.deleteForward', () => {
-  it('snaps caret forward past a formatting char (caret on the space at index 3)', () => {
+  it('deletes the next digit through a formatting char (caret on the space at index 3)', () => {
     const controller = createNationalInputController({ defaultRegion: 'AR' });
     controller.setValue(AR_RAW);
     const state = controller.deleteForward(AR_FORMATTED, 3, 3);
 
-    expect(state.value).toBe(AR_FORMATTED);
-    // Caret should jump to the next digit position (index 4).
-    expect(state.selectionStart).toBe(4);
+    expect(state.value.replace(/\D/g, '')).toBe('011534343444');
+    expect(state.selectionStart).toBe(3);
+    expect(state.selectionEnd).toBe(3);
   });
 
   it('is a no-op when caret is at the end of the value', () => {

--- a/packages/core/src/modules/input-controller/national-input-controller/national-input-controller.ts
+++ b/packages/core/src/modules/input-controller/national-input-controller/national-input-controller.ts
@@ -16,13 +16,7 @@ import { getNationalPrefixRules } from '../../number-resolver/utils/get-national
 import { createPhoneNumber, PhoneNumber, toResolvedPhoneNumber } from '../../phone-number';
 import { InputStateHistory } from '../input-state-history';
 import { InputChange, InputController, InputState } from '../models';
-import {
-  findNextDigitPosition,
-  findPreviousDigitPosition,
-  isFormattingChar,
-  toInputState,
-  toInputStateWithSelection,
-} from '../utils';
+import { findNextDigitPosition, findPreviousDigitPosition, toInputState, toInputStateWithSelection } from '../utils';
 import { resolveInput } from '../utils/resolve-input';
 import { NationalControllerState, NationalInputControllerConfig } from './models';
 import { resolveNationalControllerState } from './utils';
@@ -183,34 +177,6 @@ class NationalInputController implements InputController {
       return toInputStateWithSelection(this.#history.current, 0, 0);
     }
 
-    if (selectionStart === selectionEnd && isFormattingChar(value, selectionStart - 1)) {
-      if (findNextDigitPosition(value, selectionStart) !== -1) {
-        const prevDigit: number = findPreviousDigitPosition(value, selectionStart);
-        const pos: number = prevDigit === -1 ? 0 : prevDigit + 1;
-        this.#history.updateCurrentSelection(pos, pos);
-        return toInputStateWithSelection(this.#history.current, pos, pos);
-      }
-
-      this.#history.updateCurrentSelection(selectionStart, selectionEnd);
-
-      const trimmedState: NationalControllerState = this.#resolveFromEdit(
-        value,
-        { insertText: '', selectionStart, selectionEnd },
-        'backward',
-        true,
-      );
-
-      if (trimmedState.value.length < value.length) {
-        this.#history.push(trimmedState);
-        return toInputState(this.#history.current);
-      }
-
-      const prevDigit: number = findPreviousDigitPosition(value, selectionStart);
-      const pos: number = prevDigit === -1 ? 0 : prevDigit + 1;
-      this.#history.updateCurrentSelection(pos, pos);
-      return toInputStateWithSelection(this.#history.current, pos, pos);
-    }
-
     let effectiveStart: number = selectionStart;
     let effectiveEnd: number = selectionEnd;
 
@@ -242,13 +208,6 @@ class NationalInputController implements InputController {
   }
 
   deleteForward(value: string, selectionStart: number, selectionEnd: number): InputState {
-    if (selectionStart === selectionEnd && isFormattingChar(value, selectionStart)) {
-      const nextDigit: number = findNextDigitPosition(value, selectionStart + 1);
-      const pos: number = nextDigit === -1 ? selectionStart : nextDigit;
-      this.#history.updateCurrentSelection(pos, pos);
-      return toInputStateWithSelection(this.#history.current, pos, pos);
-    }
-
     this.#history.updateCurrentSelection(selectionStart, selectionEnd);
 
     let effectiveStart: number = selectionStart;


### PR DESCRIPTION
## Summary

Backspace and forward delete treat formatting characters as transparent and consume the nearest digit on the edit side in one press. The delete-operation specs are updated to the new behavior.

## Motivation

One press per digit matches how native phone fields behave near separators.

## Conformance impact

None.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention