### PR TITLE
chore(release): web-sdk 1.0.1

### DIFF
--- a/packages/web-sdk/CHANGELOG.md
+++ b/packages/web-sdk/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to `@telixon/web-sdk` are documented in this file. The forma
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-08-28
+
 ### Fixed
 
 - `compositionend` reads the composed text the browser has already committed into the value
@@ -27,5 +29,6 @@ All notable changes to `@telixon/web-sdk` are documented in this file. The forma
 - `regionToFlagEmoji` mapping a region code to its flag emoji.
 - `@telixon/core` as a peer dependency; the engine loads through it directly.
 
-[Unreleased]: https://github.com/martsinlabs/telixon/compare/web-sdk@v1.0.0...HEAD
+[Unreleased]: https://github.com/martsinlabs/telixon/compare/web-sdk@v1.0.1...HEAD
+[1.0.1]: https://github.com/martsinlabs/telixon/compare/web-sdk@v1.0.0...web-sdk@v1.0.1
 [1.0.0]: https://github.com/martsinlabs/telixon/releases/tag/web-sdk@v1.0.0

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telixon/web-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "DOM adapter for @telixon/core: two headless widgets, PhoneInput driving a plain <input> and RegionList feeding region pickers.",
   "keywords": [
     "phone-input",


### PR DESCRIPTION
## Summary

Cuts the 1.0.1 patch release of @telixon/web-sdk: the changelog moves the Unreleased fixes under 1.0.1 with the release date and the package version is bumped.

## Motivation

Releases the DOM synchronization fixes from #105.

## Conformance impact

None.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention