### PR TITLE
fix(core): harden selection, paste, region, and bad-input handling

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to `@telixon/core` are documented in this file. The format f
 
 ## [Unreleased]
 
+### Fixed
+
+- An insert without digits typed over a selection consumes the selected digits instead of keeping
+  them, matching native input behavior.
+- An international paste that repeats the calling code the field already shows drops the duplicate
+  code when the raw digits cannot resolve.
+- `InputState.region` reports `null` once the typed digits can no longer complete a calling code,
+  as the contract documents.
+- `parsePhoneNumber` and the controller methods coerce non-string runtime input to a string,
+  keeping the documented no-throw contract for plain JavaScript callers.
+
 ## [1.1.0] - 2026-08-27
 
 ### Changed

--- a/packages/core/src/modules/input-controller/international-input-controller/__tests__/edit-hardening.test.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/__tests__/edit-hardening.test.ts
@@ -1,0 +1,127 @@
+import { getExampleNumber } from '@telixon/core/testing';
+import { describe, expect, it } from 'vitest';
+import { createInternationalInputController } from '..';
+
+const US_MOBILE = getExampleNumber('US', 'MOBILE');
+const US_MOBILE_INTL = '1' + US_MOBILE;
+
+function digitsOf(value: string): string {
+  return value.replace(/\D/g, '');
+}
+
+describe('InternationalInputController select-all overwrite', () => {
+  it('consumes the selection when a "+" is typed over the whole value', () => {
+    const controller = createInternationalInputController({
+      defaultRegion: 'US',
+      display: { callingCodeInInput: true, plusPrefix: 'erasable' },
+    });
+    const seeded = controller.setValue('+' + US_MOBILE_INTL);
+
+    const overwritten = controller.insert(seeded.value, '+', 0, seeded.value.length);
+
+    expect(digitsOf(overwritten.value)).toBe('');
+    expect(overwritten.value).toBe('+');
+
+    const typed = controller.insert(overwritten.value, '3', 1, 1);
+    expect(digitsOf(typed.value)).toBe('3');
+  });
+
+  it('consumes the selection when a letter is typed over the whole value', () => {
+    const controller = createInternationalInputController({ defaultRegion: 'US' });
+    const seeded = controller.setValue(US_MOBILE_INTL);
+
+    const overwritten = controller.insert(seeded.value, 'x', 0, seeded.value.length);
+
+    expect(digitsOf(overwritten.value)).toBe('');
+  });
+});
+
+describe('InternationalInputController pasted calling-code dedupe', () => {
+  it('drops the duplicated calling code when pasting a full number after the seeded code', () => {
+    const controller = createInternationalInputController({ defaultRegion: 'US' });
+    const seeded = controller.currentState;
+
+    const pasted = controller.insert(seeded.value, '1 ' + US_MOBILE, seeded.value.length, seeded.value.length);
+
+    expect(digitsOf(pasted.value)).toBe(US_MOBILE_INTL);
+    expect(controller.getPhoneNumber().formatE164()).toBe('+' + US_MOBILE_INTL);
+  });
+
+  it('drops the duplicated calling code for a plus-prefixed paste', () => {
+    const controller = createInternationalInputController({ defaultRegion: 'US' });
+    const seeded = controller.currentState;
+
+    const pasted = controller.insert(seeded.value, '+1 ' + US_MOBILE, seeded.value.length, seeded.value.length);
+
+    expect(digitsOf(pasted.value)).toBe(US_MOBILE_INTL);
+  });
+
+  it('dedupes against the hidden seeded code when the calling code is not in the input', () => {
+    const controller = createInternationalInputController({
+      defaultRegion: 'US',
+      display: { callingCodeInInput: false },
+    });
+
+    const pasted = controller.insert('', '1' + US_MOBILE, 0, 0);
+
+    expect(digitsOf(pasted.value)).toBe(US_MOBILE);
+    expect(controller.getPhoneNumber().formatE164()).toBe('+' + US_MOBILE_INTL);
+  });
+
+  it('keeps every digit when the national number legitimately starts with the code digits', () => {
+    const controller = createInternationalInputController({ defaultRegion: 'IT' });
+    const seeded = controller.currentState;
+
+    const pasted = controller.insert(seeded.value, '3931234567', seeded.value.length, seeded.value.length);
+
+    expect(digitsOf(pasted.value)).toBe('393931234567');
+  });
+
+  it('keeps every digit for inserts below the paste threshold', () => {
+    const controller = createInternationalInputController({ defaultRegion: 'US' });
+    const seeded = controller.currentState;
+
+    const typed = controller.insert(seeded.value, '1201', seeded.value.length, seeded.value.length);
+
+    expect(digitsOf(typed.value)).toBe('11201');
+  });
+
+  it('keeps every digit when the paste replaces the whole value', () => {
+    const controller = createInternationalInputController({ defaultRegion: 'US' });
+    const seeded = controller.currentState;
+
+    const pasted = controller.insert(seeded.value, '1 ' + US_MOBILE, 0, seeded.value.length);
+
+    expect(digitsOf(pasted.value)).toBe(US_MOBILE_INTL);
+  });
+});
+
+describe('InternationalInputController region on dead prefixes', () => {
+  it('reports null once the typed digits can no longer complete a calling code', () => {
+    const controller = createInternationalInputController();
+
+    expect(controller.setValue('+9991234567').region).toBeNull();
+    expect(controller.setValue('+888').region).toBeNull();
+    expect(controller.setValue('+80012345678').region).toBeNull();
+  });
+
+  it('keeps the resolved region for a completed calling code', () => {
+    const controller = createInternationalInputController();
+
+    expect(controller.setValue('+1').region).toBe('US');
+    expect(controller.setValue('+44').region).toBe('GB');
+  });
+});
+
+describe('InternationalInputController bad input', () => {
+  it('treats a null value or text as empty instead of throwing', () => {
+    const controller = createInternationalInputController({ defaultRegion: 'US' });
+
+    expect(() => controller.setValue(null as unknown as string)).not.toThrow();
+    expect(digitsOf(controller.currentState.value)).toBe('');
+
+    expect(() => controller.insert(null as unknown as string, null as unknown as string, 0, 0)).not.toThrow();
+    expect(() => controller.deleteBackward(null as unknown as string, 1, 1)).not.toThrow();
+    expect(() => controller.deleteForward(null as unknown as string, 0, 0)).not.toThrow();
+  });
+});

--- a/packages/core/src/modules/input-controller/international-input-controller/international-input-controller.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/international-input-controller.ts
@@ -1,6 +1,7 @@
 import { getMetadataRegionCallingCode, NumberType, RegionCode } from '@telixon/core/engine';
 import { getResourceProvider } from '@telixon/core/resource-provider';
 import { requireEngineReady } from '@telixon/core/utils/require-engine-ready';
+import { toInputString } from '@telixon/core/utils/to-input-string';
 import { NumberResolver } from '../../number-resolver';
 import { NumberResolverSnapshot, NumberTypeProfileRef } from '../../number-resolver/models';
 import { ResolvedNumberState, resolveNumber } from '../../number-resolver/resolve-number';
@@ -10,10 +11,24 @@ import { createPhoneNumber, PhoneNumber, toResolvedPhoneNumber } from '../../pho
 import { InputStateHistory } from '../input-state-history';
 import { InputChange, InputController, InputControllerState, InputState } from '../models';
 
-import { findNextDigitPosition, findPreviousDigitPosition, toInputState, toInputStateWithSelection } from '../utils';
+import {
+  collectDigits,
+  findNextDigitPosition,
+  findPreviousDigitPosition,
+  toInputState,
+  toInputStateWithSelection,
+} from '../utils';
 import { resolveInput } from '../utils/resolve-input';
 import { InternationalInputControllerConfig } from './models';
 import { resolveInternationalControllerState } from './utils';
+
+function hasDigitAtOrAfter(value: string, index: number): boolean {
+  for (let i = index; i < value.length; i++) {
+    const charCode: number = value.charCodeAt(i);
+    if (charCode >= 48 && charCode <= 57) return true;
+  }
+  return false;
+}
 
 class InternationalInputController implements InputController {
   #history!: InputStateHistory<InputControllerState>;
@@ -117,12 +132,45 @@ class InternationalInputController implements InputController {
     return this.#plusErasable && selectionStart === 0 && selectionEnd > 0 && value.startsWith('+');
   }
 
-  insert(value: string, text: string, selectionStart: number, selectionEnd: number): InputState {
+  // A pasted number often repeats the calling code the field already shows. When the raw read dies
+  // on the doubled code, the insert retries with the duplicate stripped and keeps the resolvable read.
+  #dedupedCallingCodeInsert(
+    value: string,
+    insertText: string,
+    selectionStart: number,
+    selectionEnd: number,
+    plusErased: boolean,
+  ): InputControllerState | null {
+    const snapshot: NumberResolverSnapshot = this.#history.current.snapshot;
+    const callingCode: string = snapshot.callingCodeDigits;
+    if (callingCode === '' || !snapshot.callingCodeCompleted || snapshot.nationalDigits !== '') return null;
+
+    const insertedDigits: string = collectDigits(insertText);
+    if (insertedDigits.length < callingCode.length + 4) return null;
+    if (!insertedDigits.startsWith(callingCode)) return null;
+    if (hasDigitAtOrAfter(value, selectionStart)) return null;
+
+    return this.#resolveState(
+      value,
+      {
+        insertText: insertedDigits.slice(callingCode.length),
+        selectionStart,
+        selectionEnd,
+      },
+      'forward',
+      plusErased,
+    );
+  }
+
+  insert(rawValue: string, rawText: string, selectionStart: number, selectionEnd: number): InputState {
+    const value: string = toInputString(rawValue);
+    const text: string = toInputString(rawText);
     this.#history.updateCurrentSelection(selectionStart, selectionEnd);
 
     const plusRestored: boolean = selectionStart === 0 && text.startsWith('+');
+    const plusErased: boolean = this.#plusErased && !plusRestored;
 
-    const nextState: InputControllerState = this.#resolveState(
+    let nextState: InputControllerState = this.#resolveState(
       value,
       {
         insertText: text,
@@ -130,15 +178,27 @@ class InternationalInputController implements InputController {
         selectionEnd,
       },
       'forward',
-      this.#plusErased && !plusRestored,
+      plusErased,
     );
+
+    if (nextState.profileRef === null && text.length >= 5) {
+      const dedupedState: InputControllerState | null = this.#dedupedCallingCodeInsert(
+        value,
+        text,
+        selectionStart,
+        selectionEnd,
+        plusErased,
+      );
+      if (dedupedState !== null && dedupedState.profileRef !== null) nextState = dedupedState;
+    }
 
     this.#history.push(nextState);
 
     return toInputState(this.#history.current);
   }
 
-  deleteBackward(value: string, selectionStart: number, selectionEnd: number): InputState {
+  deleteBackward(rawValue: string, selectionStart: number, selectionEnd: number): InputState {
+    const value: string = toInputString(rawValue);
     if (selectionStart === 0 && selectionEnd === 0) {
       this.#history.updateCurrentSelection(0, 0);
       return toInputStateWithSelection(this.#history.current, 0, 0);
@@ -187,7 +247,8 @@ class InternationalInputController implements InputController {
     return toInputState(this.#history.current);
   }
 
-  deleteForward(value: string, selectionStart: number, selectionEnd: number): InputState {
+  deleteForward(rawValue: string, selectionStart: number, selectionEnd: number): InputState {
+    const value: string = toInputString(rawValue);
     // Forward delete with the caret on a visible erasable plus erases the plus and keeps the digits.
     if (this.#plusErasable && selectionStart === 0 && selectionEnd === 0 && value.startsWith('+')) {
       this.#history.updateCurrentSelection(0, 0);
@@ -225,7 +286,8 @@ class InternationalInputController implements InputController {
     return toInputState(this.#history.current);
   }
 
-  setValue(value: string): InputState {
+  setValue(rawValue: string): InputState {
+    const value: string = toInputString(rawValue);
     // Re-setting the exact current value leaves the rendering untouched and only moves the caret to the end.
     if (value === this.#history.current.value) {
       const end: number = value.length;

--- a/packages/core/src/modules/input-controller/international-input-controller/utils/resolve-international-controller-state.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/utils/resolve-international-controller-state.ts
@@ -85,7 +85,9 @@ export function resolveInternationalControllerState(
         regionIndex,
       );
     }
-  } else if (snapshot.callingCodeState !== -1) {
+  } else if (snapshot.callingCodeState !== -1 && (snapshot.callingCodeCompleted || snapshot.nationalDigits === '')) {
+    // A completed code or one still being typed reports its primary region. National digits under
+    // an incomplete code mean the walk died mid-code, and a dead prefix resolves to no region.
     const primaryRegionIndex: number = resolvePrimaryRegionIndex(snapshot.callingCodeState, -1);
 
     region = resourceProvider.regionIds[primaryRegionIndex] ?? null;

--- a/packages/core/src/modules/input-controller/national-input-controller/__tests__/bad-input.test.ts
+++ b/packages/core/src/modules/input-controller/national-input-controller/__tests__/bad-input.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { createNationalInputController } from '..';
+
+describe('NationalInputController bad input', () => {
+  it('treats a null value or text as empty instead of throwing', () => {
+    const controller = createNationalInputController({ defaultRegion: 'US' });
+
+    expect(() => controller.setValue(null as unknown as string)).not.toThrow();
+    expect(controller.currentState.value).toBe('');
+
+    expect(() => controller.insert(null as unknown as string, null as unknown as string, 0, 0)).not.toThrow();
+    expect(() => controller.deleteBackward(null as unknown as string, 1, 1)).not.toThrow();
+    expect(() => controller.deleteForward(null as unknown as string, 0, 0)).not.toThrow();
+  });
+
+  it('consumes a selection overwritten by a digit-less insert', () => {
+    const controller = createNationalInputController({ defaultRegion: 'US' });
+    const seeded = controller.setValue('4155550132');
+
+    const overwritten = controller.insert(seeded.value, '+', 0, seeded.value.length);
+
+    expect(overwritten.value.replace(/\D/g, '')).toBe('');
+  });
+});

--- a/packages/core/src/modules/input-controller/national-input-controller/national-input-controller.ts
+++ b/packages/core/src/modules/input-controller/national-input-controller/national-input-controller.ts
@@ -7,6 +7,7 @@ import {
 } from '@telixon/core/engine';
 import { getResourceProvider } from '@telixon/core/resource-provider';
 import { requireEngineReady } from '@telixon/core/utils/require-engine-ready';
+import { toInputString } from '@telixon/core/utils/to-input-string';
 import { NumberResolver } from '../../number-resolver';
 import { NumberResolverSnapshot, NumberTypeProfileRef } from '../../number-resolver/models';
 import { ResolvedNumberState, resolveNumber } from '../../number-resolver/resolve-number';
@@ -16,7 +17,13 @@ import { getNationalPrefixRules } from '../../number-resolver/utils/get-national
 import { createPhoneNumber, PhoneNumber, toResolvedPhoneNumber } from '../../phone-number';
 import { InputStateHistory } from '../input-state-history';
 import { InputChange, InputController, InputState } from '../models';
-import { findNextDigitPosition, findPreviousDigitPosition, toInputState, toInputStateWithSelection } from '../utils';
+import {
+  collectDigits,
+  findNextDigitPosition,
+  findPreviousDigitPosition,
+  toInputState,
+  toInputStateWithSelection,
+} from '../utils';
 import { resolveInput } from '../utils/resolve-input';
 import { NationalControllerState, NationalInputControllerConfig } from './models';
 import { resolveNationalControllerState } from './utils';
@@ -28,15 +35,6 @@ function hasTypedNationalPrefix(rawDigits: string, prefixRules: NationalPrefixRu
   }
 
   return rawDigits.startsWith(prefixRules.nationalPrefix);
-}
-
-function collectDigits(text: string): string {
-  let digits = '';
-  for (let index = 0; index < text.length; index++) {
-    const charCode: number = text.charCodeAt(index);
-    if (charCode >= 48 && charCode <= 57) digits += text[index];
-  }
-  return digits;
 }
 
 class NationalInputController implements InputController {
@@ -137,15 +135,12 @@ class NationalInputController implements InputController {
     const current: NationalControllerState = this.#history.current;
     if (value === current.value) {
       const insertedDigits: string = collectDigits(change.insertText);
-      // An insert without digits keeps the selected digits, same as resolveInput.
-      const keepsSelection: boolean = change.insertText.length > 0 && insertedDigits.length === 0;
-      const selectionEnd: number = keepsSelection ? change.selectionStart : change.selectionEnd;
       const range = typedRangeForSelection(
         current.alignment,
         current.rawDigits.length,
         value,
         change.selectionStart,
-        selectionEnd,
+        change.selectionEnd,
       );
       const typedDigits: string =
         current.rawDigits.slice(0, range.start) + insertedDigits + current.rawDigits.slice(range.end);
@@ -164,14 +159,19 @@ class NationalInputController implements InputController {
   }
 
   insert(value: string, text: string, selectionStart: number, selectionEnd: number): InputState {
+    const safeValue: string = toInputString(value);
+    const safeText: string = toInputString(text);
     this.#history.updateCurrentSelection(selectionStart, selectionEnd);
 
-    this.#history.push(this.#resolveFromEdit(value, { insertText: text, selectionStart, selectionEnd }, 'forward'));
+    this.#history.push(
+      this.#resolveFromEdit(safeValue, { insertText: safeText, selectionStart, selectionEnd }, 'forward'),
+    );
 
     return toInputState(this.#history.current);
   }
 
-  deleteBackward(value: string, selectionStart: number, selectionEnd: number): InputState {
+  deleteBackward(rawValue: string, selectionStart: number, selectionEnd: number): InputState {
+    const value: string = toInputString(rawValue);
     if (selectionStart === 0 && selectionEnd === 0) {
       this.#history.updateCurrentSelection(0, 0);
       return toInputStateWithSelection(this.#history.current, 0, 0);
@@ -207,7 +207,8 @@ class NationalInputController implements InputController {
     return toInputState(this.#history.current);
   }
 
-  deleteForward(value: string, selectionStart: number, selectionEnd: number): InputState {
+  deleteForward(rawValue: string, selectionStart: number, selectionEnd: number): InputState {
+    const value: string = toInputString(rawValue);
     this.#history.updateCurrentSelection(selectionStart, selectionEnd);
 
     let effectiveStart: number = selectionStart;
@@ -232,7 +233,8 @@ class NationalInputController implements InputController {
     return toInputState(this.#history.current);
   }
 
-  setValue(value: string): InputState {
+  setValue(rawValue: string): InputState {
+    const value: string = toInputString(rawValue);
     // Re-setting the exact current value leaves the rendering untouched and only moves the caret to the end.
     if (value === this.#history.current.value) {
       const end: number = value.length;

--- a/packages/core/src/modules/input-controller/utils/__tests__/resolve-input.test.ts
+++ b/packages/core/src/modules/input-controller/utils/__tests__/resolve-input.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { resolveInput } from '../resolve-input';
+
+function run(value: string, insertText: string, selectionStart: number, selectionEnd: number) {
+  let digits = '';
+  const caretIndex = resolveInput(value, { insertText, selectionStart, selectionEnd }, (digit) => {
+    digits += String(digit);
+  });
+  return { digits, caretIndex };
+}
+
+describe('resolveInput selection semantics', () => {
+  it('consumes the selected digits when the inserted text carries none', () => {
+    expect(run('123456', '+', 1, 4)).toEqual({ digits: '156', caretIndex: 1 });
+  });
+
+  it('consumes the selected digits on a plain deletion', () => {
+    expect(run('123456', '', 1, 4)).toEqual({ digits: '156', caretIndex: 1 });
+  });
+
+  it('replaces the selected digits with the inserted ones', () => {
+    expect(run('123456', '9', 1, 4)).toEqual({ digits: '1956', caretIndex: 2 });
+  });
+
+  it('keeps every digit when a digit-less insert lands on a collapsed caret', () => {
+    expect(run('123456', '+', 2, 2)).toEqual({ digits: '123456', caretIndex: 2 });
+  });
+
+  it('reads formatted values digit-by-digit around the selection', () => {
+    expect(run('(415) 555-0132', '9', 6, 9)).toEqual({ digits: '41590132', caretIndex: 4 });
+  });
+});

--- a/packages/core/src/modules/input-controller/utils/collect-digits.ts
+++ b/packages/core/src/modules/input-controller/utils/collect-digits.ts
@@ -1,0 +1,9 @@
+/** Extracts the ASCII digits of a string in order. */
+export function collectDigits(text: string): string {
+  let digits = '';
+  for (let index = 0; index < text.length; index++) {
+    const charCode: number = text.charCodeAt(index);
+    if (charCode >= 48 && charCode <= 57) digits += text[index];
+  }
+  return digits;
+}

--- a/packages/core/src/modules/input-controller/utils/index.ts
+++ b/packages/core/src/modules/input-controller/utils/index.ts
@@ -1,5 +1,6 @@
 import { InputControllerState, InputState } from '../models';
 
+export { collectDigits } from './collect-digits';
 export { findNextDigitPosition, findPreviousDigitPosition, isFormattingChar } from './find-digit-position';
 
 export const toInputState = (state: InputControllerState): InputState => {

--- a/packages/core/src/modules/input-controller/utils/resolve-input.ts
+++ b/packages/core/src/modules/input-controller/utils/resolve-input.ts
@@ -19,7 +19,6 @@ export function resolveInput(
 
   let digit: number;
   let digitIndex = 0;
-  let insertedDigitCount = 0;
 
   // ---- BEFORE ----
   for (let i = 0; i < selectionStart; i++) {
@@ -35,14 +34,12 @@ export function resolveInput(
     if (digit < 0 || digit > 9) continue;
     onDigit(digit, digitIndex);
     digitIndex++;
-    insertedDigitCount++;
   }
 
   const caretIndex: number = digitIndex;
-  const afterStart: number = insertedDigitCount === 0 && change.insertText.length > 0 ? selectionStart : selectionEnd;
 
   // ---- AFTER ----
-  for (let i = afterStart; i < valueLength; i++) {
+  for (let i = selectionEnd; i < valueLength; i++) {
     digit = value.charCodeAt(i) - 48;
     if (digit < 0 || digit > 9) continue;
     onDigit(digit, digitIndex);

--- a/packages/core/src/modules/parse-phone-number/__tests__/bad-input.test.ts
+++ b/packages/core/src/modules/parse-phone-number/__tests__/bad-input.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { parsePhoneNumber } from '..';
+
+describe('parsePhoneNumber bad input', () => {
+  it('reports EMPTY for null and undefined instead of throwing', () => {
+    for (const badInput of [null, undefined]) {
+      const phoneNumber = parsePhoneNumber(badInput as unknown as string);
+
+      expect(phoneNumber.isValid()).toBe(false);
+      expect(phoneNumber.getValidationError()).toEqual({ kind: 'EMPTY' });
+    }
+  });
+
+  it('reads a number input through its string form', () => {
+    const phoneNumber = parsePhoneNumber(12015550123 as unknown as string, { defaultRegion: 'US' });
+
+    expect(phoneNumber.formatE164()).toBe('+12015550123');
+  });
+});

--- a/packages/core/src/modules/parse-phone-number/parse-phone-number.ts
+++ b/packages/core/src/modules/parse-phone-number/parse-phone-number.ts
@@ -1,5 +1,6 @@
 import { getResourceProvider } from '@telixon/core/resource-provider';
 import { requireEngineReady } from '@telixon/core/utils/require-engine-ready';
+import { toInputString } from '@telixon/core/utils/to-input-string';
 import { ResolvedNumberState, resolveNumber } from '../number-resolver/resolve-number';
 import { createPhoneNumber, PhoneNumber, toResolvedPhoneNumber } from '../phone-number';
 import { ParsePhoneNumberOptions } from './models';
@@ -33,15 +34,16 @@ function firstPlusOrDigitIndex(input: string): number {
 export function parsePhoneNumber(input: string, options: ParsePhoneNumberOptions = {}): PhoneNumber {
   requireEngineReady();
 
+  const safeInput: string = toInputString(input);
   const resourceProvider = getResourceProvider();
   const defaultRegionIndex: number =
     options.defaultRegion !== undefined ? (resourceProvider.regionKeyToIndex[options.defaultRegion] ?? -1) : -1;
   const strict: boolean = options.strict ?? false;
 
-  const startIndex: number = firstPlusOrDigitIndex(input);
-  const hasLeadingPlus: boolean = startIndex !== -1 && input.charCodeAt(startIndex) === 0x2b;
+  const startIndex: number = firstPlusOrDigitIndex(safeInput);
+  const hasLeadingPlus: boolean = startIndex !== -1 && safeInput.charCodeAt(startIndex) === 0x2b;
   const resolved: ResolvedNumberState = resolveNumber({
-    input,
+    input: safeInput,
     hasLeadingPlus,
     seedCallingCode: null,
     defaultRegionIndex,
@@ -54,7 +56,7 @@ export function parsePhoneNumber(input: string, options: ParsePhoneNumberOptions
     return createPhoneNumber(toResolvedPhoneNumber(resolved, defaultRegionIndex, null));
   }
 
-  const extracted = extractPossibleNumber(input);
+  const extracted = extractPossibleNumber(safeInput);
   const { base, extension } = stripExtension(extracted.candidate);
 
   // The first resolution stands when the trims dropped no digit and the read mode is unchanged:

--- a/packages/core/src/utils/to-input-string.ts
+++ b/packages/core/src/utils/to-input-string.ts
@@ -1,0 +1,10 @@
+/**
+ * Coerces an untyped runtime value to the string the input pipeline expects. TypeScript callers
+ * always pass strings; plain JavaScript callers can pass anything, and the documented contract is
+ * that bad input degrades to a verdict instead of throwing.
+ */
+export function toInputString(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value === null || value === undefined) return '';
+  return String(value);
+}


### PR DESCRIPTION
## Summary

The edit path consumes selections typed over with digit-less text and merges a pasted duplicate of the seeded calling code into one resolvable value. InputState.region reports null for dead calling-code prefixes. Non-string runtime input follows the documented verdict paths at every public entry point.

## Motivation

Closes #86, closes #87, closes #88, closes #89.

## Conformance impact

Engine untouched. parsePhoneNumber gains a runtime coercion for non-string input; string input resolves through the unchanged paths. `pnpm conformance` passes locally, 26 of 26.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention