### PR TITLE
fix(web-sdk): sync the field from compositions, autofill, and prefill…

### DIFF
--- a/apps/docs/src/content/docs/web-sdk/phone-input.mdx
+++ b/apps/docs/src/content/docs/web-sdk/phone-input.mdx
@@ -44,6 +44,9 @@ The adapter adds these fields:
 | `numberTypeFilter`      | `readonly NumberType[] \| null` | Number-type filter applied at construction.                          |
 | `placeholderNumberType` | `NumberType`                    | The type the placeholder demonstrates; `'MOBILE'` by default.        |
 
+A value already present in the input element seeds the controller when `initialValue` is omitted,
+which keeps server-rendered and pre-attach autofilled values.
+
 ## PhoneInputState
 
 ```ts
@@ -88,6 +91,8 @@ empty national field reports `TOO_SHORT` under its region.
   rest of the family)
 - Undo and redo: the native `historyUndo` and `historyRedo` input types, plus Cmd/Ctrl+Z,
   Cmd/Ctrl+Shift+Z, and Cmd/Ctrl+Y
+- Browser autofill and password managers: a value change that arrives with a bare `input` event
+  resynchronizes the controller from the field
 
 ## Members
 
@@ -116,8 +121,9 @@ setValue(value: string): void;
 
 Replaces the value through the controller's
 [`setValue`](/core/reference/input-controller/#setvalue), writes the result back, then emits.
-Values written outside the event stream, browser autofill included, bypass the controller; push
-them through this method.
+Browser autofill and password managers announce their writes with an `input` event, and the widget
+adopts those on its own. A script that assigns `input.value` directly fires no event; push such
+values through this method.
 
 ### setRegion
 

--- a/packages/web-sdk/CHANGELOG.md
+++ b/packages/web-sdk/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to `@telixon/web-sdk` are documented in this file. The forma
 
 ## [Unreleased]
 
+### Fixed
+
+- `compositionend` reads the composed text the browser has already committed into the value
+  instead of inserting it a second time.
+- A DOM value changed outside the `beforeinput` pipeline (browser autofill, password managers)
+  resynchronizes the controller through a new `input`-event fallback.
+- `createPhoneInput` seeds the controller from a value already present in the input element when
+  no `initialValue` is passed, instead of clearing it at attach.
+
 ## [1.0.0] - 2026-08-21
 
 ### Added

--- a/packages/web-sdk/src/modules/phone-input/__tests__/phone-input.test.ts
+++ b/packages/web-sdk/src/modules/phone-input/__tests__/phone-input.test.ts
@@ -704,15 +704,81 @@ describe('PhoneInput filters: re-resolution', () => {
 });
 
 describe('PhoneInput compositionend', () => {
-  it('commits the IME composition data via inputController.insert', () => {
+  // Browsers commit the composed text into input.value before compositionend fires, with the caret
+  // resting after the committed text; the specs replay that exact sequence.
+  it('reads the committed IME composition once', () => {
     const { input, cleanup } = attachInput();
     const phone = createPhoneInput({ input, mode: 'national', defaultRegion: 'US' });
 
-    input.setSelectionRange(0, 0);
+    input.value = '5';
+    input.setSelectionRange(1, 1);
 
     dispatchCompositionEnd(input, '5');
 
     expect(digits(input.value)).toBe('5');
+
+    phone.destroy();
+    cleanup();
+  });
+
+  it('reads a composition committed after existing digits once', () => {
+    const { input, cleanup } = attachInput();
+    const phone = createPhoneInput({ input, mode: 'national', defaultRegion: 'US' });
+
+    dispatchBeforeInput(input, 'insertText', { data: '415' });
+    const preComposition: string = input.value;
+
+    input.value = preComposition + '555';
+    input.setSelectionRange(input.value.length, input.value.length);
+
+    dispatchCompositionEnd(input, '555');
+
+    expect(digits(input.value)).toBe('415555');
+
+    phone.destroy();
+    cleanup();
+  });
+
+  it('resynchronizes from the DOM when a composition ends without data', () => {
+    const { input, cleanup } = attachInput();
+    const phone = createPhoneInput({ input, mode: 'national', defaultRegion: 'US' });
+
+    input.value = '415';
+    input.setSelectionRange(3, 3);
+
+    dispatchCompositionEnd(input, '');
+
+    expect(digits(input.value)).toBe('415');
+    expect(digits(phone.getState().value)).toBe('415');
+
+    phone.destroy();
+    cleanup();
+  });
+});
+
+describe('PhoneInput DOM reconciliation', () => {
+  it('adopts a browser autofill that fires only an input event', () => {
+    const { input, cleanup } = attachInput();
+    const phone = createPhoneInput({ input, mode: 'international' });
+
+    input.value = '+1' + US_MOBILE;
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(digits(phone.getState().value)).toBe('1' + US_MOBILE);
+    expect(phone.getPhoneNumber().formatE164()).toBe('+1' + US_MOBILE);
+
+    phone.destroy();
+    cleanup();
+  });
+
+  it('preserves a value already present in the input at attach', () => {
+    const { input, cleanup } = attachInput();
+    input.value = '+1' + US_MOBILE;
+
+    const phone = createPhoneInput({ input, mode: 'international' });
+
+    expect(digits(input.value)).toBe('1' + US_MOBILE);
+    expect(phone.getPhoneNumber().formatE164()).toBe('+1' + US_MOBILE);
 
     phone.destroy();
     cleanup();

--- a/packages/web-sdk/src/modules/phone-input/phone-input.ts
+++ b/packages/web-sdk/src/modules/phone-input/phone-input.ts
@@ -94,14 +94,38 @@ export function createPhoneInput(options: PhoneInputOptions): PhoneInput {
     notify(buildState());
   }
 
+  // Realigns the controller when the DOM value changed outside the beforeinput pipeline
+  // (browser autofill, password managers, cancelled compositions).
+  function reconcile(): void {
+    const domValue: string = input.value;
+    if (domValue === inputController.currentState.value) return;
+
+    commit(() => inputController.setValue(domValue));
+  }
+
   function handleCompositionEnd(event: CompositionEvent): void {
     if (event.target !== input) return;
-    if (!event.data) return;
 
-    const start: number = input.selectionStart ?? 0;
-    const end: number = input.selectionEnd ?? 0;
+    // The browser commits the composed text into the value before this event fires, ending at the
+    // caret. The edit replays against the pre-composition value so the caret math stays exact.
+    const data: string = event.data ?? '';
+    const value: string = input.value;
+    const caret: number = input.selectionStart ?? value.length;
+    const start: number = caret - data.length;
 
-    commit(() => inputController.insert(input.value, event.data!, start, end));
+    if (data !== '' && start >= 0 && value.slice(start, caret) === data) {
+      commit(() => inputController.insert(value.slice(0, start) + value.slice(caret), data, start, start));
+      return;
+    }
+
+    reconcile();
+  }
+
+  function handleInput(event: Event): void {
+    if (event.target !== input) return;
+    if (event instanceof InputEvent && event.isComposing) return;
+
+    reconcile();
   }
 
   function handleBeforeInput(event: InputEvent): void {
@@ -213,6 +237,7 @@ export function createPhoneInput(options: PhoneInputOptions): PhoneInput {
 
   input.addEventListener('compositionend', handleCompositionEnd);
   input.addEventListener('beforeinput', handleBeforeInput);
+  input.addEventListener('input', handleInput);
   input.addEventListener('keydown', handleKeyDown);
   notify(buildState());
 
@@ -276,6 +301,7 @@ export function createPhoneInput(options: PhoneInputOptions): PhoneInput {
       ATTACHED_INPUTS.delete(input);
       input.removeEventListener('compositionend', handleCompositionEnd);
       input.removeEventListener('beforeinput', handleBeforeInput);
+      input.removeEventListener('input', handleInput);
       input.removeEventListener('keydown', handleKeyDown);
       listeners.clear();
     },

--- a/packages/web-sdk/src/modules/phone-input/utils/build-controller.ts
+++ b/packages/web-sdk/src/modules/phone-input/utils/build-controller.ts
@@ -29,5 +29,12 @@ function createInternationalController(options: InternationalPhoneInputOptions):
 }
 
 export function buildController(options: PhoneInputOptions): InputController {
-  return options.mode === 'national' ? createNationalController(options) : createInternationalController(options);
+  // A value already present in the DOM input (server-rendered, restored, autofilled before attach)
+  // seeds the controller unless the consumer passes an explicit initialValue.
+  const seeded: PhoneInputOptions =
+    options.initialValue === undefined && options.input.value !== ''
+      ? { ...options, initialValue: options.input.value }
+      : options;
+
+  return seeded.mode === 'national' ? createNationalController(seeded) : createInternationalController(seeded);
 }


### PR DESCRIPTION
## Summary

compositionend reads the composed text the browser has already committed into the value. A DOM value changed outside the beforeinput pipeline resynchronizes the controller through an input-event fallback. createPhoneInput seeds the controller from a value already present in the input element.

## Motivation

Closes #90, closes #91, closes #92.

## Conformance impact

None.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention