### PR TITLE
fix(core): clamp the stored selection to the value bounds

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to `@telixon/core` are documented in this file. The format f
 
 ## [Unreleased]
 
+### Fixed
+
+- A selection reported past the stored value is clamped to its bounds before it is kept, keeping
+  `currentState` and the history snapshots coherent for coerced degenerate input.
+
 ## [1.1.2] - 2026-09-01
 
 ### Fixed

--- a/packages/core/src/modules/input-controller/input-state-history.ts
+++ b/packages/core/src/modules/input-controller/input-state-history.ts
@@ -37,10 +37,15 @@ export class InputStateHistory<State extends InputControllerState = InputControl
   updateCurrentSelection(selectionStart: number, selectionEnd: number): void {
     const current: State = this.stack[this.index]!;
 
+    // Degenerate callers can hand a selection past the stored value; the stored state stays in bounds.
+    const maxIndex: number = current.value.length;
+    const start: number = Math.max(0, Math.min(selectionStart, maxIndex));
+    const end: number = Math.max(start, Math.min(selectionEnd, maxIndex));
+
     this.stack[this.index] = {
       ...current,
-      selectionStart,
-      selectionEnd,
+      selectionStart: start,
+      selectionEnd: end,
     };
   }
 

--- a/packages/core/src/modules/input-controller/international-input-controller/__tests__/delete-operations.test.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/__tests__/delete-operations.test.ts
@@ -52,6 +52,23 @@ describe('InternationalInputController.deleteBackward', () => {
     expect(state.selectionEnd).toBe(1);
   });
 
+  it('clamps a degenerate selection past the stored value to its bounds', () => {
+    const controller = createInternationalInputController({
+      defaultRegion: 'US',
+      display: { callingCodeInInput: true, plusPrefix: 'fixed' },
+    });
+
+    // The raw value coerces to an empty string while the selection points past every bound.
+    const state = controller.deleteBackward(null as unknown as string, 9, 9);
+
+    expect(state.value).toBe('+1 ');
+    expect(state.selectionStart).toBe(3);
+    expect(state.selectionEnd).toBe(3);
+    const current = controller.currentState;
+    expect(current.selectionStart).toBe(3);
+    expect(current.selectionEnd).toBe(3);
+  });
+
   it('stores the no-op caret in currentState when backspacing right after the fixed "+"', () => {
     const controller = createInternationalInputController({
       defaultRegion: 'US',
@@ -107,6 +124,23 @@ describe('InternationalInputController.deleteForward', () => {
 
     expect(state.value.startsWith('+')).toBe(true);
     expect(state.value.replace(/\D/g, '')).toBe(US_MOBILE_INTL.slice(1));
+  });
+
+  it('clamps a degenerate selection past the stored value to its bounds', () => {
+    const controller = createInternationalInputController({
+      defaultRegion: 'US',
+      display: { callingCodeInInput: true, plusPrefix: 'fixed' },
+    });
+
+    // The raw value coerces to an empty string while the selection points past every bound.
+    const state = controller.deleteForward(null as unknown as string, 9, 9);
+
+    expect(state.value).toBe('+1 ');
+    expect(state.selectionStart).toBe(3);
+    expect(state.selectionEnd).toBe(3);
+    const current = controller.currentState;
+    expect(current.selectionStart).toBe(3);
+    expect(current.selectionEnd).toBe(3);
   });
 });
 

--- a/packages/core/src/modules/input-controller/international-input-controller/international-input-controller.ts
+++ b/packages/core/src/modules/input-controller/international-input-controller/international-input-controller.ts
@@ -221,7 +221,7 @@ class InternationalInputController implements InputController {
 
       if (position === -1) {
         this.#history.updateCurrentSelection(selectionStart, selectionEnd);
-        return toInputStateWithSelection(this.#history.current, selectionStart, selectionEnd);
+        return toInputState(this.#history.current);
       }
 
       effectiveStart = position;

--- a/packages/core/src/modules/input-controller/national-input-controller/national-input-controller.ts
+++ b/packages/core/src/modules/input-controller/national-input-controller/national-input-controller.ts
@@ -185,7 +185,7 @@ class NationalInputController implements InputController {
 
       if (position === -1) {
         this.#history.updateCurrentSelection(selectionStart, selectionEnd);
-        return toInputStateWithSelection(this.#history.current, selectionStart, selectionEnd);
+        return toInputState(this.#history.current);
       }
 
       effectiveStart = position;


### PR DESCRIPTION
## Summary

`InputStateHistory.updateCurrentSelection` clamps the reported selection to the stored value's bounds before it is kept. The no-op backspace branch in both controllers now returns `toInputState(current)`. The returned state and `currentState` therefore carry the same clamped selection.

## Motivation

Closes #115. A degenerate caller could report a selection past the stored value. It survived in `currentState` and in the history snapshots that `undo` and `clearHistory` return.

## Conformance impact

None.

## Checklist

- [x] Tests added or updated (or a rationale for why none)
- [x] `pnpm test`, `pnpm lint`, `pnpm format` pass locally
- [x] Docs reflect the change (per CONTRIBUTING.md)
- [x] Commit message follows the project convention
