### PR TITLE
docs: add npm version badges for the shipped packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,14 @@ a divergence the gate misses?
 
 ## Packages
 
-| Package                                          | Status  | Role                                  |
-| ------------------------------------------------ | ------- | ------------------------------------- |
-| [`@telixon/core`](packages/core/README.md)       | shipped | parsing, formatting, validation       |
-| [`@telixon/web-sdk`](packages/web-sdk/README.md) | shipped | headless phone-field widgets          |
-| `@telixon/web-components`                        | planned | drop-in Web Component (`<tel-input>`) |
-| `@telixon/angular`                               | planned | Angular binding                       |
-| `@telixon/react`                                 | planned | React binding (hook + component)      |
-| `@telixon/vue`                                   | planned | Vue binding                           |
+| Package                                          | Version                                                                                                                            | Status  | Role                                  |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------- |
+| [`@telixon/core`](packages/core/README.md)       | [![npm](https://img.shields.io/npm/v/%40telixon%2Fcore?color=26997b&label=npm)](https://www.npmjs.com/package/@telixon/core)       | shipped | parsing, formatting, validation       |
+| [`@telixon/web-sdk`](packages/web-sdk/README.md) | [![npm](https://img.shields.io/npm/v/%40telixon%2Fweb-sdk?color=26997b&label=npm)](https://www.npmjs.com/package/@telixon/web-sdk) | shipped | headless phone-field widgets          |
+| `@telixon/web-components`                        |                                                                                                                                    | planned | drop-in Web Component (`<tel-input>`) |
+| `@telixon/angular`                               |                                                                                                                                    | planned | Angular binding                       |
+| `@telixon/react`                                 |                                                                                                                                    | planned | React binding (hook + component)      |
+| `@telixon/vue`                                   |                                                                                                                                    | planned | Vue binding                           |
 
 ## Support
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5,6 +5,7 @@ Phone-number parser, formatter, and validator built on Google libphonenumber met
 [![conformance](https://img.shields.io/endpoint?url=https://proof.telixon.dev/parity-badge.json)](https://proof.telixon.dev/parity.html)
 [![benchmarks](https://img.shields.io/endpoint?url=https://proof.telixon.dev/bench-badge.json)](https://proof.telixon.dev/benchmark.html)
 [![initial bundle](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fregistry.npmjs.org%2F%40telixon%2Fcore%2Flatest&query=%24.bundleSize&label=initial%20bundle&color=26997b)](https://www.npmjs.com/package/@telixon/core)
+[![downloads](https://img.shields.io/npm/dm/%40telixon%2Fcore?color=26997b&label=downloads)](https://www.npmjs.com/package/@telixon/core)
 
 **[Documentation](https://telixon.dev/core/)** &middot; **[Live demo](https://telixon.dev/web-sdk/guides/complete-field/)**
 

--- a/packages/web-sdk/README.md
+++ b/packages/web-sdk/README.md
@@ -5,6 +5,7 @@ The DOM adapter for [`@telixon/core`](https://www.npmjs.com/package/@telixon/cor
 [![conformance](https://img.shields.io/endpoint?url=https://proof.telixon.dev/parity-badge.json)](https://proof.telixon.dev/parity.html)
 [![benchmarks](https://img.shields.io/endpoint?url=https://proof.telixon.dev/bench-badge.json)](https://proof.telixon.dev/benchmark.html)
 [![initial bundle](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fregistry.npmjs.org%2F%40telixon%2Fweb-sdk%2Flatest&query=%24.bundleSize&label=initial%20bundle&color=26997b)](https://www.npmjs.com/package/@telixon/web-sdk)
+[![downloads](https://img.shields.io/npm/dm/%40telixon%2Fweb-sdk?color=26997b&label=downloads)](https://www.npmjs.com/package/@telixon/web-sdk)
 
 **[Documentation](https://telixon.dev/web-sdk/)** &middot; **[Live demo](https://telixon.dev/web-sdk/guides/complete-field/)**
 


### PR DESCRIPTION
## Summary

The packages table in the root README gains a Version column with live npm badges, and both package READMEs close their badge rows with a monthly downloads badge linking to the npm page.

## Motivation

The path from the repository to npm was not clickable anywhere.

## Conformance impact

None.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention