### PR TITLE
chore: add the Context7 ownership key

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -3,6 +3,8 @@
   "projectTitle": "Telixon",
   "description": "Phone number parsing, validation, formatting, and a headless input controller for JavaScript and TypeScript. Verified against Google libphonenumber.",
   "folders": ["apps/docs/src/content/docs", "packages/core", "packages/web-sdk"],
+  "url": "https://context7.com/martsinlabs/telixon",
+  "public_key": "pk_KeLqdRvVss8o07MHEKW3D",
   "excludeFolders": [
     "packages/core/src",
     "packages/core/dist",


### PR DESCRIPTION
## Summary

context7.json carries the ownership URL and public key issued by Context7 when the library was claimed, which links the repository to its Context7 entry for verification.

## Motivation

Verified libraries rank higher in Context7 search.

## Conformance impact

None.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention