### PR TITLE
chore(release): core 1.1.1

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to `@telixon/core` are documented in this file. The format f
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-08-28
+
 ### Fixed
 
 - An insert without digits typed over a selection consumes the selected digits instead of keeping
@@ -61,7 +63,8 @@ All notable changes to `@telixon/core` are documented in this file. The format f
 - A conformance gate in CI comparing every query method with a Google libphonenumber counterpart
   against Google's source at the pinned metadata commit.
 
-[Unreleased]: https://github.com/martsinlabs/telixon/compare/core@v1.1.0...HEAD
+[Unreleased]: https://github.com/martsinlabs/telixon/compare/core@v1.1.1...HEAD
+[1.1.1]: https://github.com/martsinlabs/telixon/compare/core@v1.1.0...core@v1.1.1
 [1.1.0]: https://github.com/martsinlabs/telixon/compare/core@v1.0.1...core@v1.1.0
 [1.0.1]: https://github.com/martsinlabs/telixon/compare/core@v1.0.0...core@v1.0.1
 [1.0.0]: https://github.com/martsinlabs/telixon/releases/tag/core@v1.0.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telixon/core",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Phone-number parser, formatter, and validator built on Google libphonenumber metadata.",
   "keywords": [
     "phone",


### PR DESCRIPTION
## Summary

Cuts the 1.1.1 patch release of @telixon/core: the changelog moves the Unreleased fixes under 1.1.1 with the release date and the package version is bumped.

## Motivation

Releases the input-pipeline fixes from #104.

## Conformance impact

None.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention