### PR TITLE
fix(core): keep the caret in place when backspace has nothing to delete

### DIFF
--- a/packages/core/src/modules/input-controller/international-input-controller/__tests__/delete-operations.test.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/__tests__/delete-operations.test.ts
@@ -52,6 +52,21 @@ describe('InternationalInputController.deleteBackward', () => {
     expect(state.selectionEnd).toBe(1);
   });
 
+  it('stores the no-op caret in currentState when backspacing right after the fixed "+"', () => {
+    const controller = createInternationalInputController({
+      defaultRegion: 'US',
+      display: { callingCodeInInput: true, plusPrefix: 'fixed' },
+    });
+
+    controller.deleteBackward('+1 ', 1, 1);
+
+    // Adapters render from currentState: the stored selection must match the no-op caret.
+    const current = controller.currentState;
+    expect(current.value).toBe('+1 ');
+    expect(current.selectionStart).toBe(1);
+    expect(current.selectionEnd).toBe(1);
+  });
+
   it('deletes the last digit when callingCodeInInput is false (national-only display)', () => {
     const controller = createInternationalInputController({
       defaultRegion: 'US',

--- a/packages/core/src/modules/input-controller/international-input-controller/international-input-controller.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/international-input-controller.ts
@@ -220,9 +220,8 @@ class InternationalInputController implements InputController {
       const position: number = findPreviousDigitPosition(value, selectionStart);
 
       if (position === -1) {
-        return toInputState(
-          this.#resolveState(value, { insertText: '', selectionStart, selectionEnd }, 'backward', this.#plusErased),
-        );
+        this.#history.updateCurrentSelection(selectionStart, selectionEnd);
+        return toInputStateWithSelection(this.#history.current, selectionStart, selectionEnd);
       }
 
       effectiveStart = position;

--- a/packages/core/src/modules/input-controller/national-input-controller/__tests__/delete-operations.test.ts
+++ b/packages/core/src/modules/input-controller/national-input-controller/__tests__/delete-operations.test.ts
@@ -17,6 +17,21 @@ describe('NationalInputController.deleteBackward', () => {
     expect(state.selectionEnd).toBe(0);
   });
 
+  it('stores the no-op caret in currentState when no digit precedes the caret', () => {
+    const controller = createNationalInputController({ defaultRegion: 'US' });
+    const seeded = controller.setValue('4155550132');
+    expect(seeded.value).toBe('(415) 555-0132');
+
+    // Position 1 sits after "(" with no digit before it: the delete is a no-op.
+    controller.deleteBackward(seeded.value, 1, 1);
+
+    // Adapters render from currentState: the stored selection must match the no-op caret.
+    const current = controller.currentState;
+    expect(current.value).toBe('(415) 555-0132');
+    expect(current.selectionStart).toBe(1);
+    expect(current.selectionEnd).toBe(1);
+  });
+
   it('deletes the digit before the caret through a formatting char (caret just after "011 ")', () => {
     const controller = createNationalInputController({ defaultRegion: 'AR' });
     controller.setValue(AR_RAW);

--- a/packages/core/src/modules/input-controller/national-input-controller/national-input-controller.ts
+++ b/packages/core/src/modules/input-controller/national-input-controller/national-input-controller.ts
@@ -184,9 +184,8 @@ class NationalInputController implements InputController {
       const position: number = findPreviousDigitPosition(value, selectionStart);
 
       if (position === -1) {
-        return toInputState(
-          this.#resolveFromEdit(value, { insertText: '', selectionStart, selectionEnd }, 'backward', true),
-        );
+        this.#history.updateCurrentSelection(selectionStart, selectionEnd);
+        return toInputStateWithSelection(this.#history.current, selectionStart, selectionEnd);
       }
 
       effectiveStart = position;


### PR DESCRIPTION
## Summary

Backspace with no digit before the caret now stores the caller's selection in history, matching the caret-at-zero guard in the same method. Both input controllers rendered the previous edit's caret through `currentState` in that branch, which sent the DOM caret to the end of the field when backspacing on a fixed plus. Regression tests cover the fixed-plus and national leading-parenthesis cases.

## Motivation

Closes #112.

## Conformance impact

None.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention